### PR TITLE
Parse as ItemFn

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -63,9 +63,9 @@ use proc_macro::TokenStream;
 /// ```
 #[proc_macro_attribute]
 pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
-    let output: syn::Item = syn::parse(function).unwrap();
+    let function: syn::ItemFn = syn::parse_macro_input!(function);
 
-    if let syn::Item::Fn(syn::ItemFn {
+    let syn::ItemFn {
         ident,
         vis,
         unsafety,
@@ -75,42 +75,39 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
         decl,
         attrs,
         ..
-    }) = output
-    {
-        // Ensure that visibility modifier is not present
-        match vis {
-            syn::Visibility::Inherited => {}
-            _ => panic!("#[ctor] methods must not have visibility modifiers"),
-        }
+    } = function;
 
-        // No parameters allowed
-        if decl.inputs.len() > 0 {
-            panic!("#[ctor] methods may not have parameters");
-        }
-
-        // No return type allowed
-        match decl.output {
-            syn::ReturnType::Default => {}
-            _ => panic!("#[ctor] methods must not have return types"),
-        }
-
-        let output = quote!(
-            #[used]
-            #[cfg_attr(target_os = "linux", link_section = ".ctors")]
-            #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
-            #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
-            #(#attrs)*
-            static #ident
-            :
-            extern #unsafety #abi #constness fn() =
-            { extern #unsafety #abi #constness fn #ident() #block; #ident }
-            ;
-        );
-
-        // eprintln!("{}", output);
-
-        output.into()
-    } else {
-        panic!("Expected a function");
+    // Ensure that visibility modifier is not present
+    match vis {
+        syn::Visibility::Inherited => {}
+        _ => panic!("#[ctor] methods must not have visibility modifiers"),
     }
+
+    // No parameters allowed
+    if decl.inputs.len() > 0 {
+        panic!("#[ctor] methods may not have parameters");
+    }
+
+    // No return type allowed
+    match decl.output {
+        syn::ReturnType::Default => {}
+        _ => panic!("#[ctor] methods must not have return types"),
+    }
+
+    let output = quote!(
+        #[used]
+        #[cfg_attr(target_os = "linux", link_section = ".ctors")]
+        #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
+        #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
+        #(#attrs)*
+        static #ident
+        :
+        extern #unsafety #abi #constness fn() =
+        { extern #unsafety #abi #constness fn #ident() #block; #ident }
+        ;
+    );
+
+    // eprintln!("{}", output);
+
+    output.into()
 }


### PR DESCRIPTION
We can parse directly as syn::ItemFn rather than parsing as syn::Item followed by `if let`.