### PR TITLE
Add initial support to FreeBSD

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -98,6 +98,7 @@ use proc_macro::TokenStream;
 ///```rust
 /// #[used]
 /// #[cfg_attr(target_os = "linux", link_section = ".init_array")]
+/// #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
 /// #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
 /// static FOO: extern fn() = {
@@ -137,6 +138,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[used]
             #[allow(non_upper_case_globals)]
             #[cfg_attr(target_os = "linux", link_section = ".init_array")]
+            #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             #(#attrs)*
@@ -212,6 +214,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[used]
             #[allow(non_upper_case_globals)]
             #[cfg_attr(target_os = "linux", link_section = ".init_array")]
+            #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static #ctor_ident
@@ -281,6 +284,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[used]
             #[allow(non_upper_case_globals)]
             #[cfg_attr(target_os = "linux", link_section = ".init_array")]
+            #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             #(#attrs)*

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -28,6 +28,11 @@ fn lib_extension() -> &'static str {
     "so"
 }
 
+#[cfg(target_os = "freebsd")]
+fn lib_extension() -> &'static str {
+    "so"
+}
+
 #[cfg(windows)]
 fn lib_extension() -> &'static str {
     "dll"


### PR DESCRIPTION
this patch is adding FreeBSD support to `ctor`
`cargo test` is successful.
I've tested it via the crate `typetag` and it seems working, however some code review and more hint on how to improve tests could be helpful
as soon as I can, I'll add CI support for FreeBSD

