### PR TITLE
Make unsupported targets hard error

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -280,7 +280,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 
     let output = quote!(
         #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos", target_os = "ios", windows)))]
-        compile_error!("#[ctor] is not supported on the current target");
+        compile_error!("#[dtor] is not supported on the current target");
 
         // Targets that use `atexit`.
         #[cfg(not(any(

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -135,6 +135,9 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
         // 'I'=C init, 'C'=C++ init, 'P'=Pre-terminators and 'T'=Terminators
 
         let output = quote!(
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos", target_os = "ios", windows)))]
+            compile_error!("#[ctor] is not supported on the current target");
+
             #[used]
             #[allow(non_upper_case_globals)]
             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
@@ -188,6 +191,9 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
                 .expect("Unable to create identifier");
 
         let output = quote!(
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos", target_os = "ios", windows)))]
+            compile_error!("#[ctor] is not supported on the current target");
+
             // This is mutable, but only by this macro code!
             static mut #storage_ident: Option<#ty> = None;
 
@@ -273,6 +279,9 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
     } = function;
 
     let output = quote!(
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos", target_os = "ios", windows)))]
+        compile_error!("#[ctor] is not supported on the current target");
+
         // Targets that use `atexit`.
         #[cfg(not(any(
             target_os = "macos",


### PR DESCRIPTION
Makes the macro place a compile_error in the output on unsupported platforms, which causes a nice error, pointing to the exact location of the problem:

```
error: #[dtor] is not supported on the current target
  --> ctor\src/example.rs:29:1
   |
29 | #[dtor]
   | ^^^^^^^
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

Closes #11