### PR TITLE
Make all generated function extern "C"

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -340,7 +340,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             target_os = "ios",
         ))]
         mod #mod_ident {
-            use super::*;
+            use super::#ident;
 
             #[used]
             #[allow(non_upper_case_globals)]

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -348,7 +348,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
         }
     );
 
-    eprintln!("{}", output);
+    // eprintln!("{}", output);
 
     output.into()
 }

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -116,6 +116,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
         let syn::ItemFn {
             attrs,
             block,
+            vis,
             sig:
                 syn::Signature {
                     ident,
@@ -134,21 +135,28 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
         // Why .CRT$XCU on Windows? https://www.cnblogs.com/sunkang/archive/2011/05/24/2055635.html
         // 'I'=C init, 'C'=C++ init, 'P'=Pre-terminators and 'T'=Terminators
 
+        let ctor_ident =
+            syn::parse_str::<syn::Ident>(format!("{}___rust_ctor___ctor", ident).as_ref())
+                .expect("Unable to create identifier");
+
         let output = quote!(
+
+            #(#attrs)*
+            #vis #unsafety extern #abi #constness fn #ident() #block
+
             #[used]
             #[allow(non_upper_case_globals)]
             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
-            #(#attrs)*
-            static #ident
+            static #ctor_ident
             :
-            #unsafety extern #abi #constness fn() =
+            unsafe extern "C" fn() =
             {
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
-                #unsafety extern #abi #constness fn #ident() #block;
-                #ident
+                unsafe extern "C" fn #ctor_ident() { #ident() };
+                #ctor_ident
             }
             ;
         );
@@ -219,9 +227,9 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static #ctor_ident
             :
-            unsafe fn() = {
+            unsafe extern "C" fn() = {
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
-                unsafe fn initer() {
+                unsafe extern "C" fn initer() {
                     #storage_ident = Some(#expr);
                 }; initer }
             ;
@@ -247,6 +255,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 /// ```rust
 /// # extern crate ctor;
 /// # use ctor::*;
+/// # fn main() {}
 ///
 /// #[dtor]
 /// fn shutdown() {
@@ -261,6 +270,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
     let syn::ItemFn {
         attrs,
         block,
+        vis,
         sig:
             syn::Signature {
                 ident,
@@ -272,18 +282,30 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
         ..
     } = function;
 
+    let mod_ident =
+        syn::parse_str::<syn::Ident>(format!("{}___rust_dtor___mod", ident).as_ref())
+            .expect("Unable to create identifier");
+
+    let dtor_ident =
+        syn::parse_str::<syn::Ident>(format!("{}___rust_dtor___dtor", ident).as_ref())
+            .expect("Unable to create identifier");
+
     let output = quote!(
+
+        #(#attrs)*
+        #vis #unsafety extern #abi #constness fn #ident() #block
+
         // Targets that use `atexit`.
         #[cfg(not(any(
             target_os = "macos",
             target_os = "ios",
         )))]
-        mod #ident {
-            use super::*;
+        mod #mod_ident {
+            use super::#ident;
 
             // Avoid a dep on libc by linking directly
             extern "C" {
-                fn atexit(cb: #unsafety extern fn());
+                fn atexit(cb: unsafe extern fn());
             }
 
             #[used]
@@ -291,16 +313,15 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
-            #(#attrs)*
             static __dtor_export
             :
-            unsafe extern #abi #constness fn() =
+            unsafe extern "C" fn() =
             {
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.exit")]
-                #unsafety extern #abi #constness fn #ident() #block;
+                unsafe extern "C" fn #dtor_ident() { #ident() };
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
                 unsafe extern fn __dtor_atexit() {
-                    atexit(#ident);
+                    atexit(#dtor_ident);
                 };
                 __dtor_atexit
             };
@@ -311,24 +332,23 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             target_os = "macos",
             target_os = "ios",
         ))]
-        mod #ident {
+        mod #mod_ident {
             use super::*;
 
             #[used]
             #[allow(non_upper_case_globals)]
             #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_term_func")]
-            #(#attrs)*
             static __dtor_export
             :
-            unsafe extern #abi #constness fn() =
+            unsafe extern "C" fn() =
             {
-                unsafe extern fn __dtor() #block;
+                unsafe extern fn __dtor() { #ident() };
                 __dtor
             };
         }
     );
 
-    // eprintln!("{}", output);
+    eprintln!("{}", output);
 
     output.into()
 }


### PR DESCRIPTION
Also makes it so that the original function is preserved in the output, including visibility. In theory, ctor functions can be called just fine during normal execution as long as the user makes them able to handle that.

Closes #96 