### PR TITLE
If building w/+crt-static, set explicit target

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,11 +5,13 @@ if [ -z "${MUSL:-}" ]; then
 
 # https://github.com/mmastrac/rust-ctor/pull/98#issuecomment-714594194
 if [[ $TRAVIS_OS_NAME == "linux" && $RUSTFLAGS == '-C target-feature=+crt-static' ]]; then
-    TARGET="--target x86_64-unknown-linux-gnu"
+    # We can't test dynamic linking on +crt-static
+    cargo run --example example --target
+    exit 0
 fi
 
-cargo test --all $TARGET
-cargo test --all --release $TARGET
+cargo test --all
+cargo test --all --release
 
 if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then
     echo "Testing '-Z sanitizer=address'..."

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ if [ -z "${MUSL:-}" ]; then
 # https://github.com/mmastrac/rust-ctor/pull/98#issuecomment-714594194
 if [[ $TRAVIS_OS_NAME == "linux" && $RUSTFLAGS == '-C target-feature=+crt-static' ]]; then
     # We can't test dynamic linking on +crt-static
-    cargo run --example example --target
+    cargo run --example example --target x86_64-unknown-linux-gnu
     exit 0
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -3,8 +3,13 @@ set -euf -o pipefail
 
 if [ -z "${MUSL:-}" ]; then
 
-cargo test --all
-cargo test --all --release
+# https://github.com/mmastrac/rust-ctor/pull/98#issuecomment-714594194
+if [[ $TRAVIS_OS_NAME == "linux" && $RUSTFLAGS == '-C target-feature=+crt-static' ]]; then
+    TARGET="--target x86_64-unknown-linux-gnu"
+fi
+
+cargo test --all $TARGET
+cargo test --all --release $TARGET
 
 if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then
     echo "Testing '-Z sanitizer=address'..."


### PR DESCRIPTION
Just punting on `+crt-static` builds. We cannot build cdylib in `+crt-static` for the same reasons we cannot build them in the `musl` target.

```
error: cannot produce cdylib for ... as the target `x86_64-unknown-linux-gnu` does not support these crate types
```

For googlers that are stumbling across this error, `+crt-static` won't let you create `cdylib` files.