### PR TITLE
Copycat attempt to support OpenBSD, based on #116.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/ctor/badge.svg)](https://docs.rs/ctor)
 [![crates.io](https://img.shields.io/crates/v/ctor.svg)](https://crates.io/crates/ctor)
 
-Module initialization/teardown functions for Rust (like `__attribute__((constructor))` in C/C++) for Linux, OSX, FreeBSD, NetBSD, Android, iOS, and Windows.
+Module initialization/teardown functions for Rust (like `__attribute__((constructor))` in C/C++) for Linux, OSX, FreeBSD, NetBSD, OpenBSD, Android, iOS, and Windows.
 
 This library currently requires **Rust > 1.31.0** at a minimum for the
 procedural macro support.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The above example translates into the following Rust code (approximately):
     #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
     #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
     #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
+    #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
     #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
     #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
     static FOO: extern fn() = {

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -100,6 +100,7 @@ use proc_macro::TokenStream;
 /// #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
 /// #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
+/// #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
 /// #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
 /// #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
 /// static FOO: extern fn() = {

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -141,7 +141,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
                 .expect("Unable to create identifier");
 
         let output = quote!(
-            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "ios", windows)))]
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "macos", target_os = "ios", windows)))]
             compile_error!("#[ctor] is not supported on the current target");
 
             #(#attrs)*
@@ -152,6 +152,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
             #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static #ctor_ident
@@ -200,7 +201,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
                 .expect("Unable to create identifier");
 
         let output = quote!(
-            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "ios", windows)))]
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "macos", target_os = "ios", windows)))]
             compile_error!("#[ctor] is not supported on the current target");
 
             // This is mutable, but only by this macro code!
@@ -231,6 +232,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
             #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static #ctor_ident
@@ -299,7 +301,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             .expect("Unable to create identifier");
 
     let output = quote!(
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "ios", windows)))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "macos", target_os = "ios", windows)))]
         compile_error!("#[dtor] is not supported on the current target");
 
         #(#attrs)*
@@ -323,6 +325,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static __dtor_export
             :

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -38,6 +38,11 @@ fn lib_extension() -> &'static str {
     "so"
 }
 
+#[cfg(target_os = "openbsd")]
+fn lib_extension() -> &'static str {
+    "so"
+}
+
 #[cfg(windows)]
 fn lib_extension() -> &'static str {
     "dll"


### PR DESCRIPTION
I don't know how to extensively test this, but things like value-bag and log 0.4.14 now compile on OpenBSD with this. (and the programs using them do not immediately explode)

I encountered the need for this today when trying to build a project who uses `async-std`, who eventually (via `async-io`) pulls in the `log` crate who switched to using `value-bag`, which then uses this crate.

Let me know what I can do to improve this further if needed. Thank you!