### PR TITLE
add support for illumos

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -101,6 +101,7 @@ use proc_macro::TokenStream;
 /// #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
+/// #[cfg_attr(target_os = "illumos", link_section = ".init_array")]
 /// #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
 /// #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
 /// static FOO: extern fn() = {
@@ -142,7 +143,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
                 .expect("Unable to create identifier");
 
         let output = quote!(
-            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "macos", target_os = "ios", windows)))]
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "macos", target_os = "ios", windows)))]
             compile_error!("#[ctor] is not supported on the current target");
 
             #(#attrs)*
@@ -154,6 +155,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "illumos", link_section = ".init_array")]
             #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static #ctor_ident
@@ -202,7 +204,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
                 .expect("Unable to create identifier");
 
         let output = quote!(
-            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "macos", target_os = "ios", windows)))]
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "macos", target_os = "ios", windows)))]
             compile_error!("#[ctor] is not supported on the current target");
 
             // This is mutable, but only by this macro code!
@@ -234,6 +236,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "illumos", link_section = ".init_array")]
             #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static #ctor_ident
@@ -302,7 +305,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             .expect("Unable to create identifier");
 
     let output = quote!(
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "macos", target_os = "ios", windows)))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "macos", target_os = "ios", windows)))]
         compile_error!("#[dtor] is not supported on the current target");
 
         #(#attrs)*
@@ -327,6 +330,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "illumos", link_section = ".init_array")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
             static __dtor_export
             :

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -43,6 +43,11 @@ fn lib_extension() -> &'static str {
     "so"
 }
 
+#[cfg(target_os = "illumos")]
+fn lib_extension() -> &'static str {
+    "so"
+}
+
 #[cfg(windows)]
 fn lib_extension() -> &'static str {
     "dll"


### PR DESCRIPTION
This adds support for [illumos](https://illumos.org) systems.  The tests appear to pass:

```
$ uname -a
SunOS newcastle 5.11 rti-master-0-gf6ef42236c i86pc i386 i86pc

$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running target/debug/deps/ctor-96ead4d202c4bf8d

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target/debug/deps/tests-a7da501531d30b78

running 2 tests
test test::test_initialized ... ok
test test::test_dylib ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.02s

We don't test shutdown, but if you see this message it worked!
   Doc-tests tests

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ctor

running 5 tests
test src/lib.rs - ctor (line 101) ... ok
test src/lib.rs - ctor (line 60) ... ok
test src/lib.rs - ctor (line 44) ... ok
test src/lib.rs - dtor (line 269) ... ok
test src/lib.rs - ctor (line 75) ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.60s
```