### PR TITLE
Suppress `ctor_ident` in docs (Function)

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -151,6 +151,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 
             #[used]
             #[allow(non_upper_case_globals)]
+            #[doc(hidden)]
             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".init_array")]
             #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
             #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]


### PR DESCRIPTION
The code for ctors on statics already uses the `#[doc(hidden)]` attribute to suppress symbols created by ctor out of rustdoc output, but the one for functions does not.

If you add that annotation to the function wrapped by `ctor`, it'll suppress the function at global scope, but not the static that ctor generates.

This patch adds `#[doc(hdiden)]` to the latter as well.

---

Test Plan:

EDIT: I couldn't find any contributing guidelines or anything, so if you want me to do more to test this than I have, just let me know.

Tests pass before and after this patch.

Examples before/after of rustdoc output from one of my crates:

Before this patch is applied, the following statics appear in rustdoc:
<img width="706" alt="Screen Shot 2021-04-25 at 9 56 38 PM" src="https://user-images.githubusercontent.com/596042/116027121-4196f880-a611-11eb-853e-f26353ec85e9.png">

After this patch is applied, nothing from ctor appears in rustdoc:
<img width="817" alt="image" src="https://user-images.githubusercontent.com/596042/116026984-009ee400-a611-11eb-85bc-b4f55020a958.png">
