### PR TITLE
Add used_linker feature

### DIFF
--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -11,6 +11,10 @@ readme = "../README.md"
 [badges]
 travis-ci = { repository = "mmastrac/rust-ctor", branch = "master" }
 
+[features]
+# For nightly users, used(linker) may be a better choice
+used_linker = []
+
 [dependencies]
 quote = "1.0.20"
 

--- a/ctor/src/example.rs
+++ b/ctor/src/example.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 extern crate ctor;
 extern crate libc_print;
 

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -32,7 +32,7 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
-use proc_macro::{TokenStream};
+use proc_macro::TokenStream;
 
 /// Attributes required to mark a function as a constructor. This may be exposed in the future if we determine
 /// it to be stable.
@@ -65,6 +65,7 @@ macro_rules! ctor_attributes {
 /// Print a startup message (using `libc_print` for safety):
 ///
 /// ```rust
+/// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
 /// # extern crate ctor;
 /// # use ctor::*;
 /// use libc_print::std_name::println;
@@ -82,6 +83,7 @@ macro_rules! ctor_attributes {
 /// Make changes to `static` variables:
 ///
 /// ```rust
+/// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
 /// # extern crate ctor;
 /// # use ctor::*;
 /// # use std::sync::atomic::{AtomicBool, Ordering};
@@ -176,7 +178,9 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #(#attrs)*
             #vis #unsafety extern #abi #constness fn #ident() #block
 
-            #[used]
+            #[cfg_attr(not(feature = "used_linker"), used)]
+            #[cfg_attr(feature = "used_linker", used(linker))]
+            #[no_mangle]
             #[allow(non_upper_case_globals)]
             #[doc(hidden)]
             #tokens

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Matt Mastracci <matthew@mastracci.com>"]
 edition = "2018"
 publish = false
 
+[features]
+# For nightly users, used(linker) may be a better choice
+used_linker = ["ctor/used_linker"]
+
 [dependencies]
 ctor = { path = "../ctor" }
 dlopen = "0.1.8"

--- a/tests/src/dylib.rs
+++ b/tests/src/dylib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 #![allow(dead_code, unused_imports)]
 
 use ctor::*;

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 #![allow(unused_imports)]
 
 use ctor::*;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 // Prevent a spurious 'unused_imports' warning
 #[allow(unused_imports)]
 #[macro_use]
@@ -88,6 +89,10 @@ mod test {
 
         // There are four possible outcomes for stderr, depending on the order
         // that functions are called
-        assert!(a == s || b == s || c == s || d == s, "s was unexpected:\n{}", s.replace("\n", "\\n"));
+        assert!(
+            a == s || b == s || c == s || d == s,
+            "s was unexpected:\n{}",
+            s.replace("\n", "\\n")
+        );
     }
 }


### PR DESCRIPTION
Add a feature `used_linker` that uses `#[used(linker)]`, an unstable `+nightly` feature that might fix some of the ctor pain.

This may fix #280, #206 and related bugs.