### PR TITLE
Move static ctor out of unsafe context

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -262,8 +262,12 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             :
             unsafe extern "C" fn() = {
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
-                unsafe extern "C" fn initer() {
-                    #storage_ident = Some(#expr);
+                extern "C" fn initer() {
+                    let val = Some(#expr);
+                    // Only write the value to `storage_ident` on startup
+                    unsafe {
+                        #storage_ident = val;
+                    }
                 }; initer }
             ;
         );


### PR DESCRIPTION
On `master`, the following test succeeds to mutate and read the mutable static `test` boolean without the use of an `unsafe` keyword:

```rust
extern crate ctor;
use ctor::*;

static mut test: bool = false;
#[ctor]
static STATIC_CTOR: bool = {
  test = true;
  test
}
```

This PR fixes the issue