### PR TITLE
Emit `#[allow(non_snake_case)]` for constructor identifier

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -179,13 +179,14 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 
             #[cfg_attr(not(feature = "used_linker"), used)]
             #[cfg_attr(feature = "used_linker", used(linker))]
-            #[allow(non_upper_case_globals)]
+            #[allow(non_upper_case_globals, non_snake_case)]
             #[doc(hidden)]
             #tokens
             static #ctor_ident
             :
             unsafe extern "C" fn() -> usize =
             {
+                #[allow(non_snake_case)]
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
                 unsafe extern "C" fn #ctor_ident() -> usize { #ident(); 0 };
                 #ctor_ident


### PR DESCRIPTION
This PR adds `#[allow(non_snake_case)]` to the emitted constructor identifier to prevent `#[warn(non_snake_case)]` from complaining in some situations.

The suffix used when generating the constructor identifier already triggers this warning, so regardless of the input identifier the generated identifier is already in violation of this lint:

```
λ cargo test
   Compiling ctor v0.2.5 (/Users/maxdeviant/projects/rust-ctor/ctor)
warning: function `foo___rust_ctor___ctor` should have a snake case name
  --> ctor/src/example.rs:10:4
   |
10 | fn foo___rust_ctor___ctor() {}
   |    ^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `foo_rust_ctor_ctor`
   |
   = note: `#[warn(non_snake_case)]` on by default

warning: `ctor` (example "example") generated 1 warning
```