### PR TITLE
refactor: use ::core instead of core

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -239,15 +239,15 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             #[doc(hidden)]
             #[allow(non_camel_case_types)]
             #vis struct #ident<T> {
-                _data: core::marker::PhantomData<T>
+                _data: ::core::marker::PhantomData<T>
             }
 
             #(#attrs)*
             #vis static #ident: #ident<#ty> = #ident {
-                _data: core::marker::PhantomData::<#ty>
+                _data: ::core::marker::PhantomData::<#ty>
             };
 
-            impl core::ops::Deref for #ident<#ty> {
+            impl ::core::ops::Deref for #ident<#ty> {
                 type Target = #ty;
                 fn deref(&self) -> &'static #ty {
                     unsafe {


### PR DESCRIPTION
## The issue I encountered

In my project, I have a module named `core`, it clashes with the Rust core within the `ctor` macro, as you can see from the error:

```shell
$ ls -l src
Permissions Links Size User  Group Date Modified Name
.rw-r--r--      1    0 steve steve  8 Dec 19:57  core.rs
.rw-r--r--      1   79 steve steve  8 Dec 19:57  main.rs

$ cat src/main.rs
mod core;

use ctor::ctor;

#[ctor]
static INT: i32 = {
    1
};

fn main() {}

$ cargo b -q
error[E0433]: failed to resolve: could not find `marker` in `core`
 --> src/main.rs:5:1
  |
5 | #[ctor]
  | ^^^^^^^ could not find `marker` in `core`
  |
  = note: this error originates in the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing one of these items
  |
3 + use core::marker;
  |
3 + use std::marker;
  |

error[E0433]: failed to resolve: could not find `ops` in `core`
 --> src/main.rs:5:1
  |
5 | #[ctor]
  | ^^^^^^^ could not find `ops` in `core`
  |
  = note: this error originates in the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing one of these items
  |
3 + use core::ops;
  |
3 + use std::ops;
  |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `rust` (bin "rust") due to 2 previous errors
```

### How to fix it

Add `::` before `core` so that it will use the external `core` module, i.e., the Rust core (not the core from my project)

```sh
$ cat Cargo.toml | grep ctor
ctor = { git = "https://github.com/SteveLauC/rust-ctor", branch = "core" }

$ cargo b -q
```
