### PR TITLE
Added tvOS support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ctor"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "libc-print",
  "quote 1.0.33",

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -53,7 +53,7 @@ macro_rules! ctor_attributes {
             #[cfg_attr(target_os = "dragonfly", link_section = ".init_array")]
             #[cfg_attr(target_os = "illumos", link_section = ".init_array")]
             #[cfg_attr(target_os = "haiku", link_section = ".init_array")]
-            #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA,__mod_init_func")]
+            #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_section = "__DATA,__mod_init_func")]
             #[cfg_attr(windows, link_section = ".CRT$XCU")]
         )
     };
@@ -136,7 +136,7 @@ macro_rules! ctor_attributes {
 /// #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "illumos", link_section = ".init_array")]
-/// #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_section = "__DATA_CONST,__mod_init_func")]
+/// #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_section = "__DATA_CONST,__mod_init_func")]
 /// #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
 /// static FOO: extern fn() = {
 ///   #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
@@ -171,7 +171,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 
         let tokens = ctor_attributes!();
         let output = quote!(
-            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly", target_os = "illumos", target_os = "haiku", target_os = "macos", target_os = "ios", windows)))]
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly", target_os = "illumos", target_os = "haiku", target_os = "macos", target_os = "ios", target_os = "tvos", windows)))]
             compile_error!("#[ctor] is not supported on the current target");
 
             #(#attrs)*
@@ -230,7 +230,7 @@ pub fn ctor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 
         let tokens = ctor_attributes!();
         let output = quote!(
-            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly", target_os = "illumos", target_os = "haiku", target_os = "macos", target_os = "ios", windows)))]
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly", target_os = "illumos", target_os = "haiku", target_os = "macos", target_os = "ios", target_os = "tvos", windows)))]
             compile_error!("#[ctor] is not supported on the current target");
 
             // This is mutable, but only by this macro code!
@@ -328,7 +328,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 
     let tokens = ctor_attributes!();
     let output = quote!(
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly", target_os = "illumos", target_os = "haiku", target_os = "macos", target_os = "ios", windows)))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly", target_os = "illumos", target_os = "haiku", target_os = "macos", target_os = "ios", target_os = "tvos", windows)))]
         compile_error!("#[dtor] is not supported on the current target");
 
         #(#attrs)*
@@ -339,7 +339,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
 
             // Note that we avoid a dep on the libc crate by linking directly to atexit functions
 
-            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             #[inline(always)]
             unsafe fn do_atexit(cb: unsafe extern fn()) {
                 extern "C" {
@@ -349,7 +349,7 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             }
 
             // For platforms that have __cxa_atexit, we register the dtor as scoped to dso_handle
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
             #[inline(always)]
             unsafe fn do_atexit(cb: unsafe extern fn(_: *const u8)) {
                 extern "C" {
@@ -366,10 +366,10 @@ pub fn dtor(_attribute: TokenStream, function: TokenStream) -> TokenStream {
             :
             unsafe extern "C" fn() =
             {
-                #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+                #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.exit")]
                 unsafe extern "C" fn #dtor_ident() { #ident() };
-                #[cfg(any(target_os = "macos", target_os = "ios"))]
+                #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
                 unsafe extern "C" fn #dtor_ident(_: *const u8) { #ident() };
                 #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
                 unsafe extern fn __dtor_atexit() {

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -19,7 +19,7 @@ unsafe fn dtor() {
     libc_ewriteln!("- dtor bin");
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 fn lib_extension() -> &'static str {
     "dylib"
 }


### PR DESCRIPTION
- Added tvOS cfg flags for tvOS support

How was this tested (WIP):

- cargo +nightly build -Z build-std=std --workspace --target aarch64-apple-tvos
- cargo +nightly build -Z build-std=std --workspace --target aarch64-apple-tvos-sim
- cargo +nightly build -Z build-std=std --workspace --target x86_64-apple-tvos
- cargo +nightly build -Z build-std=std --workspace --target aarch64-apple-ios
- cargo +nightly build -Z build-std=std --workspace --target aarch64-apple-ios-sim