### PR TITLE
Mention correct `link_section` in docs for Apple

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -136,7 +136,7 @@ macro_rules! ctor_attributes {
 /// #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
 /// #[cfg_attr(target_os = "illumos", link_section = ".init_array")]
-/// #[cfg_attr(target_vendor = "apple", link_section = "__DATA_CONST,__mod_init_func")]
+/// #[cfg_attr(target_vendor = "apple", link_section = "__DATA,__mod_init_func")]
 /// #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
 /// static FOO: extern fn() = {
 ///   #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]


### PR DESCRIPTION
The code is correct by putting it actually in `__DATA`; update the docs to match that.

The assembler only sets the `S_MOD_INIT_FUNC_POINTERS` section flag if the `__DATA` segment is used, and without that, dyld will just ignore it. It's the linker's job to move it to `__DATA_CONST` when targetting a new enough OS version.