### PR TITLE
WASM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 **/*.rs.bk
 .vscode
 .DS_Store
+pkg
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "ctor"
 version = "0.3.0"
 dependencies = [
@@ -68,6 +80,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "once_cell"
+version = "1.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +166,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tests-wasm"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +184,64 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote 1.0.37",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = [ "ctor", "codegen", "dtor", "tests" ]
+members = [ "ctor", "codegen", "dtor", "tests", "tests-wasm" ]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ but not tested as part of the automatic builds. This library will also work as e
 `bin` and `cdylib` outputs, ie: the `ctor` and `dtor` will run at executable or library
 startup/shutdown respectively.
 
+This library supports WASM targets, but note that only a single `#[ctor]` function is
+supported due to platform limitations.
+
 ## Warnings
 
 Rust's philosophy is that nothing happens before or after main and

--- a/codegen/src/macros.rs
+++ b/codegen/src/macros.rs
@@ -54,6 +54,15 @@ declare_macros!(
 
     macro_rules! ctor_entry {
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], item=fn $ident:ident() $block:block) => {
+            #[cfg(target_family="wasm")]
+            $(#[$fnmeta])*
+            #[allow(unused)]
+            #[wasm_bindgen(start)]
+            $($vis)* fn $ident() {
+                $block
+            }
+
+            #[cfg(not(target_family="wasm"))]
             $(#[$fnmeta])*
             #[allow(unused)]
             $($vis)* fn $ident() {
@@ -90,6 +99,15 @@ declare_macros!(
             }
         };
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], item=unsafe fn $ident:ident() $block:block) => {
+            #[cfg(target_family="wasm")]
+            $(#[$fnmeta])*
+            #[allow(unused)]
+            #[wasm_bindgen(start)]
+            $($vis)* unsafe fn $ident() {
+                $block
+            }
+
+            #[cfg(not(target_family="wasm"))]
             $(#[$fnmeta])*
             #[allow(unused)]
             $($vis)* unsafe fn $ident() {
@@ -144,6 +162,25 @@ declare_macros!(
                 }
             }
 
+            #[cfg(target_family="wasm")]
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            mod $ident {
+                #[derive(Default)]
+                #[allow(non_camel_case_types)]
+                pub struct Static<T> {
+                    pub _storage: ::std::cell::UnsafeCell<::std::option::Option<T>>
+                }
+
+                unsafe impl <T> std::marker::Sync for Static<T> {}
+
+                #[wasm_bindgen(start)]
+                fn init() {
+                    super::$ident.init_once();
+                }
+            }
+
+            #[cfg(not(target_family="wasm"))]
             #[doc(hidden)]
             #[allow(non_upper_case_globals, non_snake_case)]
             mod $ident {

--- a/codegen/src/macros.rs
+++ b/codegen/src/macros.rs
@@ -57,7 +57,7 @@ declare_macros!(
             #[cfg(target_family="wasm")]
             $(#[$fnmeta])*
             #[allow(unused)]
-            #[wasm_bindgen(start)]
+            #[::wasm_bindgen::prelude::wasm_bindgen(start)]
             $($vis)* fn $ident() {
                 $block
             }
@@ -102,7 +102,7 @@ declare_macros!(
             #[cfg(target_family="wasm")]
             $(#[$fnmeta])*
             #[allow(unused)]
-            #[wasm_bindgen(start)]
+            #[::wasm_bindgen::prelude::wasm_bindgen(start)]
             $($vis)* unsafe fn $ident() {
                 $block
             }
@@ -174,7 +174,7 @@ declare_macros!(
 
                 unsafe impl <T> std::marker::Sync for Static<T> {}
 
-                #[wasm_bindgen(start)]
+                #[::wasm_bindgen::prelude::wasm_bindgen(start)]
                 fn init() {
                     super::$ident.init_once();
                 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -195,7 +195,9 @@ mod tests {
     fn test_up_to_date() {
         let contents = generate_code().expect("Failed to generate code");
         assert_eq!(
-            std::fs::read_to_string("../ctor/src/gen.rs").unwrap().replace("\r\n", "\n"),
+            std::fs::read_to_string("../ctor/src/gen.rs")
+                .unwrap()
+                .replace("\r\n", "\n"),
             contents
         );
     }

--- a/ctor/src/gen.rs
+++ b/ctor/src/gen.rs
@@ -2583,6 +2583,92 @@ pub fn ctor() -> TokenStream {
         T::Punct(Punct::new('>', Alone)),
         T::Group(Group::new(Brace, 
           TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("target_family", c())),
+                    T::Punct(Punct::new('=', Alone)),
+                    T::Literal(Literal::string("wasm")),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("fnmeta", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unused", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("wasm_bindgen", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("start", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("vis", c())),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+            T::Ident(Ident::new("fn", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::new()
+            )),
+            T::Group(Group::new(Brace, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("block", c())),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("not", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_family", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("wasm")),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
@@ -2979,6 +3065,93 @@ pub fn ctor() -> TokenStream {
         T::Punct(Punct::new('>', Alone)),
         T::Group(Group::new(Brace, 
           TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("target_family", c())),
+                    T::Punct(Punct::new('=', Alone)),
+                    T::Literal(Literal::string("wasm")),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("fnmeta", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unused", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("wasm_bindgen", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("start", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("vis", c())),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+            T::Ident(Ident::new("unsafe", c())),
+            T::Ident(Ident::new("fn", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::new()
+            )),
+            T::Group(Group::new(Brace, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("block", c())),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("not", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_family", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("wasm")),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
@@ -3519,6 +3692,177 @@ pub fn ctor() -> TokenStream {
                           ])
                         )),
                         T::Punct(Punct::new(';', Alone)),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("target_family", c())),
+                    T::Punct(Punct::new('=', Alone)),
+                    T::Literal(Literal::string("wasm")),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("doc", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("hidden", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("non_upper_case_globals", c())),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("non_snake_case", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Ident(Ident::new("mod", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Group(Group::new(Brace, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("derive", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("Default", c())),
+                      ])
+                    )),
+                  ])
+                )),
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("allow", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("non_camel_case_types", c())),
+                      ])
+                    )),
+                  ])
+                )),
+                T::Ident(Ident::new("pub", c())),
+                T::Ident(Ident::new("struct", c())),
+                T::Ident(Ident::new("Static", c())),
+                T::Punct(Punct::new('<', Alone)),
+                T::Ident(Ident::new("T", c())),
+                T::Punct(Punct::new('>', Alone)),
+                T::Group(Group::new(Brace, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("pub", c())),
+                    T::Ident(Ident::new("_storage", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("std", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("cell", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("UnsafeCell", c())),
+                    T::Punct(Punct::new('<', Alone)),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("std", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("option", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("Option", c())),
+                    T::Punct(Punct::new('<', Alone)),
+                    T::Ident(Ident::new("T", c())),
+                    T::Punct(Punct::new('>', Joint)),
+                    T::Punct(Punct::new('>', Alone)),
+                  ])
+                )),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Ident(Ident::new("impl", c())),
+                T::Punct(Punct::new('<', Alone)),
+                T::Ident(Ident::new("T", c())),
+                T::Punct(Punct::new('>', Alone)),
+                T::Ident(Ident::new("std", c())),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("marker", c())),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("Sync", c())),
+                T::Ident(Ident::new("for", c())),
+                T::Ident(Ident::new("Static", c())),
+                T::Punct(Punct::new('<', Alone)),
+                T::Ident(Ident::new("T", c())),
+                T::Punct(Punct::new('>', Alone)),
+                T::Group(Group::new(Brace, 
+                  TokenStream::new()
+                )),
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("wasm_bindgen", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("start", c())),
+                      ])
+                    )),
+                  ])
+                )),
+                T::Ident(Ident::new("fn", c())),
+                T::Ident(Ident::new("init", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::new()
+                )),
+                T::Group(Group::new(Brace, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("super", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("ident", c())),
+                    T::Punct(Punct::new('.', Alone)),
+                    T::Ident(Ident::new("init_once", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::new()
+                    )),
+                    T::Punct(Punct::new(';', Alone)),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("not", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_family", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("wasm")),
                       ])
                     )),
                   ])

--- a/ctor/src/gen.rs
+++ b/ctor/src/gen.rs
@@ -2623,6 +2623,14 @@ pub fn ctor() -> TokenStream {
             T::Punct(Punct::new('#', Alone)),
             T::Group(Group::new(Bracket, 
               TokenStream::from_iter([
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("wasm_bindgen", c())),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("prelude", c())),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
                 T::Ident(Ident::new("wasm_bindgen", c())),
                 T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
@@ -3105,6 +3113,14 @@ pub fn ctor() -> TokenStream {
             T::Punct(Punct::new('#', Alone)),
             T::Group(Group::new(Bracket, 
               TokenStream::from_iter([
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("wasm_bindgen", c())),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("prelude", c())),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
                 T::Ident(Ident::new("wasm_bindgen", c())),
                 T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
@@ -3821,6 +3837,14 @@ pub fn ctor() -> TokenStream {
                 T::Punct(Punct::new('#', Alone)),
                 T::Group(Group::new(Bracket, 
                   TokenStream::from_iter([
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("wasm_bindgen", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("prelude", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
                     T::Ident(Ident::new("wasm_bindgen", c())),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([

--- a/tests-wasm/Cargo.toml
+++ b/tests-wasm/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tests-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+ctor = { path = "../ctor" }

--- a/tests-wasm/src/lib.rs
+++ b/tests-wasm/src/lib.rs
@@ -1,0 +1,14 @@
+use ctor::ctor;
+
+#[ctor]
+unsafe fn hello() {
+    use wasm_bindgen::prelude::wasm_bindgen;
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_namespace = console)]
+        fn log(s: &str);
+    }
+
+    log("hello!");
+}

--- a/tests-wasm/src/lib.rs
+++ b/tests-wasm/src/lib.rs
@@ -1,6 +1,5 @@
-use ctor::ctor;
-
-#[ctor]
+#[cfg(target_family="wasm")]
+#[ctor::ctor]
 unsafe fn hello() {
     use wasm_bindgen::prelude::wasm_bindgen;
 


### PR DESCRIPTION
Add support for wasm targets. Note that only one wasm start target is allowed (aka, one and only one #[ctor] will be allowed).

Fixes #273
