### PR TITLE
Fix new `unsafe_code` warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ctor"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "libc-print",
 ]

--- a/codegen/src/macros.rs
+++ b/codegen/src/macros.rs
@@ -65,6 +65,7 @@ declare_macros!(
             #[cfg(not(target_family="wasm"))]
             $(#[$fnmeta])*
             #[allow(unused)]
+            #[allow(unsafe_code)]
             $($vis)* fn $ident() {
                 mod __ctor_internal {
                     super::$($macro_path)::+::if_has_feature!(macro_path=super::$($macro_path)::+, __warn_on_missing_unsafe, $features, {
@@ -110,6 +111,7 @@ declare_macros!(
             #[cfg(not(target_family="wasm"))]
             $(#[$fnmeta])*
             #[allow(unused)]
+            #[allow(unsafe_code)]
             $($vis)* unsafe fn $ident() {
                 #[doc(hidden)]
                 mod __ctor_internal {
@@ -143,6 +145,7 @@ declare_macros!(
             impl ::core::ops::Deref for $ident::Static<$ty> {
                 type Target = $ty;
                 fn deref(&self) -> &'static $ty {
+                    #[allow(unsafe_code)]
                     unsafe {
                         let ptr = self._storage.get();
                         let val = (&*ptr).as_ref().unwrap();
@@ -155,6 +158,7 @@ declare_macros!(
                 fn init_once(&self) {
                     let val = Some($expr);
                     // Only write the value to `storage_ident` on startup
+                    #[allow(unsafe_code)]
                     unsafe {
                         let ptr = self._storage.get();
                         ::std::ptr::write(ptr, val);
@@ -165,6 +169,7 @@ declare_macros!(
             #[cfg(target_family="wasm")]
             #[doc(hidden)]
             #[allow(non_upper_case_globals, non_snake_case)]
+            #[allow(unsafe_code)]
             mod $ident {
                 #[derive(Default)]
                 #[allow(non_camel_case_types)]
@@ -183,6 +188,7 @@ declare_macros!(
             #[cfg(not(target_family="wasm"))]
             #[doc(hidden)]
             #[allow(non_upper_case_globals, non_snake_case)]
+            #[allow(unsafe_code)]
             mod $ident {
                 #[derive(Default)]
                 #[allow(non_camel_case_types)]
@@ -190,6 +196,7 @@ declare_macros!(
                     pub _storage: ::std::cell::UnsafeCell<::std::option::Option<T>>
                 }
 
+                #[allow(unsafe_code)]
                 unsafe impl <T> std::marker::Sync for Static<T> {}
 
                 super::$($macro_path)::+::ctor_link_section!(
@@ -214,6 +221,7 @@ declare_macros!(
     macro_rules! dtor_entry {
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], item=fn $ident:ident() $block:block) => {
             $(#[$fnmeta])*
+            #[allow(unsafe_code)]
             $($vis)* fn $ident() {
                 mod __dtor_internal {
                     super::$($macro_path)::+::if_has_feature!(macro_path=super::$($macro_path)::+, __warn_on_missing_unsafe, $features, {
@@ -274,6 +282,7 @@ declare_macros!(
         };
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)?], item=unsafe fn $ident:ident() $block:block) => {
             $(#[$fnmeta])*
+            #[allow(unsafe_code)]
             $($vis)* unsafe fn $ident() {
                 mod __dtor_internal {
                     super::$($macro_path)::+::ctor_link_section!(

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Matt Mastracci <matthew@mastracci.com>"]
 edition = "2021"
 description = "__attribute__((constructor)) for Rust"

--- a/ctor/src/gen.rs
+++ b/ctor/src/gen.rs
@@ -2701,6 +2701,17 @@ pub fn ctor() -> TokenStream {
                 )),
               ])
             )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
+                  ])
+                )),
+              ])
+            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
@@ -3192,6 +3203,17 @@ pub fn ctor() -> TokenStream {
                 )),
               ])
             )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
+                  ])
+                )),
+              ])
+            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
@@ -3600,6 +3622,17 @@ pub fn ctor() -> TokenStream {
                 T::Ident(Ident::new("ty", c())),
                 T::Group(Group::new(Brace, 
                   TokenStream::from_iter([
+                    T::Punct(Punct::new('#', Alone)),
+                    T::Group(Group::new(Bracket, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("allow", c())),
+                        T::Group(Group::new(Parenthesis, 
+                          TokenStream::from_iter([
+                            T::Ident(Ident::new("unsafe_code", c())),
+                          ])
+                        )),
+                      ])
+                    )),
                     T::Ident(Ident::new("unsafe", c())),
                     T::Group(Group::new(Brace, 
                       TokenStream::from_iter([
@@ -3676,6 +3709,17 @@ pub fn ctor() -> TokenStream {
                       ])
                     )),
                     T::Punct(Punct::new(';', Alone)),
+                    T::Punct(Punct::new('#', Alone)),
+                    T::Group(Group::new(Bracket, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("allow", c())),
+                        T::Group(Group::new(Parenthesis, 
+                          TokenStream::from_iter([
+                            T::Ident(Ident::new("unsafe_code", c())),
+                          ])
+                        )),
+                      ])
+                    )),
                     T::Ident(Ident::new("unsafe", c())),
                     T::Group(Group::new(Brace, 
                       TokenStream::from_iter([
@@ -3747,6 +3791,17 @@ pub fn ctor() -> TokenStream {
                     T::Ident(Ident::new("non_upper_case_globals", c())),
                     T::Punct(Punct::new(',', Alone)),
                     T::Ident(Ident::new("non_snake_case", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
                   ])
                 )),
               ])
@@ -3917,6 +3972,17 @@ pub fn ctor() -> TokenStream {
                 )),
               ])
             )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
+                  ])
+                )),
+              ])
+            )),
             T::Ident(Ident::new("mod", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("ident", c())),
@@ -3978,6 +4044,17 @@ pub fn ctor() -> TokenStream {
                     T::Ident(Ident::new("T", c())),
                     T::Punct(Punct::new('>', Joint)),
                     T::Punct(Punct::new('>', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("allow", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("unsafe_code", c())),
+                      ])
+                    )),
                   ])
                 )),
                 T::Ident(Ident::new("unsafe", c())),
@@ -4295,6 +4372,17 @@ pub fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
+                  ])
+                )),
+              ])
+            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
@@ -4984,6 +5072,17 @@ pub fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
+                  ])
+                )),
+              ])
+            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([


### PR DESCRIPTION
As part of the rewrite to use macros directly, Rust started emitting unsafe_code warnings that we need to suppress.

Fixes #316
