### PR TITLE
Be as warning-safe as we can with Rust 2024 around the corner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       CLIPPY_LINTS: >-
-        -Dclippy::all
+        -D clippy::all
         -D deprecated-safe
         -D future-incompatible
         -D keyword-idents

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Clippy
       run: cargo clippy --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
     - name: Clippy (all features)
-      run: cargo clippy --all-features --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
+      run: cargo +nightly clippy --all-features --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
     - name: Build with static CRT
       if: matrix.os == 'ubuntu-latest'
       run: RUSTFLAGS="-C target-feature=+crt-static" cargo run --example example --target x86_64-unknown-linux-gnu --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+    env:
+      CLIPPY_LINTS: >-
+        -Dclippy::all
+        -D deprecated-safe
+        -D future-incompatible
+        -D keyword-idents
+        -D let-underscore
+        -D nonstandard-style
+        -D refining-impl-trait
+        -D rust-2018-compatibility
+        -D rust-2018-idioms
+        -D rust-2021-compatibility
+        -D rust-2024-compatibility
+        -D unused
+        -D unsafe_code
+        -D unreachable-pub
 
     steps:
     - uses: actions/checkout@v3
@@ -24,6 +40,10 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Clippy
+      run: cargo clippy --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
+    - name: Clippy (all features)
+      run: cargo clippy --all-features --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
     - name: Build with static CRT
       if: matrix.os == 'ubuntu-latest'
       run: RUSTFLAGS="-C target-feature=+crt-static" cargo run --example example --target x86_64-unknown-linux-gnu --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Clippy
       run: cargo clippy --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
     - name: Clippy (all features)
-      run: cargo +nightly clippy --all-features --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
+      run: rustup toolchain add nightly && cargo +nightly clippy --all-features --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
     - name: Build with static CRT
       if: matrix.os == 'ubuntu-latest'
       run: RUSTFLAGS="-C target-feature=+crt-static" cargo run --example example --target x86_64-unknown-linux-gnu --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Clippy
       run: cargo clippy --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
     - name: Clippy (all features)
-      run: rustup toolchain add nightly && cargo +nightly clippy --all-features --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
+      run: rustup toolchain add nightly && rustup component add clippy --toolchain nightly && cargo +nightly clippy --all-features --examples --bins --all -- ${{ env.CLIPPY_LINTS }}
     - name: Build with static CRT
       if: matrix.os == 'ubuntu-latest'
       run: RUSTFLAGS="-C target-feature=+crt-static" cargo run --example example --target x86_64-unknown-linux-gnu --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,7 @@ jobs:
         -D unused
         -D unsafe_code
         -D unreachable-pub
+        -D missing-docs
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,6 @@ dependencies = [
  "dlopen",
  "libc",
  "libc-print",
- "rustversion",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,10 +25,8 @@ dependencies = [
 name = "ctor-codegen"
 version = "0.1.0"
 dependencies = [
- "libc-print",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.87",
 ]
 
 [[package]]
@@ -163,6 +161,28 @@ dependencies = [
  "dlopen",
  "libc",
  "libc-print",
+ "rustversion",
+]
+
+[[package]]
+name = "tests-edition-2018"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
+name = "tests-edition-2021"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
+name = "tests-edition-2024"
+version = "0.1.0"
+dependencies = [
+ "ctor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = [ "ctor", "codegen", "dtor", "tests", "tests-wasm" ]
+members = [ "ctor", "codegen", "dtor", "tests", "tests-wasm", "tests-edition-2018", "tests-edition-2021", "tests-edition-2024" ]
 resolver = "2"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -5,7 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-libc-print = "0.1.20"
-syn = "2"
 quote = "1"
 proc-macro2 = "1"

--- a/codegen/src/macros.rs
+++ b/codegen/src/macros.rs
@@ -202,8 +202,9 @@ declare_macros!(
         };
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
             $(#[$fnmeta])*
-            #[allow(unsafe_code, unused)]
-            $($vis)* fn $ident() {
+            #[allow(unused)]
+            $($vis)* $($unsafe)? fn $ident() {
+                #[allow(unsafe_code)]
                 mod __dtor_internal {
                     super::$($macro_path)::+::if_unsafe!($($unsafe)?, {}, {
                         super::$($macro_path)::+::if_has_feature!(macro_path=super::$($macro_path)::+, __warn_on_missing_unsafe, $features, {
@@ -246,7 +247,7 @@ declare_macros!(
 
                         unsafe extern "C" fn __dtor(
                             #[cfg(target_vendor = "apple")] _: *const u8
-                        ) { super::$ident() }
+                        ) { unsafe { super::$ident() } }
                     );
 
                     #[cfg(not(target_vendor = "apple"))]

--- a/codegen/src/macros.rs
+++ b/codegen/src/macros.rs
@@ -11,32 +11,32 @@ declare_macros!(
     /// `#[ctor] (pub) static IDENT`
     macro_rules! ctor_parse {
         (#[ctor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* pub ( $($extra:tt)* ) $($item:tt)*) => {
-            $($macro_path)::+::ctor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub($($extra)*)], item=$($item)*);
+            $($macro_path)::+::ctor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub($($extra)*)], item=$($item)*);
         };
         (#[ctor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* pub $($item:tt)*) => {
-            $($macro_path)::+::ctor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub], item=$($item)*);
+            $($macro_path)::+::ctor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub], item=$($item)*);
         };
         (#[ctor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* fn $($item:tt)*) => {
-            $($macro_path)::+::ctor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=fn $($item)*);
+            $($macro_path)::+::ctor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=fn $($item)*);
         };
         (#[ctor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* unsafe $($item:tt)*) => {
-            $($macro_path)::+::ctor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=unsafe $($item)*);
+            $($macro_path)::+::ctor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=unsafe $($item)*);
         };
         (#[ctor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* static $($item:tt)*) => {
-            $($macro_path)::+::ctor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=static $($item)*);
+            $($macro_path)::+::ctor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=static $($item)*);
         };
 
         (#[dtor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* pub ( $($extra:tt)* ) $($item:tt)*) => {
-            $($macro_path)::+::dtor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub($($extra)*)], item=$($item)*);
+            $($macro_path)::+::dtor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub($($extra)*)], item=$($item)*);
         };
         (#[dtor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* pub $($item:tt)*) => {
-            $($macro_path)::+::dtor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub], item=$($item)*);
+            $($macro_path)::+::dtor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[pub], item=$($item)*);
         };
         (#[dtor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* fn $($item:tt)*) => {
-            $($macro_path)::+::dtor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=fn $($item)*);
+            $($macro_path)::+::dtor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=fn $($item)*);
         };
         (#[dtor $( ($meta:meta) )?] $( #[feature($fname:ident)] )* #[macro_path=$($macro_path:ident)::+] $(#[$imeta:meta])* unsafe $($item:tt)*) => {
-            $($macro_path)::+::dtor_entry!(meta=[$($meta,)*], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=unsafe $($item)*);
+            $($macro_path)::+::dtor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=[$($fname,)*], imeta=$(#[$imeta])*, vis=[], item=unsafe $($item)*);
         };
     }
 
@@ -52,59 +52,24 @@ declare_macros!(
         (macro_path=$($macro_path:ident)::+, __warn_on_missing_unsafe, [], {$($if_true:tt)*}, {$($if_false:tt)*}) => { $($if_false)* };
     }
 
+    macro_rules! if_unsafe {
+        (, {$($if_unsafe:tt)*}, {$($if_safe:tt)*}) => { $($if_safe)* };
+        (unsafe, {$($if_unsafe:tt)*}, {$($if_safe:tt)*}) => { $($if_unsafe)* };
+    }
+
     macro_rules! ctor_entry {
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], item=fn $ident:ident() $block:block) => {
-            #[cfg(target_family="wasm")]
-            $(#[$fnmeta])*
-            #[allow(unused)]
-            #[::wasm_bindgen::prelude::wasm_bindgen(start)]
-            $($vis)* fn $ident() {
-                $block
-            }
-
-            #[cfg(not(target_family="wasm"))]
-            $(#[$fnmeta])*
-            #[allow(unused)]
-            #[allow(unsafe_code)]
-            $($vis)* fn $ident() {
-                mod __ctor_internal {
-                    super::$($macro_path)::+::if_has_feature!(macro_path=super::$($macro_path)::+, __warn_on_missing_unsafe, $features, {
-                        #[deprecated="ctor deprecation note:\n\n \
-                        Use of #[ctor] without `unsafe fn` is deprecated. As code execution before main\n\
-                        is unsupported by most Rust runtime functions, these functions must be marked\n\
-                        `unsafe`."]
-                        const fn ctor_without_unsafe_is_deprecated() {}
-                        #[allow(unused)]
-                        static UNSAFE_WARNING: () = ctor_without_unsafe_is_deprecated();
-                    }, {});
-
-                    super::$($macro_path)::+::ctor_link_section!(
-                        macro_path=super::$($macro_path)::+,
-                        features=$features,
-
-                        #[allow(non_upper_case_globals, non_snake_case)]
-                        #[doc(hidden)]
-                        static $ident: unsafe extern "C" fn() -> usize =
-                        {
-                            // This function must be callable from the C runtime, so it must be marked extern "C"
-                            #[allow(non_snake_case)]
-                            #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
-                            unsafe extern "C" fn $ident() -> usize { super::$ident(); 0 }
-
-                            $ident
-                        };
-                    );
-                }
-
-                $block
-            }
+            $($macro_path)::+::ctor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=, item=fn $ident() $block);
         };
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], item=unsafe fn $ident:ident() $block:block) => {
+            $($macro_path)::+::ctor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=unsafe, item=fn $ident() $block);
+        };
+        (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
             #[cfg(target_family="wasm")]
             $(#[$fnmeta])*
             #[allow(unused)]
             #[::wasm_bindgen::prelude::wasm_bindgen(start)]
-            $($vis)* unsafe fn $ident() {
+            $($vis)* fn $ident() {
                 $block
             }
 
@@ -112,9 +77,22 @@ declare_macros!(
             $(#[$fnmeta])*
             #[allow(unused)]
             #[allow(unsafe_code)]
-            $($vis)* unsafe fn $ident() {
+            $($vis)* fn $ident() {
                 #[doc(hidden)]
+                #[allow(unsafe_code)]
                 mod __ctor_internal {
+                    super::$($macro_path)::+::if_unsafe!($($unsafe)?, {}, {
+                        super::$($macro_path)::+::if_has_feature!(macro_path=super::$($macro_path)::+, __warn_on_missing_unsafe, $features, {
+                            #[deprecated="ctor deprecation note:\n\n \
+                            Use of #[ctor] without `unsafe fn` is deprecated. As code execution before main\n\
+                            is unsupported by most Rust runtime functions, these functions must be marked\n\
+                            `unsafe`."]
+                                const fn ctor_without_unsafe_is_deprecated() {}
+                                #[allow(unused)]
+                                static UNSAFE_WARNING: () = ctor_without_unsafe_is_deprecated();
+                        }, {});
+                    });
+
                     super::$($macro_path)::+::ctor_link_section!(
                         macro_path=super::$($macro_path)::+,
                         features=$features,
@@ -155,6 +133,7 @@ declare_macros!(
             }
 
             impl $ident::Static<$ty> {
+                #[allow(dead_code)]
                 fn init_once(&self) {
                     let val = Some($expr);
                     // Only write the value to `storage_ident` on startup
@@ -166,32 +145,11 @@ declare_macros!(
                 }
             }
 
-            #[cfg(target_family="wasm")]
             #[doc(hidden)]
             #[allow(non_upper_case_globals, non_snake_case)]
             #[allow(unsafe_code)]
             mod $ident {
-                #[derive(Default)]
-                #[allow(non_camel_case_types)]
-                pub struct Static<T> {
-                    pub _storage: ::std::cell::UnsafeCell<::std::option::Option<T>>
-                }
-
-                unsafe impl <T> std::marker::Sync for Static<T> {}
-
-                #[::wasm_bindgen::prelude::wasm_bindgen(start)]
-                fn init() {
-                    super::$ident.init_once();
-                }
-            }
-
-            #[cfg(not(target_family="wasm"))]
-            #[doc(hidden)]
-            #[allow(non_upper_case_globals, non_snake_case)]
-            #[allow(unsafe_code)]
-            mod $ident {
-                #[derive(Default)]
-                #[allow(non_camel_case_types)]
+                #[allow(non_camel_case_types, unreachable_pub)]
                 pub struct Static<T> {
                     pub _storage: ::std::cell::UnsafeCell<::std::option::Option<T>>
                 }
@@ -199,6 +157,13 @@ declare_macros!(
                 #[allow(unsafe_code)]
                 unsafe impl <T> std::marker::Sync for Static<T> {}
 
+                #[cfg(target_family="wasm")]
+                #[::wasm_bindgen::prelude::wasm_bindgen(start)]
+                fn init() {
+                    super::$ident.init_once();
+                }
+
+                #[cfg(not(target_family="wasm"))]
                 super::$($macro_path)::+::ctor_link_section!(
                     macro_path=super::$($macro_path)::+,
                     features=$features,
@@ -220,19 +185,27 @@ declare_macros!(
 
     macro_rules! dtor_entry {
         (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], item=fn $ident:ident() $block:block) => {
+            $($macro_path)::+::dtor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=, item=fn $ident() $block);
+        };
+        (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], item=unsafe fn $ident:ident() $block:block) => {
+            $($macro_path)::+::dtor_entry!(meta=[$($meta,)?], macro_path=$($macro_path)::+, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=unsafe, item=fn $ident() $block);
+        };
+        (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
             $(#[$fnmeta])*
-            #[allow(unsafe_code)]
+            #[allow(unsafe_code, unused)]
             $($vis)* fn $ident() {
                 mod __dtor_internal {
-                    super::$($macro_path)::+::if_has_feature!(macro_path=super::$($macro_path)::+, __warn_on_missing_unsafe, $features, {
-                        #[deprecated="dtor deprecation note:\n\n \
-                        Use of #[dtor] without `unsafe fn` is deprecated. As code execution after main\n\
-                        is unsupported by most Rust runtime functions, these functions must be marked\n\
-                        `unsafe`."]
-                        const fn dtor_without_unsafe_is_deprecated() {}
-                        #[allow(unused)]
-                        static UNSAFE_WARNING: () = dtor_without_unsafe_is_deprecated();
-                    }, {});
+                    super::$($macro_path)::+::if_unsafe!($($unsafe)?, {}, {
+                        super::$($macro_path)::+::if_has_feature!(macro_path=super::$($macro_path)::+, __warn_on_missing_unsafe, $features, {
+                            #[deprecated="dtor deprecation note:\n\n \
+                            Use of #[dtor] without `unsafe fn` is deprecated. As code execution after main\n\
+                            is unsupported by most Rust runtime functions, these functions must be marked\n\
+                            `unsafe`."]
+                            const fn dtor_without_unsafe_is_deprecated() {}
+                            #[allow(unused)]
+                            static UNSAFE_WARNING: () = dtor_without_unsafe_is_deprecated();
+                        }, {});
+                    });
 
                     super::$($macro_path)::+::ctor_link_section!(
                         macro_path=super::$($macro_path)::+,
@@ -244,7 +217,7 @@ declare_macros!(
                         {
                             #[allow(non_snake_case)]
                             #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
-                            unsafe extern "C" fn $ident() -> usize { do_atexit(__dtor); 0 }
+                            unsafe extern "C" fn $ident() -> usize { unsafe { do_atexit(__dtor); 0 } }
 
                             $ident
                         };
@@ -268,63 +241,14 @@ declare_macros!(
                     // For platforms that have __cxa_atexit, we register the dtor as scoped to dso_handle
                     #[cfg(target_vendor = "apple")]
                     #[inline(always)]
-                    pub(super) unsafe fn do_atexit(cb: unsafe extern fn(_: *const u8)) {
-                        extern "C" {
+                    pub(super) unsafe fn do_atexit(cb: unsafe extern "C" fn(_: *const u8)) {
+                        unsafe extern "C" {
                             static __dso_handle: *const u8;
-                            fn __cxa_atexit(cb: unsafe extern fn(_: *const u8), arg: *const u8, dso_handle: *const u8);
+                            fn __cxa_atexit(cb: unsafe extern "C" fn(_: *const u8), arg: *const u8, dso_handle: *const u8);
                         }
-                        __cxa_atexit(cb, core::ptr::null(), __dso_handle);
-                    }
-                }
-
-                $block
-            }
-        };
-        (meta=[$($meta:meta)?], macro_path=$($macro_path:ident)::+, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)?], item=unsafe fn $ident:ident() $block:block) => {
-            $(#[$fnmeta])*
-            #[allow(unsafe_code)]
-            $($vis)* unsafe fn $ident() {
-                mod __dtor_internal {
-                    super::$($macro_path)::+::ctor_link_section!(
-                        macro_path=super::$($macro_path)::+,
-                        features=$features,
-
-                        #[allow(non_upper_case_globals, non_snake_case)]
-                        #[doc(hidden)]
-                        static $ident: unsafe extern "C" fn() -> usize =
-                        {
-                            #[allow(non_snake_case)]
-                            #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
-                            unsafe extern "C" fn $ident() -> usize { do_atexit(__dtor); 0 }
-
-                            $ident
-                        };
-                    );
-
-                    #[cfg(not(target_vendor = "apple"))]
-                    #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.exit")]
-                    unsafe extern "C" fn __dtor() { super::$ident() }
-                    #[cfg(target_vendor = "apple")]
-                    unsafe extern "C" fn __dtor(_: *const u8) { super::$ident() }
-
-                    #[cfg(not(target_vendor = "apple"))]
-                    #[inline(always)]
-                    pub(super) unsafe fn do_atexit(cb: unsafe extern fn()) {
-                        extern "C" {
-                            fn atexit(cb: unsafe extern fn());
+                        unsafe {
+                            __cxa_atexit(cb, core::ptr::null(), __dso_handle);
                         }
-                        atexit(cb);
-                    }
-
-                    // For platforms that have __cxa_atexit, we register the dtor as scoped to dso_handle
-                    #[cfg(target_vendor = "apple")]
-                    #[inline(always)]
-                    pub(super) unsafe fn do_atexit(cb: unsafe extern fn(_: *const u8)) {
-                        extern "C" {
-                            static __dso_handle: *const u8;
-                            fn __cxa_atexit(cb: unsafe extern fn(_: *const u8), arg: *const u8, dso_handle: *const u8);
-                        }
-                        __cxa_atexit(cb, core::ptr::null(), __dso_handle);
                     }
                 }
 
@@ -337,15 +261,11 @@ declare_macros!(
     macro_rules! ctor_link_section {
         (macro_path=$($macro_path:ident)::+, features=$features:tt, $($block:tt)+) => {
             $($macro_path)::+::if_has_feature!(macro_path=$($macro_path)::+, used_linker, $features, {
-                $($macro_path)::+::ctor_link_section_attr!(used(linker), $($block)+);
+                $($macro_path)::+::ctor_link_section_attr!(const {1}, used(linker), $($block)+);
             }, {
-                $($macro_path)::+::ctor_link_section_attr!(used, $($block)+);
+                $($macro_path)::+::ctor_link_section_attr!(const {1}, used, $($block)+);
             });
-        }
-    }
 
-    macro_rules! ctor_link_section_attr {
-        ($used:meta, $item:item) => {
             #[cfg(not(any(
                 target_os = "linux",
                 target_os = "android",
@@ -359,7 +279,42 @@ declare_macros!(
                 windows
             )))]
             compile_error!("#[ctor]/#[dtor] is not supported on the current target");
+        }
+    }
 
+    /// Depending on the edition, we use either the top or bottom path because
+    /// of the change in how `const {1}` is parsed in edition 2021/2024 macros.
+    /// 
+    /// Because of some strangeness around clippy validation of unsafe(...)
+    /// attributes, we just skip them entirely when clippy-ing.
+    macro_rules! ctor_link_section_attr {
+        ($e:expr, $used:meta, $item:item) => {
+            #[allow(unsafe_code)]
+            #[cfg_attr(
+                any(
+                    target_os = "linux",
+                    target_os = "android",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                    target_os = "dragonfly",
+                    target_os = "illumos",
+                    target_os = "haiku"
+                ),
+                unsafe(link_section = ".init_array")
+            )]
+            #[cfg_attr(target_vendor = "apple", unsafe(link_section = "__DATA,__mod_init_func"))]
+            #[cfg_attr(windows, unsafe(link_section = ".CRT$XCU"))]
+            #[$used]
+            $item
+        };
+        (const $e:expr, $used:meta, $item:item) => {
+            #[cfg(clippy)]
+            #[$used]
+            $item
+
+            #[cfg(not(clippy))]
+            #[allow(unsafe_code)]
             #[cfg_attr(
                 any(
                     target_os = "linux",

--- a/codegen/src/macros.rs
+++ b/codegen/src/macros.rs
@@ -76,8 +76,7 @@ declare_macros!(
             #[cfg(not(target_family="wasm"))]
             $(#[$fnmeta])*
             #[allow(unused)]
-            #[allow(unsafe_code)]
-            $($vis)* fn $ident() {
+            $($vis)* $($unsafe)? fn $ident() {
                 #[doc(hidden)]
                 #[allow(unsafe_code)]
                 mod __ctor_internal {
@@ -108,7 +107,7 @@ declare_macros!(
                                 features=$features,
 
                                 #[allow(non_snake_case)]
-                                unsafe extern "C" fn $ident() -> usize { super::$ident(); 0 }
+                                unsafe extern "C" fn $ident() -> usize { unsafe { super::$ident(); 0 } }
                             );
 
                             $ident

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -124,7 +124,7 @@ macros::ctor_parse!(
     #[ctor]
     #[feature(__warn_on_missing_unsafe)]
     #[macro_path=macros]
-    #[allow(deprecated)]
+    #[allow(unsafe_code)]
     unsafe fn foo_with_unsafe() {}
 );
 

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,20 +1,25 @@
+//! This crate is used to generate the token streams for the macros in the `ctor` crate.
 use std::fmt::Write;
 
 pub mod macros;
 
+/// Declare the macros in this crate. These macros will be available in the
+/// codegen crate for testing, as well as in `TokenStream` form in the `ctor`
+/// crate.
 #[macro_export]
 macro_rules! declare_macros {
     (
         $( $( #[doc = $doc:literal] )* macro_rules ! $name:ident $defn:tt )*
     ) => {
-        $( macro_rules! $name $defn )*
+        $( #[allow(unused, unused_macro_rules, edition_2024_expr_fragment_specifier)] macro_rules! $name $defn )*
 
         $( pub(crate) use $name; )*
 
+        /// Generate the token streams for the macros in this crate using `quote`.
         pub fn tokens() -> ::proc_macro2::TokenStream {
             quote::quote! {
                 $(
-                    #[allow(unused)] macro_rules! $name $defn
+                    #[allow(unused, unused_macro_rules, edition_2024_expr_fragment_specifier)] macro_rules! $name $defn
                     pub(crate) use $name;
                 )*
             }
@@ -80,7 +85,8 @@ fn dump_tokens(
     name: &str,
     tokens: ::proc_macro2::TokenStream,
 ) -> Result<(), std::fmt::Error> {
-    writeln!(w, "pub fn {name}() -> TokenStream {{")?;
+    writeln!(w, "/// Generated macro token stream.")?;
+    writeln!(w, "pub(crate) fn {name}() -> TokenStream {{")?;
     dump_tokens_recursive("  ", w, tokens).unwrap();
     writeln!(w, "}}")?;
     writeln!(w)?;
@@ -112,6 +118,14 @@ macros::ctor_parse!(
     #[macro_path=macros]
     #[allow(deprecated)]
     fn foo_missing_unsafe() {}
+);
+
+macros::ctor_parse!(
+    #[ctor]
+    #[feature(__warn_on_missing_unsafe)]
+    #[macro_path=macros]
+    #[allow(deprecated)]
+    unsafe fn foo_with_unsafe() {}
 );
 
 macros::ctor_parse!(
@@ -168,9 +182,9 @@ mod module {
         #[macro_path=macros]
         pub(crate) static STATIC_CTOR: HashMap<u32, &'static str> = {
             let mut m = HashMap::new();
-            m.insert(0, "foo");
-            m.insert(1, "bar");
-            m.insert(2, "baz");
+            _ = m.insert(0, "foo");
+            _ = m.insert(1, "bar");
+            _ = m.insert(2, "baz");
             m
         };
     );

--- a/ctor/src/example.rs
+++ b/ctor/src/example.rs
@@ -19,21 +19,25 @@ static STATIC_CTOR: HashMap<u32, &'static str> = {
 };
 
 #[ctor]
+#[allow(unsafe_code)]
 unsafe fn ctor() {
     libc_eprintln!("ctor");
 }
 
 #[ctor]
+#[allow(unsafe_code)]
 unsafe fn ctor_unsafe() {
     libc_eprintln!("ctor_unsafe");
 }
 
 #[dtor]
+#[allow(unsafe_code)]
 unsafe fn dtor() {
     libc_eprintln!("dtor");
 }
 
 #[dtor]
+#[allow(unsafe_code)]
 unsafe fn dtor_unsafe() {
     libc_eprintln!("dtor_unsafe");
 }

--- a/ctor/src/example.rs
+++ b/ctor/src/example.rs
@@ -1,6 +1,7 @@
+//! This example demonstrates the various types of ctor/dtor in an executable
+//! context.
+
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
-extern crate ctor;
-extern crate libc_print;
 
 use ctor::*;
 use libc_print::*;
@@ -10,15 +11,15 @@ use std::collections::HashMap;
 /// This is an immutable static, evaluated at init time
 static STATIC_CTOR: HashMap<u32, &'static str> = {
     let mut m = HashMap::new();
-    m.insert(0, "foo");
-    m.insert(1, "bar");
-    m.insert(2, "baz");
+    _ = m.insert(0, "foo");
+    _ = m.insert(1, "bar");
+    _ = m.insert(2, "baz");
     libc_eprintln!("STATIC_CTOR");
     m
 };
 
 #[ctor]
-fn ctor() {
+unsafe fn ctor() {
     libc_eprintln!("ctor");
 }
 
@@ -28,7 +29,7 @@ unsafe fn ctor_unsafe() {
 }
 
 #[dtor]
-fn dtor() {
+unsafe fn dtor() {
     libc_eprintln!("dtor");
 }
 
@@ -42,12 +43,13 @@ mod module {
     use libc_print::*;
 
     #[ctor]
-    pub static STATIC_CTOR: u8 = {
+    pub(crate) static STATIC_CTOR: u8 = {
         libc_eprintln!("module::STATIC_CTOR");
         42
     };
 }
 
+/// Executable main which demonstrates the various types of ctor/dtor.
 pub fn main() {
     libc_eprintln!("main!");
     libc_eprintln!("STATIC_CTOR = {:?}", *STATIC_CTOR);

--- a/ctor/src/gen.rs
+++ b/ctor/src/gen.rs
@@ -8,7 +8,8 @@ use std::iter::FromIterator;
 
 fn c() -> Span { Span::call_site() }
 
-pub fn ctor() -> TokenStream {
+/// Generated macro token stream.
+pub(crate) fn ctor() -> TokenStream {
   TokenStream::from_iter([
     T::Punct(Punct::new('#', Alone)),
     T::Group(Group::new(Bracket, 
@@ -17,6 +18,10 @@ pub fn ctor() -> TokenStream {
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
             T::Ident(Ident::new("unused", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unused_macro_rules", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("edition_2024_expr_fragment_specifier", c())),
           ])
         )),
       ])
@@ -161,7 +166,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -367,7 +372,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -561,7 +566,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -754,7 +759,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -947,7 +952,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -1154,7 +1159,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -1360,7 +1365,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -1554,7 +1559,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -1747,7 +1752,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(',', Alone)),
                       ])
                     )),
-                    T::Punct(Punct::new('*', Alone)),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
                 T::Punct(Punct::new(',', Alone)),
@@ -1837,6 +1842,10 @@ pub fn ctor() -> TokenStream {
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
             T::Ident(Ident::new("unused", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unused_macro_rules", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("edition_2024_expr_fragment_specifier", c())),
           ])
         )),
       ])
@@ -2478,6 +2487,140 @@ pub fn ctor() -> TokenStream {
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
             T::Ident(Ident::new("unused", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unused_macro_rules", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("edition_2024_expr_fragment_specifier", c())),
+          ])
+        )),
+      ])
+    )),
+    T::Ident(Ident::new("macro_rules", c())),
+    T::Punct(Punct::new('!', Alone)),
+    T::Ident(Ident::new("if_unsafe", c())),
+    T::Group(Group::new(Brace, 
+      TokenStream::from_iter([
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new(',', Alone)),
+            T::Group(Group::new(Brace, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("if_unsafe", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("tt", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+              ])
+            )),
+            T::Punct(Punct::new(',', Alone)),
+            T::Group(Group::new(Brace, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("if_safe", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("tt", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+              ])
+            )),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("if_safe", c())),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("unsafe", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Group(Group::new(Brace, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("if_unsafe", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("tt", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+              ])
+            )),
+            T::Punct(Punct::new(',', Alone)),
+            T::Group(Group::new(Brace, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("if_safe", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("tt", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+              ])
+            )),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("if_unsafe", c())),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+      ])
+    )),
+    T::Ident(Ident::new("pub", c())),
+    T::Group(Group::new(Parenthesis, 
+      TokenStream::from_iter([
+        T::Ident(Ident::new("crate", c())),
+      ])
+    )),
+    T::Ident(Ident::new("use", c())),
+    T::Ident(Ident::new("if_unsafe", c())),
+    T::Punct(Punct::new(';', Alone)),
+    T::Punct(Punct::new('#', Alone)),
+    T::Group(Group::new(Bracket, 
+      TokenStream::from_iter([
+        T::Ident(Ident::new("allow", c())),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("unused", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unused_macro_rules", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("edition_2024_expr_fragment_specifier", c())),
           ])
         )),
       ])
@@ -2583,407 +2726,103 @@ pub fn ctor() -> TokenStream {
         T::Punct(Punct::new('>', Alone)),
         T::Group(Group::new(Brace, 
           TokenStream::from_iter([
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("cfg", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("target_family", c())),
-                    T::Punct(Punct::new('=', Alone)),
-                    T::Literal(Literal::string("wasm")),
-                  ])
-                )),
-              ])
-            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
-                T::Punct(Punct::new('#', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+              ])
+            )),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Punct(Punct::new('+', Alone)),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("ctor_entry", c())),
+            T::Punct(Punct::new('!', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("meta", c())),
+                T::Punct(Punct::new('=', Alone)),
                 T::Group(Group::new(Bracket, 
                   TokenStream::from_iter([
                     T::Punct(Punct::new('$', Alone)),
-                    T::Ident(Ident::new("fnmeta", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('*', Alone)),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("allow", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("unused", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Punct(Punct::new(':', Joint)),
-                T::Punct(Punct::new(':', Alone)),
-                T::Ident(Ident::new("wasm_bindgen", c())),
-                T::Punct(Punct::new(':', Joint)),
-                T::Punct(Punct::new(':', Alone)),
-                T::Ident(Ident::new("prelude", c())),
-                T::Punct(Punct::new(':', Joint)),
-                T::Punct(Punct::new(':', Alone)),
-                T::Ident(Ident::new("wasm_bindgen", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("start", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('$', Alone)),
-            T::Group(Group::new(Parenthesis, 
-              TokenStream::from_iter([
-                T::Punct(Punct::new('$', Alone)),
-                T::Ident(Ident::new("vis", c())),
-              ])
-            )),
-            T::Punct(Punct::new('*', Alone)),
-            T::Ident(Ident::new("fn", c())),
-            T::Punct(Punct::new('$', Alone)),
-            T::Ident(Ident::new("ident", c())),
-            T::Group(Group::new(Parenthesis, 
-              TokenStream::new()
-            )),
-            T::Group(Group::new(Brace, 
-              TokenStream::from_iter([
-                T::Punct(Punct::new('$', Alone)),
-                T::Ident(Ident::new("block", c())),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("cfg", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("not", c())),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
-                        T::Ident(Ident::new("target_family", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Literal(Literal::string("wasm")),
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("meta", c())),
+                        T::Punct(Punct::new(',', Alone)),
+                      ])
+                    )),
+                    T::Punct(Punct::new('?', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("macro_path", c())),
+                  ])
+                )),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Punct(Punct::new('+', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("imeta", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('#', Alone)),
+                    T::Group(Group::new(Bracket, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("fnmeta", c())),
                       ])
                     )),
                   ])
                 )),
-              ])
-            )),
-            T::Punct(Punct::new('$', Alone)),
-            T::Group(Group::new(Parenthesis, 
-              TokenStream::from_iter([
-                T::Punct(Punct::new('#', Alone)),
+                T::Punct(Punct::new('*', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("vis", c())),
+                T::Punct(Punct::new('=', Alone)),
                 T::Group(Group::new(Bracket, 
                   TokenStream::from_iter([
                     T::Punct(Punct::new('$', Alone)),
-                    T::Ident(Ident::new("fnmeta", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("vis", c())),
+                      ])
+                    )),
+                    T::Punct(Punct::new('*', Alone)),
                   ])
                 )),
-              ])
-            )),
-            T::Punct(Punct::new('*', Alone)),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("allow", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("unused", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("allow", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("unsafe_code", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('$', Alone)),
-            T::Group(Group::new(Parenthesis, 
-              TokenStream::from_iter([
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("item", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Ident(Ident::new("fn", c())),
                 T::Punct(Punct::new('$', Alone)),
-                T::Ident(Ident::new("vis", c())),
-              ])
-            )),
-            T::Punct(Punct::new('*', Alone)),
-            T::Ident(Ident::new("fn", c())),
-            T::Punct(Punct::new('$', Alone)),
-            T::Ident(Ident::new("ident", c())),
-            T::Group(Group::new(Parenthesis, 
-              TokenStream::new()
-            )),
-            T::Group(Group::new(Brace, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("mod", c())),
-                T::Ident(Ident::new("__ctor_internal", c())),
-                T::Group(Group::new(Brace, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("super", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('$', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("macro_path", c())),
-                      ])
-                    )),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('+', Alone)),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("if_has_feature", c())),
-                    T::Punct(Punct::new('!', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("macro_path", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("macro_path", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('+', Alone)),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Ident(Ident::new("__warn_on_missing_unsafe", c())),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("features", c())),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("deprecated", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("ctor deprecation note:\n\n \
-                        Use of #[ctor] without `unsafe fn` is deprecated. As code execution before main\n\
-                        is unsupported by most Rust runtime functions, these functions must be marked\n\
-                        `unsafe`.")),
-                              ])
-                            )),
-                            T::Ident(Ident::new("const", c())),
-                            T::Ident(Ident::new("fn", c())),
-                            T::Ident(Ident::new("ctor_without_unsafe_is_deprecated", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Group(Group::new(Brace, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("allow", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("unused", c())),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Ident(Ident::new("static", c())),
-                            T::Ident(Ident::new("UNSAFE_WARNING", c())),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('=', Alone)),
-                            T::Ident(Ident::new("ctor_without_unsafe_is_deprecated", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new(';', Alone)),
-                          ])
-                        )),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::new()
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new(';', Alone)),
-                    T::Ident(Ident::new("super", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('$', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("macro_path", c())),
-                      ])
-                    )),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('+', Alone)),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("ctor_link_section", c())),
-                    T::Punct(Punct::new('!', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("macro_path", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("macro_path", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('+', Alone)),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Ident(Ident::new("features", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("features", c())),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Punct(Punct::new('#', Alone)),
-                        T::Group(Group::new(Bracket, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("allow", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("non_upper_case_globals", c())),
-                                T::Punct(Punct::new(',', Alone)),
-                                T::Ident(Ident::new("non_snake_case", c())),
-                              ])
-                            )),
-                          ])
-                        )),
-                        T::Punct(Punct::new('#', Alone)),
-                        T::Group(Group::new(Bracket, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("doc", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("hidden", c())),
-                              ])
-                            )),
-                          ])
-                        )),
-                        T::Ident(Ident::new("static", c())),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("ident", c())),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Ident(Ident::new("unsafe", c())),
-                        T::Ident(Ident::new("extern", c())),
-                        T::Literal(Literal::string("C")),
-                        T::Ident(Ident::new("fn", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                        T::Punct(Punct::new('-', Joint)),
-                        T::Punct(Punct::new('>', Alone)),
-                        T::Ident(Ident::new("usize", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("allow", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("non_snake_case", c())),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("cfg_attr", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("any", c())),
-                                    T::Group(Group::new(Parenthesis, 
-                                      TokenStream::from_iter([
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("linux")),
-                                        T::Punct(Punct::new(',', Alone)),
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("android")),
-                                      ])
-                                    )),
-                                    T::Punct(Punct::new(',', Alone)),
-                                    T::Ident(Ident::new("link_section", c())),
-                                    T::Punct(Punct::new('=', Alone)),
-                                    T::Literal(Literal::string(".text.startup")),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Ident(Ident::new("unsafe", c())),
-                            T::Ident(Ident::new("extern", c())),
-                            T::Literal(Literal::string("C")),
-                            T::Ident(Ident::new("fn", c())),
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("ident", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('-', Joint)),
-                            T::Punct(Punct::new('>', Alone)),
-                            T::Ident(Ident::new("usize", c())),
-                            T::Group(Group::new(Brace, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("super", c())),
-                                T::Punct(Punct::new(':', Joint)),
-                                T::Punct(Punct::new(':', Alone)),
-                                T::Punct(Punct::new('$', Alone)),
-                                T::Ident(Ident::new("ident", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::new()
-                                )),
-                                T::Punct(Punct::new(';', Alone)),
-                                T::Literal(Literal::usize_unsuffixed(0)),
-                              ])
-                            )),
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("ident", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(';', Alone)),
-                      ])
-                    )),
-                    T::Punct(Punct::new(';', Alone)),
-                  ])
+                T::Ident(Ident::new("ident", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::new()
                 )),
                 T::Punct(Punct::new('$', Alone)),
                 T::Ident(Ident::new("block", c())),
               ])
             )),
+            T::Punct(Punct::new(';', Alone)),
           ])
         )),
         T::Punct(Punct::new(';', Alone)),
@@ -3084,6 +2923,216 @@ pub fn ctor() -> TokenStream {
         T::Punct(Punct::new('>', Alone)),
         T::Group(Group::new(Brace, 
           TokenStream::from_iter([
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+              ])
+            )),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Punct(Punct::new('+', Alone)),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("ctor_entry", c())),
+            T::Punct(Punct::new('!', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("meta", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("meta", c())),
+                        T::Punct(Punct::new(',', Alone)),
+                      ])
+                    )),
+                    T::Punct(Punct::new('?', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("macro_path", c())),
+                  ])
+                )),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Punct(Punct::new('+', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("imeta", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('#', Alone)),
+                    T::Group(Group::new(Bracket, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("fnmeta", c())),
+                      ])
+                    )),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("vis", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("vis", c())),
+                      ])
+                    )),
+                    T::Punct(Punct::new('*', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("item", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Ident(Ident::new("fn", c())),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("ident", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::new()
+                )),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("block", c())),
+              ])
+            )),
+            T::Punct(Punct::new(';', Alone)),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("meta", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("meta", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('?', Alone)),
+              ])
+            )),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("macro_path", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("ident", c())),
+              ])
+            )),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Punct(Punct::new('+', Alone)),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("features", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("features", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("tt", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("imeta", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("fnmeta", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("meta", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("vis", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("vis", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("tt", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+              ])
+            )),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unsafe", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("ident", c())),
+              ])
+            )),
+            T::Punct(Punct::new('?', Alone)),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Ident(Ident::new("fn", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::new()
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("block", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("block", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
             T::Punct(Punct::new('#', Alone)),
             T::Group(Group::new(Bracket, 
               TokenStream::from_iter([
@@ -3148,7 +3197,6 @@ pub fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new('*', Alone)),
-            T::Ident(Ident::new("unsafe", c())),
             T::Ident(Ident::new("fn", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("ident", c())),
@@ -3222,7 +3270,6 @@ pub fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new('*', Alone)),
-            T::Ident(Ident::new("unsafe", c())),
             T::Ident(Ident::new("fn", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("ident", c())),
@@ -3242,10 +3289,154 @@ pub fn ctor() -> TokenStream {
                     )),
                   ])
                 )),
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("allow", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("unsafe_code", c())),
+                      ])
+                    )),
+                  ])
+                )),
                 T::Ident(Ident::new("mod", c())),
                 T::Ident(Ident::new("__ctor_internal", c())),
                 T::Group(Group::new(Brace, 
                   TokenStream::from_iter([
+                    T::Ident(Ident::new("super", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("macro_path", c())),
+                      ])
+                    )),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('+', Alone)),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("if_unsafe", c())),
+                    T::Punct(Punct::new('!', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Group(Group::new(Parenthesis, 
+                          TokenStream::from_iter([
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Ident(Ident::new("unsafe", c())),
+                          ])
+                        )),
+                        T::Punct(Punct::new('?', Alone)),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Group(Group::new(Brace, 
+                          TokenStream::new()
+                        )),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Group(Group::new(Brace, 
+                          TokenStream::from_iter([
+                            T::Ident(Ident::new("super", c())),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::from_iter([
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("macro_path", c())),
+                              ])
+                            )),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('+', Alone)),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Ident(Ident::new("if_has_feature", c())),
+                            T::Punct(Punct::new('!', Alone)),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("macro_path", c())),
+                                T::Punct(Punct::new('=', Alone)),
+                                T::Ident(Ident::new("super", c())),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::from_iter([
+                                    T::Punct(Punct::new('$', Alone)),
+                                    T::Ident(Ident::new("macro_path", c())),
+                                  ])
+                                )),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('+', Alone)),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("__warn_on_missing_unsafe", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("features", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Group(Group::new(Brace, 
+                                  TokenStream::from_iter([
+                                    T::Punct(Punct::new('#', Alone)),
+                                    T::Group(Group::new(Bracket, 
+                                      TokenStream::from_iter([
+                                        T::Ident(Ident::new("deprecated", c())),
+                                        T::Punct(Punct::new('=', Alone)),
+                                        T::Literal(Literal::string("ctor deprecation note:\n\n \
+                            Use of #[ctor] without `unsafe fn` is deprecated. As code execution before main\n\
+                            is unsupported by most Rust runtime functions, these functions must be marked\n\
+                            `unsafe`.")),
+                                      ])
+                                    )),
+                                    T::Ident(Ident::new("const", c())),
+                                    T::Ident(Ident::new("fn", c())),
+                                    T::Ident(Ident::new("ctor_without_unsafe_is_deprecated", c())),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Group(Group::new(Brace, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Punct(Punct::new('#', Alone)),
+                                    T::Group(Group::new(Bracket, 
+                                      TokenStream::from_iter([
+                                        T::Ident(Ident::new("allow", c())),
+                                        T::Group(Group::new(Parenthesis, 
+                                          TokenStream::from_iter([
+                                            T::Ident(Ident::new("unused", c())),
+                                          ])
+                                        )),
+                                      ])
+                                    )),
+                                    T::Ident(Ident::new("static", c())),
+                                    T::Ident(Ident::new("UNSAFE_WARNING", c())),
+                                    T::Punct(Punct::new(':', Alone)),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Punct(Punct::new('=', Alone)),
+                                    T::Ident(Ident::new("ctor_without_unsafe_is_deprecated", c())),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Punct(Punct::new(';', Alone)),
+                                  ])
+                                )),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Group(Group::new(Brace, 
+                                  TokenStream::new()
+                                )),
+                              ])
+                            )),
+                            T::Punct(Punct::new(';', Alone)),
+                          ])
+                        )),
+                      ])
+                    )),
+                    T::Punct(Punct::new(';', Alone)),
                     T::Ident(Ident::new("super", c())),
                     T::Punct(Punct::new(':', Joint)),
                     T::Punct(Punct::new(':', Alone)),
@@ -3688,6 +3879,17 @@ pub fn ctor() -> TokenStream {
             T::Punct(Punct::new('>', Alone)),
             T::Group(Group::new(Brace, 
               TokenStream::from_iter([
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("allow", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("dead_code", c())),
+                      ])
+                    )),
+                  ])
+                )),
                 T::Ident(Ident::new("fn", c())),
                 T::Ident(Ident::new("init_once", c())),
                 T::Group(Group::new(Parenthesis, 
@@ -3761,19 +3963,6 @@ pub fn ctor() -> TokenStream {
             T::Punct(Punct::new('#', Alone)),
             T::Group(Group::new(Bracket, 
               TokenStream::from_iter([
-                T::Ident(Ident::new("cfg", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("target_family", c())),
-                    T::Punct(Punct::new('=', Alone)),
-                    T::Literal(Literal::string("wasm")),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
                 T::Ident(Ident::new("doc", c())),
                 T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
@@ -3814,198 +4003,12 @@ pub fn ctor() -> TokenStream {
                 T::Punct(Punct::new('#', Alone)),
                 T::Group(Group::new(Bracket, 
                   TokenStream::from_iter([
-                    T::Ident(Ident::new("derive", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("Default", c())),
-                      ])
-                    )),
-                  ])
-                )),
-                T::Punct(Punct::new('#', Alone)),
-                T::Group(Group::new(Bracket, 
-                  TokenStream::from_iter([
                     T::Ident(Ident::new("allow", c())),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
                         T::Ident(Ident::new("non_camel_case_types", c())),
-                      ])
-                    )),
-                  ])
-                )),
-                T::Ident(Ident::new("pub", c())),
-                T::Ident(Ident::new("struct", c())),
-                T::Ident(Ident::new("Static", c())),
-                T::Punct(Punct::new('<', Alone)),
-                T::Ident(Ident::new("T", c())),
-                T::Punct(Punct::new('>', Alone)),
-                T::Group(Group::new(Brace, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("pub", c())),
-                    T::Ident(Ident::new("_storage", c())),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("std", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("cell", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("UnsafeCell", c())),
-                    T::Punct(Punct::new('<', Alone)),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("std", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("option", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("Option", c())),
-                    T::Punct(Punct::new('<', Alone)),
-                    T::Ident(Ident::new("T", c())),
-                    T::Punct(Punct::new('>', Joint)),
-                    T::Punct(Punct::new('>', Alone)),
-                  ])
-                )),
-                T::Ident(Ident::new("unsafe", c())),
-                T::Ident(Ident::new("impl", c())),
-                T::Punct(Punct::new('<', Alone)),
-                T::Ident(Ident::new("T", c())),
-                T::Punct(Punct::new('>', Alone)),
-                T::Ident(Ident::new("std", c())),
-                T::Punct(Punct::new(':', Joint)),
-                T::Punct(Punct::new(':', Alone)),
-                T::Ident(Ident::new("marker", c())),
-                T::Punct(Punct::new(':', Joint)),
-                T::Punct(Punct::new(':', Alone)),
-                T::Ident(Ident::new("Sync", c())),
-                T::Ident(Ident::new("for", c())),
-                T::Ident(Ident::new("Static", c())),
-                T::Punct(Punct::new('<', Alone)),
-                T::Ident(Ident::new("T", c())),
-                T::Punct(Punct::new('>', Alone)),
-                T::Group(Group::new(Brace, 
-                  TokenStream::new()
-                )),
-                T::Punct(Punct::new('#', Alone)),
-                T::Group(Group::new(Bracket, 
-                  TokenStream::from_iter([
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("wasm_bindgen", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("prelude", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("wasm_bindgen", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("start", c())),
-                      ])
-                    )),
-                  ])
-                )),
-                T::Ident(Ident::new("fn", c())),
-                T::Ident(Ident::new("init", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::new()
-                )),
-                T::Group(Group::new(Brace, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("super", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('$', Alone)),
-                    T::Ident(Ident::new("ident", c())),
-                    T::Punct(Punct::new('.', Alone)),
-                    T::Ident(Ident::new("init_once", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::new()
-                    )),
-                    T::Punct(Punct::new(';', Alone)),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("cfg", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("not", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("target_family", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Literal(Literal::string("wasm")),
-                      ])
-                    )),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("doc", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("hidden", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("allow", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("non_upper_case_globals", c())),
-                    T::Punct(Punct::new(',', Alone)),
-                    T::Ident(Ident::new("non_snake_case", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("allow", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("unsafe_code", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Ident(Ident::new("mod", c())),
-            T::Punct(Punct::new('$', Alone)),
-            T::Ident(Ident::new("ident", c())),
-            T::Group(Group::new(Brace, 
-              TokenStream::from_iter([
-                T::Punct(Punct::new('#', Alone)),
-                T::Group(Group::new(Bracket, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("derive", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("Default", c())),
-                      ])
-                    )),
-                  ])
-                )),
-                T::Punct(Punct::new('#', Alone)),
-                T::Group(Group::new(Bracket, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("allow", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("non_camel_case_types", c())),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("unreachable_pub", c())),
                       ])
                     )),
                   ])
@@ -4076,6 +4079,76 @@ pub fn ctor() -> TokenStream {
                 T::Punct(Punct::new('>', Alone)),
                 T::Group(Group::new(Brace, 
                   TokenStream::new()
+                )),
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("cfg", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_family", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("wasm")),
+                      ])
+                    )),
+                  ])
+                )),
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("wasm_bindgen", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("prelude", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("wasm_bindgen", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("start", c())),
+                      ])
+                    )),
+                  ])
+                )),
+                T::Ident(Ident::new("fn", c())),
+                T::Ident(Ident::new("init", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::new()
+                )),
+                T::Group(Group::new(Brace, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("super", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("ident", c())),
+                    T::Punct(Punct::new('.', Alone)),
+                    T::Ident(Ident::new("init_once", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::new()
+                    )),
+                    T::Punct(Punct::new(';', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("cfg", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("not", c())),
+                        T::Group(Group::new(Parenthesis, 
+                          TokenStream::from_iter([
+                            T::Ident(Ident::new("target_family", c())),
+                            T::Punct(Punct::new('=', Alone)),
+                            T::Literal(Literal::string("wasm")),
+                          ])
+                        )),
+                      ])
+                    )),
+                  ])
                 )),
                 T::Ident(Ident::new("super", c())),
                 T::Punct(Punct::new(':', Joint)),
@@ -4254,6 +4327,10 @@ pub fn ctor() -> TokenStream {
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
             T::Ident(Ident::new("unused", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unused_macro_rules", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("edition_2024_expr_fragment_specifier", c())),
           ])
         )),
       ])
@@ -4362,603 +4439,100 @@ pub fn ctor() -> TokenStream {
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
-                T::Punct(Punct::new('#', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+              ])
+            )),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Punct(Punct::new('+', Alone)),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("dtor_entry", c())),
+            T::Punct(Punct::new('!', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("meta", c())),
+                T::Punct(Punct::new('=', Alone)),
                 T::Group(Group::new(Bracket, 
                   TokenStream::from_iter([
                     T::Punct(Punct::new('$', Alone)),
-                    T::Ident(Ident::new("fnmeta", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("meta", c())),
+                        T::Punct(Punct::new(',', Alone)),
+                      ])
+                    )),
+                    T::Punct(Punct::new('?', Alone)),
                   ])
                 )),
-              ])
-            )),
-            T::Punct(Punct::new('*', Alone)),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("allow", c())),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
                 T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
-                    T::Ident(Ident::new("unsafe_code", c())),
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("macro_path", c())),
                   ])
                 )),
-              ])
-            )),
-            T::Punct(Punct::new('$', Alone)),
-            T::Group(Group::new(Parenthesis, 
-              TokenStream::from_iter([
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Punct(Punct::new('+', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new('=', Alone)),
                 T::Punct(Punct::new('$', Alone)),
-                T::Ident(Ident::new("vis", c())),
-              ])
-            )),
-            T::Punct(Punct::new('*', Alone)),
-            T::Ident(Ident::new("fn", c())),
-            T::Punct(Punct::new('$', Alone)),
-            T::Ident(Ident::new("ident", c())),
-            T::Group(Group::new(Parenthesis, 
-              TokenStream::new()
-            )),
-            T::Group(Group::new(Brace, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("mod", c())),
-                T::Ident(Ident::new("__dtor_internal", c())),
-                T::Group(Group::new(Brace, 
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("imeta", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
-                    T::Ident(Ident::new("super", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('$', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("macro_path", c())),
-                      ])
-                    )),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('+', Alone)),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("if_has_feature", c())),
-                    T::Punct(Punct::new('!', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("macro_path", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("macro_path", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('+', Alone)),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Ident(Ident::new("__warn_on_missing_unsafe", c())),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("features", c())),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("deprecated", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("dtor deprecation note:\n\n \
-                        Use of #[dtor] without `unsafe fn` is deprecated. As code execution after main\n\
-                        is unsupported by most Rust runtime functions, these functions must be marked\n\
-                        `unsafe`.")),
-                              ])
-                            )),
-                            T::Ident(Ident::new("const", c())),
-                            T::Ident(Ident::new("fn", c())),
-                            T::Ident(Ident::new("dtor_without_unsafe_is_deprecated", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Group(Group::new(Brace, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("allow", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("unused", c())),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Ident(Ident::new("static", c())),
-                            T::Ident(Ident::new("UNSAFE_WARNING", c())),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('=', Alone)),
-                            T::Ident(Ident::new("dtor_without_unsafe_is_deprecated", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new(';', Alone)),
-                          ])
-                        )),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::new()
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new(';', Alone)),
-                    T::Ident(Ident::new("super", c())),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('$', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("macro_path", c())),
-                      ])
-                    )),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Punct(Punct::new('+', Alone)),
-                    T::Punct(Punct::new(':', Joint)),
-                    T::Punct(Punct::new(':', Alone)),
-                    T::Ident(Ident::new("ctor_link_section", c())),
-                    T::Punct(Punct::new('!', Alone)),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("macro_path", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("macro_path", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('+', Alone)),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Ident(Ident::new("features", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("features", c())),
-                        T::Punct(Punct::new(',', Alone)),
-                        T::Punct(Punct::new('#', Alone)),
-                        T::Group(Group::new(Bracket, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("allow", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("non_upper_case_globals", c())),
-                                T::Punct(Punct::new(',', Alone)),
-                                T::Ident(Ident::new("non_snake_case", c())),
-                              ])
-                            )),
-                          ])
-                        )),
-                        T::Punct(Punct::new('#', Alone)),
-                        T::Group(Group::new(Bracket, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("doc", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("hidden", c())),
-                              ])
-                            )),
-                          ])
-                        )),
-                        T::Ident(Ident::new("static", c())),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("ident", c())),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Ident(Ident::new("unsafe", c())),
-                        T::Ident(Ident::new("extern", c())),
-                        T::Literal(Literal::string("C")),
-                        T::Ident(Ident::new("fn", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                        T::Punct(Punct::new('-', Joint)),
-                        T::Punct(Punct::new('>', Alone)),
-                        T::Ident(Ident::new("usize", c())),
-                        T::Punct(Punct::new('=', Alone)),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::from_iter([
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("allow", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("non_snake_case", c())),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("cfg_attr", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("any", c())),
-                                    T::Group(Group::new(Parenthesis, 
-                                      TokenStream::from_iter([
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("linux")),
-                                        T::Punct(Punct::new(',', Alone)),
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("android")),
-                                      ])
-                                    )),
-                                    T::Punct(Punct::new(',', Alone)),
-                                    T::Ident(Ident::new("link_section", c())),
-                                    T::Punct(Punct::new('=', Alone)),
-                                    T::Literal(Literal::string(".text.startup")),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Ident(Ident::new("unsafe", c())),
-                            T::Ident(Ident::new("extern", c())),
-                            T::Literal(Literal::string("C")),
-                            T::Ident(Ident::new("fn", c())),
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("ident", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('-', Joint)),
-                            T::Punct(Punct::new('>', Alone)),
-                            T::Ident(Ident::new("usize", c())),
-                            T::Group(Group::new(Brace, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("do_atexit", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("__dtor", c())),
-                                  ])
-                                )),
-                                T::Punct(Punct::new(';', Alone)),
-                                T::Literal(Literal::usize_unsuffixed(0)),
-                              ])
-                            )),
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("ident", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(';', Alone)),
-                      ])
-                    )),
-                    T::Punct(Punct::new(';', Alone)),
                     T::Punct(Punct::new('#', Alone)),
                     T::Group(Group::new(Bracket, 
                       TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("not", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("target_vendor", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("apple")),
-                              ])
-                            )),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg_attr", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("any", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("target_os", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("linux")),
-                                T::Punct(Punct::new(',', Alone)),
-                                T::Ident(Ident::new("target_os", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("android")),
-                              ])
-                            )),
-                            T::Punct(Punct::new(',', Alone)),
-                            T::Ident(Ident::new("link_section", c())),
-                            T::Punct(Punct::new('=', Alone)),
-                            T::Literal(Literal::string(".text.exit")),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Ident(Ident::new("unsafe", c())),
-                    T::Ident(Ident::new("extern", c())),
-                    T::Literal(Literal::string("C")),
-                    T::Ident(Ident::new("fn", c())),
-                    T::Ident(Ident::new("__dtor", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::new()
-                    )),
-                    T::Group(Group::new(Brace, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
                         T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("ident", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("target_vendor", c())),
-                            T::Punct(Punct::new('=', Alone)),
-                            T::Literal(Literal::string("apple")),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Ident(Ident::new("unsafe", c())),
-                    T::Ident(Ident::new("extern", c())),
-                    T::Literal(Literal::string("C")),
-                    T::Ident(Ident::new("fn", c())),
-                    T::Ident(Ident::new("__dtor", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("_", c())),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('*', Alone)),
-                        T::Ident(Ident::new("const", c())),
-                        T::Ident(Ident::new("u8", c())),
-                      ])
-                    )),
-                    T::Group(Group::new(Brace, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("ident", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("not", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("target_vendor", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("apple")),
-                              ])
-                            )),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("inline", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("always", c())),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Ident(Ident::new("pub", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("super", c())),
-                      ])
-                    )),
-                    T::Ident(Ident::new("unsafe", c())),
-                    T::Ident(Ident::new("fn", c())),
-                    T::Ident(Ident::new("do_atexit", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cb", c())),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Ident(Ident::new("unsafe", c())),
-                        T::Ident(Ident::new("extern", c())),
-                        T::Ident(Ident::new("fn", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                      ])
-                    )),
-                    T::Group(Group::new(Brace, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("extern", c())),
-                        T::Literal(Literal::string("C")),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("fn", c())),
-                            T::Ident(Ident::new("atexit", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("cb", c())),
-                                T::Punct(Punct::new(':', Alone)),
-                                T::Ident(Ident::new("unsafe", c())),
-                                T::Ident(Ident::new("extern", c())),
-                                T::Ident(Ident::new("fn", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::new()
-                                )),
-                              ])
-                            )),
-                            T::Punct(Punct::new(';', Alone)),
-                          ])
-                        )),
-                        T::Ident(Ident::new("atexit", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("cb", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(';', Alone)),
-                      ])
-                    )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("target_vendor", c())),
-                            T::Punct(Punct::new('=', Alone)),
-                            T::Literal(Literal::string("apple")),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("inline", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("always", c())),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Ident(Ident::new("pub", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("super", c())),
-                      ])
-                    )),
-                    T::Ident(Ident::new("unsafe", c())),
-                    T::Ident(Ident::new("fn", c())),
-                    T::Ident(Ident::new("do_atexit", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cb", c())),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Ident(Ident::new("unsafe", c())),
-                        T::Ident(Ident::new("extern", c())),
-                        T::Ident(Ident::new("fn", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("_", c())),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Punct(Punct::new('*', Alone)),
-                            T::Ident(Ident::new("const", c())),
-                            T::Ident(Ident::new("u8", c())),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Group(Group::new(Brace, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("extern", c())),
-                        T::Literal(Literal::string("C")),
-                        T::Group(Group::new(Brace, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("static", c())),
-                            T::Ident(Ident::new("__dso_handle", c())),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Punct(Punct::new('*', Alone)),
-                            T::Ident(Ident::new("const", c())),
-                            T::Ident(Ident::new("u8", c())),
-                            T::Punct(Punct::new(';', Alone)),
-                            T::Ident(Ident::new("fn", c())),
-                            T::Ident(Ident::new("__cxa_atexit", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("cb", c())),
-                                T::Punct(Punct::new(':', Alone)),
-                                T::Ident(Ident::new("unsafe", c())),
-                                T::Ident(Ident::new("extern", c())),
-                                T::Ident(Ident::new("fn", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("_", c())),
-                                    T::Punct(Punct::new(':', Alone)),
-                                    T::Punct(Punct::new('*', Alone)),
-                                    T::Ident(Ident::new("const", c())),
-                                    T::Ident(Ident::new("u8", c())),
-                                  ])
-                                )),
-                                T::Punct(Punct::new(',', Alone)),
-                                T::Ident(Ident::new("arg", c())),
-                                T::Punct(Punct::new(':', Alone)),
-                                T::Punct(Punct::new('*', Alone)),
-                                T::Ident(Ident::new("const", c())),
-                                T::Ident(Ident::new("u8", c())),
-                                T::Punct(Punct::new(',', Alone)),
-                                T::Ident(Ident::new("dso_handle", c())),
-                                T::Punct(Punct::new(':', Alone)),
-                                T::Punct(Punct::new('*', Alone)),
-                                T::Ident(Ident::new("const", c())),
-                                T::Ident(Ident::new("u8", c())),
-                              ])
-                            )),
-                            T::Punct(Punct::new(';', Alone)),
-                          ])
-                        )),
-                        T::Ident(Ident::new("__cxa_atexit", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("cb", c())),
-                            T::Punct(Punct::new(',', Alone)),
-                            T::Ident(Ident::new("core", c())),
-                            T::Punct(Punct::new(':', Joint)),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Ident(Ident::new("ptr", c())),
-                            T::Punct(Punct::new(':', Joint)),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Ident(Ident::new("null", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new(',', Alone)),
-                            T::Ident(Ident::new("__dso_handle", c())),
-                          ])
-                        )),
-                        T::Punct(Punct::new(';', Alone)),
+                        T::Ident(Ident::new("fnmeta", c())),
                       ])
                     )),
                   ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("vis", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("vis", c())),
+                      ])
+                    )),
+                    T::Punct(Punct::new('*', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("item", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Ident(Ident::new("fn", c())),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("ident", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::new()
                 )),
                 T::Punct(Punct::new('$', Alone)),
                 T::Ident(Ident::new("block", c())),
               ])
             )),
+            T::Punct(Punct::new(';', Alone)),
           ])
         )),
         T::Punct(Punct::new(';', Alone)),
@@ -5034,13 +4608,223 @@ pub fn ctor() -> TokenStream {
                     T::Ident(Ident::new("tt", c())),
                   ])
                 )),
-                T::Punct(Punct::new('?', Alone)),
+                T::Punct(Punct::new('*', Alone)),
               ])
             )),
             T::Punct(Punct::new(',', Alone)),
             T::Ident(Ident::new("item", c())),
             T::Punct(Punct::new('=', Alone)),
             T::Ident(Ident::new("unsafe", c())),
+            T::Ident(Ident::new("fn", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::new()
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("block", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("block", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+              ])
+            )),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Punct(Punct::new('+', Alone)),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("dtor_entry", c())),
+            T::Punct(Punct::new('!', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("meta", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("meta", c())),
+                        T::Punct(Punct::new(',', Alone)),
+                      ])
+                    )),
+                    T::Punct(Punct::new('?', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("macro_path", c())),
+                  ])
+                )),
+                T::Punct(Punct::new(':', Joint)),
+                T::Punct(Punct::new(':', Alone)),
+                T::Punct(Punct::new('+', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("features", c())),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("imeta", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('#', Alone)),
+                    T::Group(Group::new(Bracket, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("fnmeta", c())),
+                      ])
+                    )),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("vis", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("vis", c())),
+                      ])
+                    )),
+                    T::Punct(Punct::new('*', Alone)),
+                  ])
+                )),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new(',', Alone)),
+                T::Ident(Ident::new("item", c())),
+                T::Punct(Punct::new('=', Alone)),
+                T::Ident(Ident::new("fn", c())),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("ident", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::new()
+                )),
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("block", c())),
+              ])
+            )),
+            T::Punct(Punct::new(';', Alone)),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("meta", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("meta", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('?', Alone)),
+              ])
+            )),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("macro_path", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("macro_path", c())),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("ident", c())),
+              ])
+            )),
+            T::Punct(Punct::new(':', Joint)),
+            T::Punct(Punct::new(':', Alone)),
+            T::Punct(Punct::new('+', Alone)),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("features", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("features", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("tt", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("imeta", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("fnmeta", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("meta", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("vis", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Ident(Ident::new("vis", c())),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("tt", c())),
+                  ])
+                )),
+                T::Punct(Punct::new('*', Alone)),
+              ])
+            )),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unsafe", c())),
+            T::Punct(Punct::new('=', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+                T::Punct(Punct::new(':', Alone)),
+                T::Ident(Ident::new("ident", c())),
+              ])
+            )),
+            T::Punct(Punct::new('?', Alone)),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new('=', Alone)),
             T::Ident(Ident::new("fn", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("ident", c())),
@@ -5079,6 +4863,8 @@ pub fn ctor() -> TokenStream {
                 T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
                     T::Ident(Ident::new("unsafe_code", c())),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("unused", c())),
                   ])
                 )),
               ])
@@ -5091,7 +4877,6 @@ pub fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new('*', Alone)),
-            T::Ident(Ident::new("unsafe", c())),
             T::Ident(Ident::new("fn", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("ident", c())),
@@ -5104,6 +4889,139 @@ pub fn ctor() -> TokenStream {
                 T::Ident(Ident::new("__dtor_internal", c())),
                 T::Group(Group::new(Brace, 
                   TokenStream::from_iter([
+                    T::Ident(Ident::new("super", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("macro_path", c())),
+                      ])
+                    )),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('+', Alone)),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("if_unsafe", c())),
+                    T::Punct(Punct::new('!', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Group(Group::new(Parenthesis, 
+                          TokenStream::from_iter([
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Ident(Ident::new("unsafe", c())),
+                          ])
+                        )),
+                        T::Punct(Punct::new('?', Alone)),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Group(Group::new(Brace, 
+                          TokenStream::new()
+                        )),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Group(Group::new(Brace, 
+                          TokenStream::from_iter([
+                            T::Ident(Ident::new("super", c())),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::from_iter([
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("macro_path", c())),
+                              ])
+                            )),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('+', Alone)),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Ident(Ident::new("if_has_feature", c())),
+                            T::Punct(Punct::new('!', Alone)),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("macro_path", c())),
+                                T::Punct(Punct::new('=', Alone)),
+                                T::Ident(Ident::new("super", c())),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::from_iter([
+                                    T::Punct(Punct::new('$', Alone)),
+                                    T::Ident(Ident::new("macro_path", c())),
+                                  ])
+                                )),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('+', Alone)),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("__warn_on_missing_unsafe", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("features", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Group(Group::new(Brace, 
+                                  TokenStream::from_iter([
+                                    T::Punct(Punct::new('#', Alone)),
+                                    T::Group(Group::new(Bracket, 
+                                      TokenStream::from_iter([
+                                        T::Ident(Ident::new("deprecated", c())),
+                                        T::Punct(Punct::new('=', Alone)),
+                                        T::Literal(Literal::string("dtor deprecation note:\n\n \
+                            Use of #[dtor] without `unsafe fn` is deprecated. As code execution after main\n\
+                            is unsupported by most Rust runtime functions, these functions must be marked\n\
+                            `unsafe`.")),
+                                      ])
+                                    )),
+                                    T::Ident(Ident::new("const", c())),
+                                    T::Ident(Ident::new("fn", c())),
+                                    T::Ident(Ident::new("dtor_without_unsafe_is_deprecated", c())),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Group(Group::new(Brace, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Punct(Punct::new('#', Alone)),
+                                    T::Group(Group::new(Bracket, 
+                                      TokenStream::from_iter([
+                                        T::Ident(Ident::new("allow", c())),
+                                        T::Group(Group::new(Parenthesis, 
+                                          TokenStream::from_iter([
+                                            T::Ident(Ident::new("unused", c())),
+                                          ])
+                                        )),
+                                      ])
+                                    )),
+                                    T::Ident(Ident::new("static", c())),
+                                    T::Ident(Ident::new("UNSAFE_WARNING", c())),
+                                    T::Punct(Punct::new(':', Alone)),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Punct(Punct::new('=', Alone)),
+                                    T::Ident(Ident::new("dtor_without_unsafe_is_deprecated", c())),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Punct(Punct::new(';', Alone)),
+                                  ])
+                                )),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Group(Group::new(Brace, 
+                                  TokenStream::new()
+                                )),
+                              ])
+                            )),
+                            T::Punct(Punct::new(';', Alone)),
+                          ])
+                        )),
+                      ])
+                    )),
+                    T::Punct(Punct::new(';', Alone)),
                     T::Ident(Ident::new("super", c())),
                     T::Punct(Punct::new(':', Joint)),
                     T::Punct(Punct::new(':', Alone)),
@@ -5236,14 +5154,19 @@ pub fn ctor() -> TokenStream {
                             T::Ident(Ident::new("usize", c())),
                             T::Group(Group::new(Brace, 
                               TokenStream::from_iter([
-                                T::Ident(Ident::new("do_atexit", c())),
-                                T::Group(Group::new(Parenthesis, 
+                                T::Ident(Ident::new("unsafe", c())),
+                                T::Group(Group::new(Brace, 
                                   TokenStream::from_iter([
-                                    T::Ident(Ident::new("__dtor", c())),
+                                    T::Ident(Ident::new("do_atexit", c())),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::from_iter([
+                                        T::Ident(Ident::new("__dtor", c())),
+                                      ])
+                                    )),
+                                    T::Punct(Punct::new(';', Alone)),
+                                    T::Literal(Literal::usize_unsuffixed(0)),
                                   ])
                                 )),
-                                T::Punct(Punct::new(';', Alone)),
-                                T::Literal(Literal::usize_unsuffixed(0)),
                               ])
                             )),
                             T::Punct(Punct::new('$', Alone)),
@@ -5478,6 +5401,7 @@ pub fn ctor() -> TokenStream {
                         T::Punct(Punct::new(':', Alone)),
                         T::Ident(Ident::new("unsafe", c())),
                         T::Ident(Ident::new("extern", c())),
+                        T::Literal(Literal::string("C")),
                         T::Ident(Ident::new("fn", c())),
                         T::Group(Group::new(Parenthesis, 
                           TokenStream::from_iter([
@@ -5492,6 +5416,7 @@ pub fn ctor() -> TokenStream {
                     )),
                     T::Group(Group::new(Brace, 
                       TokenStream::from_iter([
+                        T::Ident(Ident::new("unsafe", c())),
                         T::Ident(Ident::new("extern", c())),
                         T::Literal(Literal::string("C")),
                         T::Group(Group::new(Brace, 
@@ -5511,6 +5436,7 @@ pub fn ctor() -> TokenStream {
                                 T::Punct(Punct::new(':', Alone)),
                                 T::Ident(Ident::new("unsafe", c())),
                                 T::Ident(Ident::new("extern", c())),
+                                T::Literal(Literal::string("C")),
                                 T::Ident(Ident::new("fn", c())),
                                 T::Group(Group::new(Parenthesis, 
                                   TokenStream::from_iter([
@@ -5538,26 +5464,31 @@ pub fn ctor() -> TokenStream {
                             T::Punct(Punct::new(';', Alone)),
                           ])
                         )),
-                        T::Ident(Ident::new("__cxa_atexit", c())),
-                        T::Group(Group::new(Parenthesis, 
+                        T::Ident(Ident::new("unsafe", c())),
+                        T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
-                            T::Ident(Ident::new("cb", c())),
-                            T::Punct(Punct::new(',', Alone)),
-                            T::Ident(Ident::new("core", c())),
-                            T::Punct(Punct::new(':', Joint)),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Ident(Ident::new("ptr", c())),
-                            T::Punct(Punct::new(':', Joint)),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Ident(Ident::new("null", c())),
+                            T::Ident(Ident::new("__cxa_atexit", c())),
                             T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("cb", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("core", c())),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Ident(Ident::new("ptr", c())),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Ident(Ident::new("null", c())),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::new()
+                                )),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("__dso_handle", c())),
+                              ])
                             )),
-                            T::Punct(Punct::new(',', Alone)),
-                            T::Ident(Ident::new("__dso_handle", c())),
+                            T::Punct(Punct::new(';', Alone)),
                           ])
                         )),
-                        T::Punct(Punct::new(';', Alone)),
                       ])
                     )),
                   ])
@@ -5587,6 +5518,10 @@ pub fn ctor() -> TokenStream {
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
             T::Ident(Ident::new("unused", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unused_macro_rules", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("edition_2024_expr_fragment_specifier", c())),
           ])
         )),
       ])
@@ -5688,6 +5623,13 @@ pub fn ctor() -> TokenStream {
                     T::Punct(Punct::new('!', Alone)),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
+                        T::Ident(Ident::new("const", c())),
+                        T::Group(Group::new(Brace, 
+                          TokenStream::from_iter([
+                            T::Literal(Literal::usize_unsuffixed(1)),
+                          ])
+                        )),
+                        T::Punct(Punct::new(',', Alone)),
                         T::Ident(Ident::new("used", c())),
                         T::Group(Group::new(Parenthesis, 
                           TokenStream::from_iter([
@@ -5727,6 +5669,13 @@ pub fn ctor() -> TokenStream {
                     T::Punct(Punct::new('!', Alone)),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
+                        T::Ident(Ident::new("const", c())),
+                        T::Group(Group::new(Brace, 
+                          TokenStream::from_iter([
+                            T::Literal(Literal::usize_unsuffixed(1)),
+                          ])
+                        )),
+                        T::Punct(Punct::new(',', Alone)),
                         T::Ident(Ident::new("used", c())),
                         T::Punct(Punct::new(',', Alone)),
                         T::Punct(Punct::new('$', Alone)),
@@ -5745,52 +5694,6 @@ pub fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new(';', Alone)),
-          ])
-        )),
-      ])
-    )),
-    T::Ident(Ident::new("pub", c())),
-    T::Group(Group::new(Parenthesis, 
-      TokenStream::from_iter([
-        T::Ident(Ident::new("crate", c())),
-      ])
-    )),
-    T::Ident(Ident::new("use", c())),
-    T::Ident(Ident::new("ctor_link_section", c())),
-    T::Punct(Punct::new(';', Alone)),
-    T::Punct(Punct::new('#', Alone)),
-    T::Group(Group::new(Bracket, 
-      TokenStream::from_iter([
-        T::Ident(Ident::new("allow", c())),
-        T::Group(Group::new(Parenthesis, 
-          TokenStream::from_iter([
-            T::Ident(Ident::new("unused", c())),
-          ])
-        )),
-      ])
-    )),
-    T::Ident(Ident::new("macro_rules", c())),
-    T::Punct(Punct::new('!', Alone)),
-    T::Ident(Ident::new("ctor_link_section_attr", c())),
-    T::Group(Group::new(Brace, 
-      TokenStream::from_iter([
-        T::Group(Group::new(Parenthesis, 
-          TokenStream::from_iter([
-            T::Punct(Punct::new('$', Alone)),
-            T::Ident(Ident::new("used", c())),
-            T::Punct(Punct::new(':', Alone)),
-            T::Ident(Ident::new("meta", c())),
-            T::Punct(Punct::new(',', Alone)),
-            T::Punct(Punct::new('$', Alone)),
-            T::Ident(Ident::new("item", c())),
-            T::Punct(Punct::new(':', Alone)),
-            T::Ident(Ident::new("item", c())),
-          ])
-        )),
-        T::Punct(Punct::new('=', Joint)),
-        T::Punct(Punct::new('>', Alone)),
-        T::Group(Group::new(Brace, 
-          TokenStream::from_iter([
             T::Punct(Punct::new('#', Alone)),
             T::Group(Group::new(Bracket, 
               TokenStream::from_iter([
@@ -5856,6 +5759,251 @@ pub fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new(';', Alone)),
+          ])
+        )),
+      ])
+    )),
+    T::Ident(Ident::new("pub", c())),
+    T::Group(Group::new(Parenthesis, 
+      TokenStream::from_iter([
+        T::Ident(Ident::new("crate", c())),
+      ])
+    )),
+    T::Ident(Ident::new("use", c())),
+    T::Ident(Ident::new("ctor_link_section", c())),
+    T::Punct(Punct::new(';', Alone)),
+    T::Punct(Punct::new('#', Alone)),
+    T::Group(Group::new(Bracket, 
+      TokenStream::from_iter([
+        T::Ident(Ident::new("allow", c())),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("unused", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("unused_macro_rules", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("edition_2024_expr_fragment_specifier", c())),
+          ])
+        )),
+      ])
+    )),
+    T::Ident(Ident::new("macro_rules", c())),
+    T::Punct(Punct::new('!', Alone)),
+    T::Ident(Ident::new("ctor_link_section_attr", c())),
+    T::Group(Group::new(Brace, 
+      TokenStream::from_iter([
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("e", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("expr", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("used", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg_attr", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("any", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("linux")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("android")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("freebsd")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("netbsd")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("openbsd")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("dragonfly")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("illumos")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("haiku")),
+                      ])
+                    )),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("unsafe", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("link_section", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string(".init_array")),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg_attr", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("target_vendor", c())),
+                    T::Punct(Punct::new('=', Alone)),
+                    T::Literal(Literal::string("apple")),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("unsafe", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("link_section", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("__DATA,__mod_init_func")),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg_attr", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("windows", c())),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("unsafe", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("link_section", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string(".CRT$XCU")),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("used", c())),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("const", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("e", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("expr", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("used", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("clippy", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("used", c())),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("not", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("clippy", c())),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("allow", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("unsafe_code", c())),
+                  ])
+                )),
+              ])
+            )),
             T::Punct(Punct::new('#', Alone)),
             T::Group(Group::new(Bracket, 
               TokenStream::from_iter([

--- a/ctor/src/gen.rs
+++ b/ctor/src/gen.rs
@@ -3456,6 +3456,8 @@ pub(crate) fn ctor() -> TokenStream {
                     T::Punct(Punct::new('!', Alone)),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
+                        T::Ident(Ident::new("array", c())),
+                        T::Punct(Punct::new(',', Alone)),
                         T::Ident(Ident::new("macro_path", c())),
                         T::Punct(Punct::new('=', Alone)),
                         T::Ident(Ident::new("super", c())),
@@ -3518,69 +3520,88 @@ pub(crate) fn ctor() -> TokenStream {
                         T::Punct(Punct::new('=', Alone)),
                         T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("allow", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("non_snake_case", c())),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("cfg_attr", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("any", c())),
-                                    T::Group(Group::new(Parenthesis, 
-                                      TokenStream::from_iter([
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("linux")),
-                                        T::Punct(Punct::new(',', Alone)),
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("android")),
-                                      ])
-                                    )),
-                                    T::Punct(Punct::new(',', Alone)),
-                                    T::Ident(Ident::new("link_section", c())),
-                                    T::Punct(Punct::new('=', Alone)),
-                                    T::Literal(Literal::string(".text.startup")),
-                                  ])
-                                )),
-                              ])
-                            )),
-                            T::Ident(Ident::new("unsafe", c())),
-                            T::Ident(Ident::new("extern", c())),
-                            T::Literal(Literal::string("C")),
-                            T::Ident(Ident::new("fn", c())),
+                            T::Ident(Ident::new("super", c())),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
                             T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("ident", c())),
                             T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('-', Joint)),
-                            T::Punct(Punct::new('>', Alone)),
-                            T::Ident(Ident::new("usize", c())),
-                            T::Group(Group::new(Brace, 
                               TokenStream::from_iter([
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("macro_path", c())),
+                              ])
+                            )),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('+', Alone)),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Ident(Ident::new("ctor_link_section", c())),
+                            T::Punct(Punct::new('!', Alone)),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("startup", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("macro_path", c())),
+                                T::Punct(Punct::new('=', Alone)),
                                 T::Ident(Ident::new("super", c())),
                                 T::Punct(Punct::new(':', Joint)),
                                 T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::from_iter([
+                                    T::Punct(Punct::new('$', Alone)),
+                                    T::Ident(Ident::new("macro_path", c())),
+                                  ])
+                                )),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('+', Alone)),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("features", c())),
+                                T::Punct(Punct::new('=', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("features", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Punct(Punct::new('#', Alone)),
+                                T::Group(Group::new(Bracket, 
+                                  TokenStream::from_iter([
+                                    T::Ident(Ident::new("allow", c())),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::from_iter([
+                                        T::Ident(Ident::new("non_snake_case", c())),
+                                      ])
+                                    )),
+                                  ])
+                                )),
+                                T::Ident(Ident::new("unsafe", c())),
+                                T::Ident(Ident::new("extern", c())),
+                                T::Literal(Literal::string("C")),
+                                T::Ident(Ident::new("fn", c())),
                                 T::Punct(Punct::new('$', Alone)),
                                 T::Ident(Ident::new("ident", c())),
                                 T::Group(Group::new(Parenthesis, 
                                   TokenStream::new()
                                 )),
-                                T::Punct(Punct::new(';', Alone)),
-                                T::Literal(Literal::usize_unsuffixed(0)),
+                                T::Punct(Punct::new('-', Joint)),
+                                T::Punct(Punct::new('>', Alone)),
+                                T::Ident(Ident::new("usize", c())),
+                                T::Group(Group::new(Brace, 
+                                  TokenStream::from_iter([
+                                    T::Ident(Ident::new("super", c())),
+                                    T::Punct(Punct::new(':', Joint)),
+                                    T::Punct(Punct::new(':', Alone)),
+                                    T::Punct(Punct::new('$', Alone)),
+                                    T::Ident(Ident::new("ident", c())),
+                                    T::Group(Group::new(Parenthesis, 
+                                      TokenStream::new()
+                                    )),
+                                    T::Punct(Punct::new(';', Alone)),
+                                    T::Literal(Literal::usize_unsuffixed(0)),
+                                  ])
+                                )),
                               ])
                             )),
+                            T::Punct(Punct::new(';', Alone)),
                             T::Punct(Punct::new('$', Alone)),
                             T::Ident(Ident::new("ident", c())),
                           ])
@@ -4169,6 +4190,8 @@ pub(crate) fn ctor() -> TokenStream {
                 T::Punct(Punct::new('!', Alone)),
                 T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
+                    T::Ident(Ident::new("array", c())),
+                    T::Punct(Punct::new(',', Alone)),
                     T::Ident(Ident::new("macro_path", c())),
                     T::Punct(Punct::new('=', Alone)),
                     T::Ident(Ident::new("super", c())),
@@ -4231,71 +4254,90 @@ pub(crate) fn ctor() -> TokenStream {
                     T::Punct(Punct::new('=', Alone)),
                     T::Group(Group::new(Brace, 
                       TokenStream::from_iter([
-                        T::Punct(Punct::new('#', Alone)),
-                        T::Group(Group::new(Bracket, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("allow", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("non_snake_case", c())),
-                              ])
-                            )),
-                          ])
-                        )),
-                        T::Punct(Punct::new('#', Alone)),
-                        T::Group(Group::new(Bracket, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("cfg_attr", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("any", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("target_os", c())),
-                                    T::Punct(Punct::new('=', Alone)),
-                                    T::Literal(Literal::string("linux")),
-                                    T::Punct(Punct::new(',', Alone)),
-                                    T::Ident(Ident::new("target_os", c())),
-                                    T::Punct(Punct::new('=', Alone)),
-                                    T::Literal(Literal::string("android")),
-                                  ])
-                                )),
-                                T::Punct(Punct::new(',', Alone)),
-                                T::Ident(Ident::new("link_section", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string(".text.startup")),
-                              ])
-                            )),
-                          ])
-                        )),
-                        T::Ident(Ident::new("unsafe", c())),
-                        T::Ident(Ident::new("extern", c())),
-                        T::Literal(Literal::string("C")),
-                        T::Ident(Ident::new("fn", c())),
+                        T::Ident(Ident::new("super", c())),
+                        T::Punct(Punct::new(':', Joint)),
+                        T::Punct(Punct::new(':', Alone)),
                         T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("ident", c())),
                         T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                        T::Punct(Punct::new('-', Joint)),
-                        T::Punct(Punct::new('>', Alone)),
-                        T::Ident(Ident::new("usize", c())),
-                        T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Ident(Ident::new("macro_path", c())),
+                          ])
+                        )),
+                        T::Punct(Punct::new(':', Joint)),
+                        T::Punct(Punct::new(':', Alone)),
+                        T::Punct(Punct::new('+', Alone)),
+                        T::Punct(Punct::new(':', Joint)),
+                        T::Punct(Punct::new(':', Alone)),
+                        T::Ident(Ident::new("ctor_link_section", c())),
+                        T::Punct(Punct::new('!', Alone)),
+                        T::Group(Group::new(Parenthesis, 
+                          TokenStream::from_iter([
+                            T::Ident(Ident::new("startup", c())),
+                            T::Punct(Punct::new(',', Alone)),
+                            T::Ident(Ident::new("macro_path", c())),
+                            T::Punct(Punct::new('=', Alone)),
                             T::Ident(Ident::new("super", c())),
                             T::Punct(Punct::new(':', Joint)),
                             T::Punct(Punct::new(':', Alone)),
                             T::Punct(Punct::new('$', Alone)),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::from_iter([
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("macro_path", c())),
+                              ])
+                            )),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('+', Alone)),
+                            T::Punct(Punct::new(',', Alone)),
+                            T::Ident(Ident::new("features", c())),
+                            T::Punct(Punct::new('=', Alone)),
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Ident(Ident::new("features", c())),
+                            T::Punct(Punct::new(',', Alone)),
+                            T::Punct(Punct::new('#', Alone)),
+                            T::Group(Group::new(Bracket, 
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("allow", c())),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::from_iter([
+                                    T::Ident(Ident::new("non_snake_case", c())),
+                                  ])
+                                )),
+                              ])
+                            )),
+                            T::Ident(Ident::new("unsafe", c())),
+                            T::Ident(Ident::new("extern", c())),
+                            T::Literal(Literal::string("C")),
+                            T::Ident(Ident::new("fn", c())),
+                            T::Punct(Punct::new('$', Alone)),
                             T::Ident(Ident::new("ident", c())),
-                            T::Punct(Punct::new('.', Alone)),
-                            T::Ident(Ident::new("init_once", c())),
                             T::Group(Group::new(Parenthesis, 
                               TokenStream::new()
                             )),
-                            T::Punct(Punct::new(';', Alone)),
-                            T::Literal(Literal::usize_unsuffixed(0)),
+                            T::Punct(Punct::new('-', Joint)),
+                            T::Punct(Punct::new('>', Alone)),
+                            T::Ident(Ident::new("usize", c())),
+                            T::Group(Group::new(Brace, 
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("super", c())),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("ident", c())),
+                                T::Punct(Punct::new('.', Alone)),
+                                T::Ident(Ident::new("init_once", c())),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::new()
+                                )),
+                                T::Punct(Punct::new(';', Alone)),
+                                T::Literal(Literal::usize_unsuffixed(0)),
+                              ])
+                            )),
                           ])
                         )),
+                        T::Punct(Punct::new(';', Alone)),
                         T::Punct(Punct::new('$', Alone)),
                         T::Ident(Ident::new("ident", c())),
                       ])
@@ -5041,6 +5083,8 @@ pub(crate) fn ctor() -> TokenStream {
                     T::Punct(Punct::new('!', Alone)),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
+                        T::Ident(Ident::new("array", c())),
+                        T::Punct(Punct::new(',', Alone)),
                         T::Ident(Ident::new("macro_path", c())),
                         T::Punct(Punct::new('=', Alone)),
                         T::Ident(Ident::new("super", c())),
@@ -5103,72 +5147,91 @@ pub(crate) fn ctor() -> TokenStream {
                         T::Punct(Punct::new('=', Alone)),
                         T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
+                            T::Ident(Ident::new("super", c())),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Group(Group::new(Parenthesis, 
                               TokenStream::from_iter([
-                                T::Ident(Ident::new("allow", c())),
-                                T::Group(Group::new(Parenthesis, 
-                                  TokenStream::from_iter([
-                                    T::Ident(Ident::new("non_snake_case", c())),
-                                  ])
-                                )),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("macro_path", c())),
                               ])
                             )),
-                            T::Punct(Punct::new('#', Alone)),
-                            T::Group(Group::new(Bracket, 
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('+', Alone)),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Ident(Ident::new("ctor_link_section", c())),
+                            T::Punct(Punct::new('!', Alone)),
+                            T::Group(Group::new(Parenthesis, 
                               TokenStream::from_iter([
-                                T::Ident(Ident::new("cfg_attr", c())),
+                                T::Ident(Ident::new("startup", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("macro_path", c())),
+                                T::Punct(Punct::new('=', Alone)),
+                                T::Ident(Ident::new("super", c())),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
                                 T::Group(Group::new(Parenthesis, 
                                   TokenStream::from_iter([
-                                    T::Ident(Ident::new("any", c())),
+                                    T::Punct(Punct::new('$', Alone)),
+                                    T::Ident(Ident::new("macro_path", c())),
+                                  ])
+                                )),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('+', Alone)),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Ident(Ident::new("features", c())),
+                                T::Punct(Punct::new('=', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("features", c())),
+                                T::Punct(Punct::new(',', Alone)),
+                                T::Punct(Punct::new('#', Alone)),
+                                T::Group(Group::new(Bracket, 
+                                  TokenStream::from_iter([
+                                    T::Ident(Ident::new("allow", c())),
                                     T::Group(Group::new(Parenthesis, 
                                       TokenStream::from_iter([
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("linux")),
-                                        T::Punct(Punct::new(',', Alone)),
-                                        T::Ident(Ident::new("target_os", c())),
-                                        T::Punct(Punct::new('=', Alone)),
-                                        T::Literal(Literal::string("android")),
+                                        T::Ident(Ident::new("non_snake_case", c())),
                                       ])
                                     )),
-                                    T::Punct(Punct::new(',', Alone)),
-                                    T::Ident(Ident::new("link_section", c())),
-                                    T::Punct(Punct::new('=', Alone)),
-                                    T::Literal(Literal::string(".text.startup")),
                                   ])
                                 )),
-                              ])
-                            )),
-                            T::Ident(Ident::new("unsafe", c())),
-                            T::Ident(Ident::new("extern", c())),
-                            T::Literal(Literal::string("C")),
-                            T::Ident(Ident::new("fn", c())),
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("ident", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
-                            )),
-                            T::Punct(Punct::new('-', Joint)),
-                            T::Punct(Punct::new('>', Alone)),
-                            T::Ident(Ident::new("usize", c())),
-                            T::Group(Group::new(Brace, 
-                              TokenStream::from_iter([
                                 T::Ident(Ident::new("unsafe", c())),
+                                T::Ident(Ident::new("extern", c())),
+                                T::Literal(Literal::string("C")),
+                                T::Ident(Ident::new("fn", c())),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("ident", c())),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::new()
+                                )),
+                                T::Punct(Punct::new('-', Joint)),
+                                T::Punct(Punct::new('>', Alone)),
+                                T::Ident(Ident::new("usize", c())),
                                 T::Group(Group::new(Brace, 
                                   TokenStream::from_iter([
-                                    T::Ident(Ident::new("do_atexit", c())),
-                                    T::Group(Group::new(Parenthesis, 
+                                    T::Ident(Ident::new("unsafe", c())),
+                                    T::Group(Group::new(Brace, 
                                       TokenStream::from_iter([
-                                        T::Ident(Ident::new("__dtor", c())),
+                                        T::Ident(Ident::new("do_atexit", c())),
+                                        T::Group(Group::new(Parenthesis, 
+                                          TokenStream::from_iter([
+                                            T::Ident(Ident::new("__dtor", c())),
+                                          ])
+                                        )),
+                                        T::Punct(Punct::new(';', Alone)),
+                                        T::Literal(Literal::usize_unsuffixed(0)),
                                       ])
                                     )),
-                                    T::Punct(Punct::new(';', Alone)),
-                                    T::Literal(Literal::usize_unsuffixed(0)),
                                   ])
                                 )),
                               ])
                             )),
+                            T::Punct(Punct::new(';', Alone)),
                             T::Punct(Punct::new('$', Alone)),
                             T::Ident(Ident::new("ident", c())),
                           ])
@@ -5177,109 +5240,90 @@ pub(crate) fn ctor() -> TokenStream {
                       ])
                     )),
                     T::Punct(Punct::new(';', Alone)),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
+                    T::Ident(Ident::new("super", c())),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('$', Alone)),
+                    T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg", c())),
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("macro_path", c())),
+                      ])
+                    )),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Punct(Punct::new('+', Alone)),
+                    T::Punct(Punct::new(':', Joint)),
+                    T::Punct(Punct::new(':', Alone)),
+                    T::Ident(Ident::new("ctor_link_section", c())),
+                    T::Punct(Punct::new('!', Alone)),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("exit", c())),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("macro_path", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Ident(Ident::new("super", c())),
+                        T::Punct(Punct::new(':', Joint)),
+                        T::Punct(Punct::new(':', Alone)),
+                        T::Punct(Punct::new('$', Alone)),
                         T::Group(Group::new(Parenthesis, 
                           TokenStream::from_iter([
-                            T::Ident(Ident::new("not", c())),
-                            T::Group(Group::new(Parenthesis, 
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Ident(Ident::new("macro_path", c())),
+                          ])
+                        )),
+                        T::Punct(Punct::new(':', Joint)),
+                        T::Punct(Punct::new(':', Alone)),
+                        T::Punct(Punct::new('+', Alone)),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("features", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("features", c())),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("unsafe", c())),
+                        T::Ident(Ident::new("extern", c())),
+                        T::Literal(Literal::string("C")),
+                        T::Ident(Ident::new("fn", c())),
+                        T::Ident(Ident::new("__dtor", c())),
+                        T::Group(Group::new(Parenthesis, 
+                          TokenStream::from_iter([
+                            T::Punct(Punct::new('#', Alone)),
+                            T::Group(Group::new(Bracket, 
                               TokenStream::from_iter([
-                                T::Ident(Ident::new("target_vendor", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("apple")),
+                                T::Ident(Ident::new("cfg", c())),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::from_iter([
+                                    T::Ident(Ident::new("target_vendor", c())),
+                                    T::Punct(Punct::new('=', Alone)),
+                                    T::Literal(Literal::string("apple")),
+                                  ])
+                                )),
                               ])
+                            )),
+                            T::Ident(Ident::new("_", c())),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('*', Alone)),
+                            T::Ident(Ident::new("const", c())),
+                            T::Ident(Ident::new("u8", c())),
+                          ])
+                        )),
+                        T::Group(Group::new(Brace, 
+                          TokenStream::from_iter([
+                            T::Ident(Ident::new("super", c())),
+                            T::Punct(Punct::new(':', Joint)),
+                            T::Punct(Punct::new(':', Alone)),
+                            T::Punct(Punct::new('$', Alone)),
+                            T::Ident(Ident::new("ident", c())),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::new()
                             )),
                           ])
                         )),
                       ])
                     )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg_attr", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("any", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::from_iter([
-                                T::Ident(Ident::new("target_os", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("linux")),
-                                T::Punct(Punct::new(',', Alone)),
-                                T::Ident(Ident::new("target_os", c())),
-                                T::Punct(Punct::new('=', Alone)),
-                                T::Literal(Literal::string("android")),
-                              ])
-                            )),
-                            T::Punct(Punct::new(',', Alone)),
-                            T::Ident(Ident::new("link_section", c())),
-                            T::Punct(Punct::new('=', Alone)),
-                            T::Literal(Literal::string(".text.exit")),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Ident(Ident::new("unsafe", c())),
-                    T::Ident(Ident::new("extern", c())),
-                    T::Literal(Literal::string("C")),
-                    T::Ident(Ident::new("fn", c())),
-                    T::Ident(Ident::new("__dtor", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::new()
-                    )),
-                    T::Group(Group::new(Brace, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("ident", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                      ])
-                    )),
-                    T::Punct(Punct::new('#', Alone)),
-                    T::Group(Group::new(Bracket, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("cfg", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::from_iter([
-                            T::Ident(Ident::new("target_vendor", c())),
-                            T::Punct(Punct::new('=', Alone)),
-                            T::Literal(Literal::string("apple")),
-                          ])
-                        )),
-                      ])
-                    )),
-                    T::Ident(Ident::new("unsafe", c())),
-                    T::Ident(Ident::new("extern", c())),
-                    T::Literal(Literal::string("C")),
-                    T::Ident(Ident::new("fn", c())),
-                    T::Ident(Ident::new("__dtor", c())),
-                    T::Group(Group::new(Parenthesis, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("_", c())),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('*', Alone)),
-                        T::Ident(Ident::new("const", c())),
-                        T::Ident(Ident::new("u8", c())),
-                      ])
-                    )),
-                    T::Group(Group::new(Brace, 
-                      TokenStream::from_iter([
-                        T::Ident(Ident::new("super", c())),
-                        T::Punct(Punct::new(':', Joint)),
-                        T::Punct(Punct::new(':', Alone)),
-                        T::Punct(Punct::new('$', Alone)),
-                        T::Ident(Ident::new("ident", c())),
-                        T::Group(Group::new(Parenthesis, 
-                          TokenStream::new()
-                        )),
-                      ])
-                    )),
+                    T::Punct(Punct::new(';', Alone)),
                     T::Punct(Punct::new('#', Alone)),
                     T::Group(Group::new(Bracket, 
                       TokenStream::from_iter([
@@ -5332,6 +5376,7 @@ pub(crate) fn ctor() -> TokenStream {
                     )),
                     T::Group(Group::new(Brace, 
                       TokenStream::from_iter([
+                        T::Ident(Ident::new("unsafe", c())),
                         T::Ident(Ident::new("extern", c())),
                         T::Literal(Literal::string("C")),
                         T::Group(Group::new(Brace, 
@@ -5353,13 +5398,18 @@ pub(crate) fn ctor() -> TokenStream {
                             T::Punct(Punct::new(';', Alone)),
                           ])
                         )),
-                        T::Ident(Ident::new("atexit", c())),
-                        T::Group(Group::new(Parenthesis, 
+                        T::Ident(Ident::new("unsafe", c())),
+                        T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
-                            T::Ident(Ident::new("cb", c())),
+                            T::Ident(Ident::new("atexit", c())),
+                            T::Group(Group::new(Parenthesis, 
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("cb", c())),
+                              ])
+                            )),
+                            T::Punct(Punct::new(';', Alone)),
                           ])
                         )),
-                        T::Punct(Punct::new(';', Alone)),
                       ])
                     )),
                     T::Punct(Punct::new('#', Alone)),
@@ -5533,6 +5583,11 @@ pub(crate) fn ctor() -> TokenStream {
       TokenStream::from_iter([
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("section", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("ident", c())),
+            T::Punct(Punct::new(',', Alone)),
             T::Ident(Ident::new("macro_path", c())),
             T::Punct(Punct::new('=', Alone)),
             T::Punct(Punct::new('$', Alone)),
@@ -5623,6 +5678,9 @@ pub(crate) fn ctor() -> TokenStream {
                     T::Punct(Punct::new('!', Alone)),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("section", c())),
+                        T::Punct(Punct::new(',', Alone)),
                         T::Ident(Ident::new("const", c())),
                         T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
@@ -5669,6 +5727,9 @@ pub(crate) fn ctor() -> TokenStream {
                     T::Punct(Punct::new('!', Alone)),
                     T::Group(Group::new(Parenthesis, 
                       TokenStream::from_iter([
+                        T::Punct(Punct::new('$', Alone)),
+                        T::Ident(Ident::new("section", c())),
+                        T::Punct(Punct::new(',', Alone)),
                         T::Ident(Ident::new("const", c())),
                         T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
@@ -5794,6 +5855,8 @@ pub(crate) fn ctor() -> TokenStream {
       TokenStream::from_iter([
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
+            T::Ident(Ident::new("array", c())),
+            T::Punct(Punct::new(',', Alone)),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("e", c())),
             T::Punct(Punct::new(':', Alone)),
@@ -5936,6 +5999,8 @@ pub(crate) fn ctor() -> TokenStream {
         T::Punct(Punct::new(';', Alone)),
         T::Group(Group::new(Parenthesis, 
           TokenStream::from_iter([
+            T::Ident(Ident::new("array", c())),
+            T::Punct(Punct::new(',', Alone)),
             T::Ident(Ident::new("const", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("e", c())),
@@ -5957,26 +6022,6 @@ pub(crate) fn ctor() -> TokenStream {
         T::Punct(Punct::new('>', Alone)),
         T::Group(Group::new(Brace, 
           TokenStream::from_iter([
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("cfg", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("clippy", c())),
-                  ])
-                )),
-              ])
-            )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Punct(Punct::new('$', Alone)),
-                T::Ident(Ident::new("used", c())),
-              ])
-            )),
-            T::Punct(Punct::new('$', Alone)),
-            T::Ident(Ident::new("item", c())),
             T::Punct(Punct::new('#', Alone)),
             T::Group(Group::new(Bracket, 
               TokenStream::from_iter([
@@ -6091,6 +6136,315 @@ pub(crate) fn ctor() -> TokenStream {
               TokenStream::from_iter([
                 T::Punct(Punct::new('$', Alone)),
                 T::Ident(Ident::new("used", c())),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("clippy", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("used", c())),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("startup", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("e", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("expr", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("used", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("not", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("clippy", c())),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg_attr", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("any", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("linux")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("android")),
+                      ])
+                    )),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("link_section", c())),
+                    T::Punct(Punct::new('=', Alone)),
+                    T::Literal(Literal::string(".text.startup")),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("clippy", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("startup", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("const", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("e", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("expr", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("used", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg_attr", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("any", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("linux")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("android")),
+                      ])
+                    )),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("unsafe", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("link_section", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string(".text.startup")),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("exit", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("e", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("expr", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("used", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("not", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("clippy", c())),
+                      ])
+                    )),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg_attr", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("any", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("linux")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("android")),
+                      ])
+                    )),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("link_section", c())),
+                    T::Punct(Punct::new('=', Alone)),
+                    T::Literal(Literal::string(".text.exit")),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("clippy", c())),
+                  ])
+                )),
+              ])
+            )),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new(';', Alone)),
+        T::Group(Group::new(Parenthesis, 
+          TokenStream::from_iter([
+            T::Ident(Ident::new("exit", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Ident(Ident::new("const", c())),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("e", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("expr", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("used", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("meta", c())),
+            T::Punct(Punct::new(',', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Ident(Ident::new("item", c())),
+            T::Punct(Punct::new(':', Alone)),
+            T::Ident(Ident::new("item", c())),
+          ])
+        )),
+        T::Punct(Punct::new('=', Joint)),
+        T::Punct(Punct::new('>', Alone)),
+        T::Group(Group::new(Brace, 
+          TokenStream::from_iter([
+            T::Punct(Punct::new('#', Alone)),
+            T::Group(Group::new(Bracket, 
+              TokenStream::from_iter([
+                T::Ident(Ident::new("cfg_attr", c())),
+                T::Group(Group::new(Parenthesis, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("any", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("linux")),
+                        T::Punct(Punct::new(',', Alone)),
+                        T::Ident(Ident::new("target_os", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string("android")),
+                      ])
+                    )),
+                    T::Punct(Punct::new(',', Alone)),
+                    T::Ident(Ident::new("unsafe", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("link_section", c())),
+                        T::Punct(Punct::new('=', Alone)),
+                        T::Literal(Literal::string(".text.exit")),
+                      ])
+                    )),
+                  ])
+                )),
               ])
             )),
             T::Punct(Punct::new('$', Alone)),

--- a/ctor/src/gen.rs
+++ b/ctor/src/gen.rs
@@ -3251,17 +3251,6 @@ pub(crate) fn ctor() -> TokenStream {
                 )),
               ])
             )),
-            T::Punct(Punct::new('#', Alone)),
-            T::Group(Group::new(Bracket, 
-              TokenStream::from_iter([
-                T::Ident(Ident::new("allow", c())),
-                T::Group(Group::new(Parenthesis, 
-                  TokenStream::from_iter([
-                    T::Ident(Ident::new("unsafe_code", c())),
-                  ])
-                )),
-              ])
-            )),
             T::Punct(Punct::new('$', Alone)),
             T::Group(Group::new(Parenthesis, 
               TokenStream::from_iter([
@@ -3270,6 +3259,14 @@ pub(crate) fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+              ])
+            )),
+            T::Punct(Punct::new('?', Alone)),
             T::Ident(Ident::new("fn", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("ident", c())),
@@ -3587,16 +3584,21 @@ pub(crate) fn ctor() -> TokenStream {
                                 T::Ident(Ident::new("usize", c())),
                                 T::Group(Group::new(Brace, 
                                   TokenStream::from_iter([
-                                    T::Ident(Ident::new("super", c())),
-                                    T::Punct(Punct::new(':', Joint)),
-                                    T::Punct(Punct::new(':', Alone)),
-                                    T::Punct(Punct::new('$', Alone)),
-                                    T::Ident(Ident::new("ident", c())),
-                                    T::Group(Group::new(Parenthesis, 
-                                      TokenStream::new()
+                                    T::Ident(Ident::new("unsafe", c())),
+                                    T::Group(Group::new(Brace, 
+                                      TokenStream::from_iter([
+                                        T::Ident(Ident::new("super", c())),
+                                        T::Punct(Punct::new(':', Joint)),
+                                        T::Punct(Punct::new(':', Alone)),
+                                        T::Punct(Punct::new('$', Alone)),
+                                        T::Ident(Ident::new("ident", c())),
+                                        T::Group(Group::new(Parenthesis, 
+                                          TokenStream::new()
+                                        )),
+                                        T::Punct(Punct::new(';', Alone)),
+                                        T::Literal(Literal::usize_unsuffixed(0)),
+                                      ])
                                     )),
-                                    T::Punct(Punct::new(';', Alone)),
-                                    T::Literal(Literal::usize_unsuffixed(0)),
                                   ])
                                 )),
                               ])

--- a/ctor/src/gen.rs
+++ b/ctor/src/gen.rs
@@ -4906,8 +4906,6 @@ pub(crate) fn ctor() -> TokenStream {
                 T::Ident(Ident::new("allow", c())),
                 T::Group(Group::new(Parenthesis, 
                   TokenStream::from_iter([
-                    T::Ident(Ident::new("unsafe_code", c())),
-                    T::Punct(Punct::new(',', Alone)),
                     T::Ident(Ident::new("unused", c())),
                   ])
                 )),
@@ -4921,6 +4919,14 @@ pub(crate) fn ctor() -> TokenStream {
               ])
             )),
             T::Punct(Punct::new('*', Alone)),
+            T::Punct(Punct::new('$', Alone)),
+            T::Group(Group::new(Parenthesis, 
+              TokenStream::from_iter([
+                T::Punct(Punct::new('$', Alone)),
+                T::Ident(Ident::new("unsafe", c())),
+              ])
+            )),
+            T::Punct(Punct::new('?', Alone)),
             T::Ident(Ident::new("fn", c())),
             T::Punct(Punct::new('$', Alone)),
             T::Ident(Ident::new("ident", c())),
@@ -4929,6 +4935,17 @@ pub(crate) fn ctor() -> TokenStream {
             )),
             T::Group(Group::new(Brace, 
               TokenStream::from_iter([
+                T::Punct(Punct::new('#', Alone)),
+                T::Group(Group::new(Bracket, 
+                  TokenStream::from_iter([
+                    T::Ident(Ident::new("allow", c())),
+                    T::Group(Group::new(Parenthesis, 
+                      TokenStream::from_iter([
+                        T::Ident(Ident::new("unsafe_code", c())),
+                      ])
+                    )),
+                  ])
+                )),
                 T::Ident(Ident::new("mod", c())),
                 T::Ident(Ident::new("__dtor_internal", c())),
                 T::Group(Group::new(Brace, 
@@ -5313,13 +5330,18 @@ pub(crate) fn ctor() -> TokenStream {
                         )),
                         T::Group(Group::new(Brace, 
                           TokenStream::from_iter([
-                            T::Ident(Ident::new("super", c())),
-                            T::Punct(Punct::new(':', Joint)),
-                            T::Punct(Punct::new(':', Alone)),
-                            T::Punct(Punct::new('$', Alone)),
-                            T::Ident(Ident::new("ident", c())),
-                            T::Group(Group::new(Parenthesis, 
-                              TokenStream::new()
+                            T::Ident(Ident::new("unsafe", c())),
+                            T::Group(Group::new(Brace, 
+                              TokenStream::from_iter([
+                                T::Ident(Ident::new("super", c())),
+                                T::Punct(Punct::new(':', Joint)),
+                                T::Punct(Punct::new(':', Alone)),
+                                T::Punct(Punct::new('$', Alone)),
+                                T::Ident(Ident::new("ident", c())),
+                                T::Group(Group::new(Parenthesis, 
+                                  TokenStream::new()
+                                )),
+                              ])
                             )),
                           ])
                         )),

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "256"]
+#![allow(if_let_rescope)]
 
 //! Procedural macro for defining global constructor/destructor functions.
 //!
@@ -27,14 +28,10 @@
 
 // https://reviews.llvm.org/D45578
 
-extern crate proc_macro;
-
-use std::iter::FromIterator;
-
 use proc_macro::*;
 
 #[rustfmt::skip]
-mod gen;
+mod r#gen;
 
 /// Marks a function or static variable as a library/executable constructor.
 /// This uses OS-specific linker sections to call a specific function at
@@ -255,6 +252,6 @@ fn generate(name: &str, ctor_type: &str, item: TokenStream) -> TokenStream {
         T::Punct(Punct::new(';', Spacing::Alone)),
         T::Ident(Ident::new("mod", Span::call_site())),
         T::Ident(Ident::new(&macros_name, Span::call_site())),
-        T::Group(Group::new(Delimiter::Brace, gen::ctor())),
+        T::Group(Group::new(Delimiter::Brace, r#gen::ctor())),
     ])
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "beta"
+

--- a/tests-edition-2018/Cargo.toml
+++ b/tests-edition-2018/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tests-edition-2018"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[features]
+used_linker = ["ctor/used_linker"]
+
+[dependencies]
+ctor = { path = "../ctor" }

--- a/tests-edition-2018/src/main.rs
+++ b/tests-edition-2018/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+//! Edition 2018 test.
 
 use ctor::ctor;
 

--- a/tests-edition-2018/src/main.rs
+++ b/tests-edition-2018/src/main.rs
@@ -3,6 +3,7 @@
 use ctor::ctor;
 
 #[ctor]
+#[allow(unsafe_code)]
 unsafe fn foo() {
     println!("foo");
 }

--- a/tests-edition-2018/src/main.rs
+++ b/tests-edition-2018/src/main.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+
+use ctor::ctor;
+
+#[ctor]
+fn foo() {
+    println!("foo");
+}
+
+fn main() {
+    println!("main");
+}

--- a/tests-edition-2018/src/main.rs
+++ b/tests-edition-2018/src/main.rs
@@ -3,7 +3,7 @@
 use ctor::ctor;
 
 #[ctor]
-fn foo() {
+unsafe fn foo() {
     println!("foo");
 }
 

--- a/tests-edition-2021/Cargo.toml
+++ b/tests-edition-2021/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tests-edition-2021"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+used_linker = ["ctor/used_linker"]
+
+[dependencies]
+ctor = { path = "../ctor" }

--- a/tests-edition-2021/src/main.rs
+++ b/tests-edition-2021/src/main.rs
@@ -3,6 +3,7 @@
 use ctor::ctor;
 
 #[ctor]
+#[allow(unsafe_code)]
 unsafe fn foo() {
     println!("foo");
 }

--- a/tests-edition-2021/src/main.rs
+++ b/tests-edition-2021/src/main.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+
+use ctor::ctor;
+
+#[ctor]
+fn foo() {
+    println!("foo");
+}
+
+fn main() {
+    println!("main");
+}

--- a/tests-edition-2021/src/main.rs
+++ b/tests-edition-2021/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+//! Edition 2021 test.
 
 use ctor::ctor;
 

--- a/tests-edition-2021/src/main.rs
+++ b/tests-edition-2021/src/main.rs
@@ -3,7 +3,7 @@
 use ctor::ctor;
 
 #[ctor]
-fn foo() {
+unsafe fn foo() {
     println!("foo");
 }
 

--- a/tests-edition-2024/Cargo.toml
+++ b/tests-edition-2024/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tests-edition-2024"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[features]
+used_linker = ["ctor/used_linker"]
+
+[dependencies]
+ctor = { path = "../ctor" }

--- a/tests-edition-2024/src/main.rs
+++ b/tests-edition-2024/src/main.rs
@@ -3,6 +3,7 @@
 use ctor::ctor;
 
 #[ctor]
+#[allow(unsafe_code)]
 unsafe fn foo() {
     println!("foo");
 }

--- a/tests-edition-2024/src/main.rs
+++ b/tests-edition-2024/src/main.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+
+use ctor::ctor;
+
+#[ctor]
+fn foo() {
+    println!("foo");
+}
+
+fn main() {
+    println!("main");
+}

--- a/tests-edition-2024/src/main.rs
+++ b/tests-edition-2024/src/main.rs
@@ -3,7 +3,7 @@
 use ctor::ctor;
 
 #[ctor]
-fn foo() {
+unsafe fn foo() {
     println!("foo");
 }
 

--- a/tests-edition-2024/src/main.rs
+++ b/tests-edition-2024/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+//! Edition 2024 test.
 
 use ctor::ctor;
 

--- a/tests-wasm/src/lib.rs
+++ b/tests-wasm/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(target_family="wasm")]
+#[cfg(target_family = "wasm")]
 #[ctor::ctor]
 unsafe fn hello() {
     use wasm_bindgen::prelude::wasm_bindgen;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,6 +13,7 @@ ctor = { path = "../ctor" }
 dlopen = "0.1.8"
 libc-print = "0.1.15"
 libc = { version = "0.2.96", default-features = false }
+rustversion = "1"
 
 [[example]]
 name = "dylib"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 publish = false
 
 [features]
-# For nightly users, used(linker) may be a better choice
 used_linker = ["ctor/used_linker"]
 
 [dependencies]
@@ -13,7 +12,6 @@ ctor = { path = "../ctor" }
 dlopen = "0.1.8"
 libc-print = "0.1.15"
 libc = { version = "0.2.96", default-features = false }
-rustversion = "1"
 
 [[example]]
 name = "dylib"

--- a/tests/src/dylib.rs
+++ b/tests/src/dylib.rs
@@ -5,18 +5,21 @@ use ctor::*;
 use libc_print::*;
 
 #[cfg(windows)]
-extern "C" {
-    fn Sleep(ms: u32);
+unsafe extern "C" {
+    #[allow(unused)]
+    unsafe fn Sleep(ms: u32);
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
-    Sleep(seconds * 1000);
+    unsafe { Sleep(seconds * 1000); }
 }
 
 #[cfg(not(windows))]
+#[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
-    libc::sleep(seconds);
+    unsafe { libc::sleep(seconds); }
 }
 
 #[ctor]
@@ -28,22 +31,25 @@ pub static STATIC_INT: u8 = {
 #[ctor]
 #[cfg(not(test))]
 #[cfg(target_feature = "crt-static")]
+#[allow(unsafe_code)]
 unsafe fn ctor() {
-    sleep(1);
+    unsafe { sleep(1); }
     libc_ewriteln!("+++ ctor lib (+crt-static)");
 }
 
 #[ctor]
 #[cfg(not(test))]
 #[cfg(not(target_feature = "crt-static"))]
+#[allow(unsafe_code)]
 unsafe fn ctor() {
-    sleep(1);
+    unsafe { sleep(1); }
     libc_ewriteln!("+++ ctor lib (-crt-static)");
 }
 
 #[dtor]
 #[cfg(not(test))]
+#[allow(unsafe_code)]
 unsafe fn dtor() {
-    sleep(1);
+    unsafe { sleep(1); }
     libc_ewriteln!("--- dtor lib");
 }

--- a/tests/src/dylib.rs
+++ b/tests/src/dylib.rs
@@ -5,6 +5,7 @@ use ctor::*;
 use libc_print::*;
 
 #[cfg(windows)]
+#[allow(unsafe_code)]
 unsafe extern "C" {
     #[allow(unused)]
     unsafe fn Sleep(ms: u32);

--- a/tests/src/dylib.rs
+++ b/tests/src/dylib.rs
@@ -13,13 +13,17 @@ unsafe extern "C" {
 #[cfg(windows)]
 #[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
-    unsafe { Sleep(seconds * 1000); }
+    unsafe {
+        Sleep(seconds * 1000);
+    }
 }
 
 #[cfg(not(windows))]
 #[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
-    unsafe { libc::sleep(seconds); }
+    unsafe {
+        libc::sleep(seconds);
+    }
 }
 
 #[ctor]
@@ -33,7 +37,9 @@ pub static STATIC_INT: u8 = {
 #[cfg(target_feature = "crt-static")]
 #[allow(unsafe_code)]
 unsafe fn ctor() {
-    unsafe { sleep(1); }
+    unsafe {
+        sleep(1);
+    }
     libc_ewriteln!("+++ ctor lib (+crt-static)");
 }
 
@@ -42,7 +48,9 @@ unsafe fn ctor() {
 #[cfg(not(target_feature = "crt-static"))]
 #[allow(unsafe_code)]
 unsafe fn ctor() {
-    unsafe { sleep(1); }
+    unsafe {
+        sleep(1);
+    }
     libc_ewriteln!("+++ ctor lib (-crt-static)");
 }
 
@@ -50,6 +58,8 @@ unsafe fn ctor() {
 #[cfg(not(test))]
 #[allow(unsafe_code)]
 unsafe fn dtor() {
-    unsafe { sleep(1); }
+    unsafe {
+        sleep(1);
+    }
     libc_ewriteln!("--- dtor lib");
 }

--- a/tests/src/dylib.rs
+++ b/tests/src/dylib.rs
@@ -1,3 +1,4 @@
+//! Tests for ctor in dylibs.
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 #![allow(dead_code, unused_imports)]
 
@@ -28,7 +29,7 @@ unsafe fn sleep(seconds: u32) {
 }
 
 #[ctor]
-pub static STATIC_INT: u8 = {
+static STATIC_INT: u8 = {
     libc_ewriteln!("+++ ctor STATIC_INT");
     200
 };

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -1,3 +1,4 @@
+//! Tests for ctor in an executable that loads a dylib.
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 #![allow(unused_imports)]
 
@@ -72,6 +73,7 @@ unsafe fn sleep(seconds: u32) {
     }
 }
 
+/// Entry point for the executable.
 pub fn main() {
     #[allow(unsafe_code)]
     unsafe {

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -51,14 +51,16 @@ fn prefix() -> &'static str {
 }
 
 #[cfg(windows)]
-extern "C" {
-    fn Sleep(ms: u32);
+unsafe extern "C" {
+    unsafe fn Sleep(ms: u32);
 }
 
 #[cfg(windows)]
 #[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
-    Sleep(seconds * 1000);
+    unsafe {
+        Sleep(seconds * 1000);
+    }
 }
 
 #[cfg(not(windows))]

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -9,7 +9,9 @@ use libc_print::*;
 #[cfg(not(test))]
 #[allow(unsafe_code)]
 unsafe fn ctor() {
-    unsafe { sleep(1); }
+    unsafe {
+        sleep(1);
+    }
     libc_ewriteln!("+ ctor bin");
 }
 
@@ -17,7 +19,9 @@ unsafe fn ctor() {
 #[cfg(not(test))]
 #[allow(unsafe_code)]
 unsafe fn dtor() {
-    unsafe { sleep(1); }
+    unsafe {
+        sleep(1);
+    }
     libc_ewriteln!("- dtor bin");
 }
 
@@ -60,7 +64,9 @@ unsafe fn sleep(seconds: u32) {
 #[cfg(not(windows))]
 #[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
-    unsafe { libc::sleep(seconds); }
+    unsafe {
+        libc::sleep(seconds);
+    }
 }
 
 pub fn main() {

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -51,6 +51,7 @@ fn prefix() -> &'static str {
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)]
 unsafe extern "C" {
     unsafe fn Sleep(ms: u32);
 }

--- a/tests/src/dylib_load.rs
+++ b/tests/src/dylib_load.rs
@@ -7,15 +7,17 @@ use libc_print::*;
 
 #[ctor]
 #[cfg(not(test))]
+#[allow(unsafe_code)]
 unsafe fn ctor() {
-    sleep(1);
+    unsafe { sleep(1); }
     libc_ewriteln!("+ ctor bin");
 }
 
 #[dtor]
 #[cfg(not(test))]
+#[allow(unsafe_code)]
 unsafe fn dtor() {
-    sleep(1);
+    unsafe { sleep(1); }
     libc_ewriteln!("- dtor bin");
 }
 
@@ -50,16 +52,19 @@ extern "C" {
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
     Sleep(seconds * 1000);
 }
 
 #[cfg(not(windows))]
+#[allow(unsafe_code)]
 unsafe fn sleep(seconds: u32) {
-    libc::sleep(seconds);
+    unsafe { libc::sleep(seconds); }
 }
 
 pub fn main() {
+    #[allow(unsafe_code)]
     unsafe {
         sleep(1);
         libc_ewriteln!("++ main start");

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,3 +1,4 @@
+//! Tests for various configurations of the crate.
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 // Prevent a spurious 'unused_imports' warning
 #[allow(unused_imports)]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -16,13 +16,13 @@ mod test {
 
     /// Doc comment
     #[ctor]
-    fn foo() {
+    unsafe fn foo() {
         INITED.store(true, Ordering::SeqCst);
     }
 
     /// This ensures that we support more than of these
     #[ctor]
-    fn foo_2() {
+    unsafe fn foo_2() {
         INITED_2.store(true, Ordering::SeqCst);
     }
 
@@ -30,7 +30,7 @@ mod test {
     static INITED_3: u8 = 42;
 
     #[dtor]
-    fn shutdown() {
+    unsafe fn shutdown() {
         // Using println or eprintln here will panic as Rust has shut down
         libc_eprintln!("We don't test shutdown, but if you see this message it worked!");
     }


### PR DESCRIPTION
Rust 2024 is coming and requires some minor lint fixes.

There's some strangeness in how clippy and Rust process unsafe attributes. We use a trick to determine the current edition and generate either 2021 or 2024 compatible output.
