### PR TITLE
Allow easier re-export of ctor crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,19 +27,19 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "ctor"
 version = "0.3.4"
 dependencies = [
- "ctor-proc-macro 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor-proc-macro 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc-print",
 ]
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.2"
+version = "0.0.4"
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107adb396b2d8e7766e79151083ce1cc624b51dfd1c23e0429c50226bba693eb"
+checksum = "c426d2ba3e525b39c1f0a9ba41b9fe61878dee11fa4e4a76b6ab440f46c5db5d"
 
 [[package]]
 name = "diff"

--- a/ctor-proc-macro/Cargo.toml
+++ b/ctor-proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor-proc-macro"
-version = "0.0.2"
+version = "0.0.4"
 authors = ["Matt Mastracci <matthew@mastracci.com>"]
 edition = "2018"
 description = "proc-macro support for the ctor crate"

--- a/ctor-proc-macro/src/lib.rs
+++ b/ctor-proc-macro/src/lib.rs
@@ -28,6 +28,36 @@ fn generate(
 ) -> TokenStream {
     let mut inner = TokenStream::new();
 
+    // Search for crate_path in attributes
+    let mut crate_path = None;
+    let mut tokens = attribute.clone().into_iter().peekable();
+    while let Some(token) = tokens.next() {
+        if let TokenTree::Ident(ident) = &token {
+            if ident.to_string() == "crate_path" {
+                // Look for =
+                if let Some(TokenTree::Punct(punct)) = tokens.next() {
+                    if punct.as_char() == '=' {
+                        // Collect tokens until comma or end
+                        let mut path = TokenStream::new();
+                        while let Some(token) = tokens.peek() {
+                            match token {
+                                TokenTree::Punct(p) if p.as_char() == ',' => {
+                                    tokens.next();
+                                    break;
+                                }
+                                _ => {
+                                    path.extend(std::iter::once(tokens.next().unwrap()));
+                                }
+                            }
+                        }
+                        crate_path = Some(path);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     #[cfg(feature = "used_linker")]
     inner.extend([
         TokenTree::Punct(Punct::new('#', Spacing::Alone)),
@@ -91,21 +121,28 @@ fn generate(
 
     inner.extend(item);
 
-    TokenStream::from_iter([
-        TokenTree::Punct(Punct::new(':', Spacing::Joint)),
-        TokenTree::Punct(Punct::new(':', Spacing::Alone)),
-        TokenTree::Ident(Ident::new(macro_crate, Span::call_site())),
+    let mut invoke = crate_path.unwrap_or_else(|| {
+        TokenStream::from_iter([
+            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Ident(Ident::new(macro_crate, Span::call_site())),
+        ])
+    });
+
+    invoke.extend([
         TokenTree::Punct(Punct::new(':', Spacing::Joint)),
         TokenTree::Punct(Punct::new(':', Spacing::Alone)),
         TokenTree::Ident(Ident::new("__support", Span::call_site())),
         TokenTree::Punct(Punct::new(':', Spacing::Joint)),
         TokenTree::Punct(Punct::new(':', Spacing::Alone)),
         TokenTree::Ident(Ident::new(
-            &format!("{}_parse", macro_crate),
+            &format!("{}_parse", macro_type),
             Span::call_site(),
         )),
         TokenTree::Punct(Punct::new('!', Spacing::Alone)),
         TokenTree::Group(Group::new(Delimiter::Parenthesis, inner)),
         TokenTree::Punct(Punct::new(';', Spacing::Alone)),
-    ])
+    ]);
+
+    invoke
 }

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -20,7 +20,7 @@ used_linker = ["ctor-proc-macro/used_linker"]
 __warn_on_missing_unsafe = ["ctor-proc-macro/__warn_on_missing_unsafe"]
 
 [dependencies]
-ctor-proc-macro = "=0.0.2"
+ctor-proc-macro = "=0.0.4"
 
 [dev-dependencies]
 libc-print = "0.1.20"

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -4,9 +4,8 @@ pub mod __support {
     pub use crate::__ctor_entry as ctor_entry;
     pub use crate::__ctor_link_section as ctor_link_section;
     pub use crate::__ctor_link_section_attr as ctor_link_section_attr;
-    #[doc(hidden)]
-    pub use crate::__ctor_parse as dtor_parse;
     pub use crate::__dtor_entry as dtor_entry;
+    pub use crate::__dtor_parse as dtor_parse;
     pub use crate::__if_has_feature as if_has_feature;
     pub use crate::__if_unsafe as if_unsafe;
 }
@@ -34,3 +33,34 @@ mod macros;
 /// }
 /// ```
 pub use dtor_proc_macro::dtor;
+
+/// Declarative forms of the `#[dtor]` macro.
+///
+/// The declarative forms wrap and parse a proc_macro-like syntax like so, and
+/// are identical in expansion to the undecorated procedural macros. The
+/// declarative forms support the same attribute parameters as the procedural
+/// macros.
+///
+/// ```rust
+/// # mod test { use dtor::*; use libc_print::*;
+/// dtor::declarative::dtor! {
+///   #[dtor]
+///   fn foo() {
+///     libc_println!("Goodbye, world!");
+///   }
+/// }
+/// # }
+///
+/// // ... the above is identical to:
+///
+/// # mod test_2 { use dtor::*; use libc_print::*;
+/// #[dtor]
+/// fn foo() {
+///   libc_println!("Goodbye, world!");
+/// }
+/// # }
+/// ```
+pub mod declarative {
+    #[doc(inline)]
+    pub use crate::__support::dtor_parse as dtor;
+}


### PR DESCRIPTION
The recent refactoring in 0.3.x to split ctor into a declarative/proc_macro hybrid crate broke some downstream uses of ctor where ctor-annotated items were injected into code that was not importing the ctor crate.

Fixes #325 (a breakage in `napi-rs` reported by @Brooooooklyn by offering two options for re-export of ctor items:

  1) #[ctor] now has a `crate_path` attribute allowing re-exporters to specify a private re-export path:

```rust
#[ctor(crate_path=::my_crate::private::ctor)]
unsafe fn foo() {
}
```

  2) A new `declarative` module that avoids any `proc_macro` usage is available. This module exposes a macro that parses #[ctor]-annotated items. As this declarative macro is fully-implemented with `macro_rules!` and `$crate`-relative references to support macros, there should be no issues with re-exporting of ctor items.

```rust
ctor::declarative::ctor! {
  #[ctor]
  unsafe fn foo() {
  }
}
```

Either solution should solve the issue.