### PR TITLE
Allow arbitrary #[meta] before and after #[ctor]/#[dtor]

### DIFF
--- a/shared/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_doc.expanded.rs
@@ -1,0 +1,31 @@
+#[cfg(not(target_family = "wasm"))]
+/// Doc 1
+/// Doc 2
+#[allow(unused)]
+unsafe fn foo() {
+    #[doc(hidden)]
+    /// Internal module.
+    ///features=[]
+    #[allow(unsafe_code)]
+    mod __ctor_internal {
+        #[link_section = "__DATA,__mod_init_func"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static foo: extern "C" fn() -> usize = {
+            #[allow(non_snake_case)]
+            extern "C" fn foo() -> usize {
+                unsafe {
+                    super::foo();
+                    0
+                }
+            }
+            foo
+        };
+    }
+    {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
+}

--- a/shared/tests/expand-darwin/ctor_doc.rs
+++ b/shared/tests/expand-darwin/ctor_doc.rs
@@ -1,0 +1,8 @@
+shared::ctor_parse!(
+    /// Doc 1
+    #[ctor]
+    /// Doc 2
+    unsafe fn foo() {
+        println!("foo");
+    }
+);

--- a/shared/tests/expand-darwin/ctor_static.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_static.expanded.rs
@@ -1,0 +1,38 @@
+static STATIC_CTOR: STATIC_CTOR::Static<HashMap<u32, &'static str>> = STATIC_CTOR::Static::<
+    HashMap<u32, &'static str>,
+> {
+    _storage: {
+        #[link_section = "__DATA,__mod_init_func"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> usize = {
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> usize {
+                _ = &*STATIC_CTOR;
+                0
+            }
+            f
+        };
+        ::std::sync::OnceLock::new()
+    },
+};
+impl ::core::ops::Deref for STATIC_CTOR::Static<HashMap<u32, &'static str>> {
+    type Target = HashMap<u32, &'static str>;
+    fn deref(&self) -> &HashMap<u32, &'static str> {
+        fn init() -> HashMap<u32, &'static str> {
+            let m = HashMap::new();
+            m
+        }
+        self._storage.get_or_init(move || { init() })
+    }
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals, non_snake_case)]
+#[allow(unsafe_code)]
+mod STATIC_CTOR {
+    #[allow(non_camel_case_types, unreachable_pub)]
+    pub struct Static<T> {
+        pub _storage: ::std::sync::OnceLock<T>,
+    }
+}

--- a/shared/tests/expand-darwin/ctor_static.rs
+++ b/shared/tests/expand-darwin/ctor_static.rs
@@ -1,0 +1,7 @@
+shared::ctor_parse!(
+    #[ctor]
+    static STATIC_CTOR: HashMap<u32, &'static str> = unsafe {
+        let m = HashMap::new();
+        m
+    };
+);

--- a/shared/tests/expand-darwin/dtor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/dtor_doc.expanded.rs
@@ -1,0 +1,45 @@
+/// Doc 1
+/// Doc 2
+#[allow(unused)]
+unsafe fn foo() {
+    #[allow(unsafe_code)]
+    mod __dtor_internal {
+        #[link_section = "__DATA,__mod_init_func"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static foo: extern "C" fn() -> usize = {
+            #[allow(non_snake_case)]
+            extern "C" fn foo() -> usize {
+                unsafe {
+                    do_atexit(__dtor);
+                    0
+                }
+            }
+            foo
+        };
+        extern "C" fn __dtor(#[cfg(target_vendor = "apple")] _: *const u8) {
+            unsafe { super::foo() }
+        }
+        #[cfg(target_vendor = "apple")]
+        #[inline(always)]
+        pub(super) unsafe fn do_atexit(cb: extern "C" fn(_: *const u8)) {
+            extern "C" {
+                static __dso_handle: *const u8;
+                fn __cxa_atexit(
+                    cb: extern "C" fn(_: *const u8),
+                    arg: *const u8,
+                    dso_handle: *const u8,
+                );
+            }
+            unsafe {
+                __cxa_atexit(cb, core::ptr::null(), __dso_handle);
+            }
+        }
+    }
+    {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
+}

--- a/shared/tests/expand-darwin/dtor_doc.rs
+++ b/shared/tests/expand-darwin/dtor_doc.rs
@@ -1,0 +1,8 @@
+shared::dtor_parse!(
+    /// Doc 1
+    #[dtor]
+    /// Doc 2
+    unsafe fn foo() {
+        println!("foo");
+    }
+);

--- a/tests/system/Cargo.toml
+++ b/tests/system/Cargo.toml
@@ -21,3 +21,6 @@ crate-type = ["cdylib"]
 [[example]]
 name = "dylib_load"
 path = "src/dylib_load.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(never)'] }

--- a/tests/system/src/dylib.rs
+++ b/tests/system/src/dylib.rs
@@ -5,6 +5,25 @@
 use ctor::*;
 use libc_print::*;
 
+#[cfg(never)]
+#[ctor]
+unsafe fn never() {
+    libc_ewriteln!("+++ ctor never run");
+}
+
+#[cfg(never)]
+#[ctor]
+static NEVER_STATIC: u8 = unsafe {
+    libc_ewriteln!("+++ ctor static never run");
+    42
+};
+
+#[cfg(never)]
+#[dtor]
+unsafe fn never() {
+    libc_ewriteln!("+++ dtor never run");
+}
+
 #[cfg(windows)]
 #[allow(unsafe_code)]
 unsafe extern "C" {


### PR DESCRIPTION
Fix for doc comments not allowed before `#[ctor]` using declarative macro (fixes issue mentioned in #332).

Allow this:

```rust
/// Doc 1
#[ctor]
/// Doc 2
unsafe fn foo() { }
```
