### PR TITLE
Allow anonymous ctor (either explicit or via anonymous)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,17 @@ members = [
     "tests/edition-2021", 
     "tests/edition-2024" 
 ]
+default-members = [
+    "ctor",
+    "dtor",
+    "ctor-proc-macro",
+    "dtor-proc-macro",
+    "shared",
+    "tests/system",
+    "tests/wasm",
+    "tests/edition-2018",
+    "tests/edition-2021",
+]
 resolver = "2"
 
 [patch.crates-io]

--- a/ctor/src/example.rs
+++ b/ctor/src/example.rs
@@ -20,13 +20,36 @@ static STATIC_CTOR: HashMap<u32, &'static str> = unsafe {
 
 #[ctor(anonymous)]
 unsafe fn anonymous_ctor() {
-    libc_eprintln!("ctor_anonymous");
+    libc_eprintln!("ctor_anonymous (#1)");
+    // We can still reference the function itself
+    let f = anonymous_ctor;
 }
+
+#[ctor(anonymous)]
+unsafe fn anonymous_ctor() {
+    libc_eprintln!("ctor_anonymous (#2)");
+}
+
+const _: () = {
+    #[ctor]
+    unsafe fn anonymous_ctor() {
+        libc_eprintln!("ctor_anonymous (#3)");
+        let f = anonymous_ctor;
+    }
+
+    #[dtor]
+    unsafe fn anonymous_dtor() {
+        libc_eprintln!("dtor_anonymous");
+        let f = anonymous_dtor;
+    }
+};
 
 #[ctor]
 #[allow(unsafe_code)]
 unsafe fn ctor() {
     libc_eprintln!("ctor");
+    // We can still reference the function itself
+    let f = ctor;
 }
 
 #[ctor]
@@ -39,12 +62,26 @@ unsafe fn ctor_unsafe() {
 #[allow(unsafe_code)]
 unsafe fn dtor() {
     libc_eprintln!("dtor");
+    // We can still reference the function itself
+    let f = dtor;
 }
 
 #[dtor]
 #[allow(unsafe_code)]
 unsafe fn dtor_unsafe() {
     libc_eprintln!("dtor_unsafe");
+}
+
+#[dtor(anonymous)]
+unsafe fn anonymous_dtor() {
+    libc_eprintln!("dtor_anonymous (#1)");
+    let f = anonymous_dtor;
+}
+
+#[dtor(anonymous)]
+unsafe fn anonymous_dtor() {
+    libc_eprintln!("dtor_anonymous (#2");
+    let f = anonymous_dtor;
 }
 
 /// A module with a static ctor/dtor

--- a/ctor/src/example.rs
+++ b/ctor/src/example.rs
@@ -18,6 +18,11 @@ static STATIC_CTOR: HashMap<u32, &'static str> = unsafe {
     m
 };
 
+#[ctor(anonymous)]
+unsafe fn anonymous_ctor() {
+    libc_eprintln!("ctor_anonymous");
+}
+
 #[ctor]
 #[allow(unsafe_code)]
 unsafe fn ctor() {

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -79,7 +79,8 @@ pub mod declarative {
 ///    containing the support macros. If you re-export `ctor` items as part of
 ///    your crate, you can use this to redirect the macro's output to the
 ///    correct crate.
-///  - `used(linker)`: Use the linker to load the constructor.
+///  - `used(linker)`: (Advanced) Mark the function as being used in the link
+///    phase.
 ///  - `link_section = "section"`: The section to place the constructor in.
 ///  - `anonymous`: Do not give the constructor a name in the generated code
 ///    (allows for multiple constructors with the same name).

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -81,6 +81,8 @@ pub mod declarative {
 ///    correct crate.
 ///  - `used(linker)`: Use the linker to load the constructor.
 ///  - `link_section = "section"`: The section to place the constructor in.
+///  - `anonymous`: Do not give the constructor a name in the generated code
+///    (allows for multiple constructors with the same name).
 ///
 /// # Examples
 ///

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -1,4 +1,3 @@
-
 #![doc = include_str!("../README.md")]
 
 mod macros;
@@ -12,6 +11,18 @@ pub use macros::__support;
 ///
 /// Multiple shutdown functions are supported, but the invocation order is not
 /// guaranteed.
+///
+/// # Attribute parameters
+///
+///  - `crate_path = ::path::to::dtor::crate`: The path to the `dtor` crate
+///    containing the support macros. If you re-export `dtor` items as part of
+///    your crate, you can use this to redirect the macro's output to the
+///    correct crate.
+///  - `used(linker)`: (Advanced) Mark the function as being used in the link
+///    phase.
+///  - `link_section = "section"`: The section to place the dtor's code in.
+///  - `anonymous`: Do not give the destructor a name in the generated code
+///    (allows for multiple destructors with the same name).
 ///
 /// ```rust
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]

--- a/shared/src/macros/mod.rs
+++ b/shared/src/macros/mod.rs
@@ -148,6 +148,9 @@ macro_rules! __unify_features {
     (continue, next=$next_macro:path, meta=[crate_path = $path:path $(, $($meta:tt)* )?], features=[$($features:tt)*], $($rest:tt)*) => {
         $crate::__support::unify_features!(continue, next=$next_macro, meta=[$($($meta)*)?], features=[(crate_path=$path),$($features)*], $($rest)*);
     };
+    (continue, next=$next_macro:path, meta=[anonymous $(, $($meta:tt)* )?], features=[$($features:tt)*], $($rest:tt)*) => {
+        $crate::__support::unify_features!(continue, next=$next_macro, meta=[$($($meta)*)?], features=[anonymous,$($features)*], $($rest)*);
+    };
     (continue, next=$next_macro:path, meta=[$unknown_meta:meta $($meta:tt)*], features=[$($features:tt)*], $($rest:tt)*) => {
         compile_error!(concat!("Unknown attribute parameter: ", stringify!($unknown_meta)));
     };
@@ -204,6 +207,7 @@ macro_rules! __include_no_warn_on_missing_unsafe_feature {
 macro_rules! __if_has_feature {
     (used_linker,                 [used_linker,                     $($rest:tt)*], {$($if_true:tt)*}, {$($if_false:tt)*}) => { $($if_true)* };
     (__no_warn_on_missing_unsafe, [__no_warn_on_missing_unsafe,     $($rest:tt)*], {$($if_true:tt)*}, {$($if_false:tt)*}) => { $($if_true)* };
+    (anonymous,                   [anonymous,                       $($rest:tt)*], {$($if_true:tt)*}, {$($if_false:tt)*}) => { $($if_true)* };
     ((link_section(c)),           [(link_section=$section:literal), $($rest:tt)*], {$($if_true:tt)*}, {$($if_false:tt)*}) => { #[link_section = $section] $($if_true)* };
 
     // Fallback rules
@@ -239,6 +243,18 @@ macro_rules! __ctor_entry {
         $crate::__support::ctor_entry!(features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=, item=static $ident: $ty = $($item)*);
     };
     (features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
+        $crate::__support::if_has_feature!(anonymous, $features, {
+            $crate::__support::ctor_entry!(unnamed, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+        }, {
+            $crate::__support::ctor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+        });
+    };
+    (unnamed,features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
+        const _: () = {
+            $crate::__support::ctor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+        };
+    };
+    (named, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
         #[cfg(target_family="wasm")]
         $(#[$fnmeta])*
         #[allow(unused)]
@@ -251,11 +267,8 @@ macro_rules! __ctor_entry {
         $(#[$fnmeta])*
         #[allow(unused)]
         $($vis)* $($unsafe)? fn $ident() {
-            #[doc(hidden)]
-            /// Internal module.
-            #[doc = concat!("features=", stringify!($features))]
             #[allow(unsafe_code)]
-            mod __ctor_internal {
+            {
                 $crate::__support::if_unsafe!($($unsafe)?, {}, {
                     $crate::__support::if_has_feature!( __warn_on_missing_unsafe, $features, {
                         #[deprecated="ctor deprecation note:\n\n \
@@ -274,17 +287,17 @@ macro_rules! __ctor_entry {
 
                     #[allow(non_upper_case_globals, non_snake_case)]
                     #[doc(hidden)]
-                    static $ident: /*unsafe*/ extern "C" fn() -> usize =
+                    static f: /*unsafe*/ extern "C" fn() -> usize =
                     {
                         $crate::__support::ctor_link_section!(
                             startup,
                             features=$features,
 
                             #[allow(non_snake_case)]
-                            /*unsafe*/ extern "C" fn $ident() -> usize { unsafe { super::$ident(); 0 } }
+                            /*unsafe*/ extern "C" fn f() -> usize { unsafe { $ident(); 0 } }
                         );
 
-                        $ident
+                        f
                     };
                 );
             }

--- a/shared/tests/errors/ctor_anon.rs
+++ b/shared/tests/errors/ctor_anon.rs
@@ -1,0 +1,21 @@
+
+shared::ctor_parse!(
+    #[ctor(anonymous)]
+    unsafe fn foo() {
+        println!("Hello, world!");
+    }
+);
+
+shared::ctor_parse!(
+    #[ctor]
+    unsafe fn bar() {
+        println!("Hello, world!");
+    }
+);
+
+fn main() {
+    // Disallowed
+    foo();
+    // Allowed
+    bar();
+}

--- a/shared/tests/errors/ctor_anon.stderr
+++ b/shared/tests/errors/ctor_anon.stderr
@@ -1,0 +1,5 @@
+error[E0425]: cannot find function `foo` in this scope
+  --> tests/errors/ctor_anon.rs:18:5
+   |
+18 |     foo();
+   |     ^^^ not found in this scope

--- a/shared/tests/expand-darwin/ctor.expanded.rs
+++ b/shared/tests/expand-darwin/ctor.expanded.rs
@@ -1,24 +1,21 @@
 #[cfg(not(target_family = "wasm"))]
 #[allow(unused)]
 unsafe fn foo() {
-    #[doc(hidden)]
-    /// Internal module.
-    ///features=[]
     #[allow(unsafe_code)]
-    mod __ctor_internal {
+    {
         #[link_section = "__DATA,__mod_init_func"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
-                    super::foo();
+                    foo();
                     0
                 }
             }
-            foo
+            f
         };
     }
     {

--- a/shared/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_anon.expanded.rs
@@ -1,0 +1,56 @@
+const _: () = {
+    #[cfg(not(target_family = "wasm"))]
+    #[allow(unused)]
+    unsafe fn foo() {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = "__DATA,__mod_init_func"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> usize = {
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> usize {
+                    unsafe {
+                        foo();
+                        0
+                    }
+                }
+                f
+            };
+        }
+        {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
+    }
+};
+const _: () = {
+    #[cfg(not(target_family = "wasm"))]
+    #[allow(unused)]
+    unsafe fn foo() {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = "__DATA,__mod_init_func"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> usize = {
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> usize {
+                    unsafe {
+                        foo();
+                        0
+                    }
+                }
+                f
+            };
+        }
+        {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
+    }
+};

--- a/shared/tests/expand-darwin/ctor_anon.rs
+++ b/shared/tests/expand-darwin/ctor_anon.rs
@@ -1,0 +1,13 @@
+shared::ctor_parse!(
+    #[ctor(anonymous)]
+    unsafe fn foo() {
+        println!("foo");
+    }
+);
+
+shared::ctor_parse!(
+    #[ctor(anonymous)]
+    unsafe fn foo() {
+        println!("foo");
+    }
+);

--- a/shared/tests/expand-darwin/ctor_attribute.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_attribute.expanded.rs
@@ -1,25 +1,22 @@
 #[cfg(not(target_family = "wasm"))]
 #[allow(unused)]
 fn foo() {
-    #[doc(hidden)]
-    /// Internal module.
-    ///features=[(link_section = ".ctors"),]
     #[allow(unsafe_code)]
-    mod __ctor_internal {
+    {
         #[link_section = ".ctors"]
         #[allow(unsafe_code)]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
-                    super::foo();
+                    foo();
                     0
                 }
             }
-            foo
+            f
         };
     }
     {

--- a/shared/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_doc.expanded.rs
@@ -3,24 +3,21 @@
 /// Doc 2
 #[allow(unused)]
 unsafe fn foo() {
-    #[doc(hidden)]
-    /// Internal module.
-    ///features=[]
     #[allow(unsafe_code)]
-    mod __ctor_internal {
+    {
         #[link_section = "__DATA,__mod_init_func"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
-                    super::foo();
+                    foo();
                     0
                 }
             }
-            foo
+            f
         };
     }
     {

--- a/shared/tests/expand-darwin/ctor_mutli_attr.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_mutli_attr.expanded.rs
@@ -1,25 +1,22 @@
 #[cfg(not(target_family = "wasm"))]
 #[allow(unused)]
 unsafe fn foo() {
-    #[doc(hidden)]
-    /// Internal module.
-    ///features=[(link_section = ".ctors"), used_linker,]
     #[allow(unsafe_code)]
-    mod __ctor_internal {
+    {
         #[link_section = ".ctors"]
         #[allow(unsafe_code)]
         #[used(linker)]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
-                    super::foo();
+                    foo();
                     0
                 }
             }
-            foo
+            f
         };
     }
     {

--- a/shared/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -1,24 +1,21 @@
 #[cfg(not(target_family = "wasm"))]
 #[allow(unused)]
 unsafe fn foo() {
-    #[doc(hidden)]
-    /// Internal module.
-    ///features=[]
     #[allow(unsafe_code)]
-    mod __ctor_internal {
+    {
         #[link_section = "__DATA,__mod_init_func"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
-                    super::foo();
+                    foo();
                     0
                 }
             }
-            foo
+            f
         };
     }
     {

--- a/shared/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -1,24 +1,21 @@
 #[cfg(not(target_family = "wasm"))]
 #[allow(unused)]
 fn foo() {
-    #[doc(hidden)]
-    /// Internal module.
-    ///features=[used_linker,]
     #[allow(unsafe_code)]
-    mod __ctor_internal {
+    {
         #[link_section = "__DATA,__mod_init_func"]
         #[used(linker)]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
-                    super::foo();
+                    foo();
                     0
                 }
             }
-            foo
+            f
         };
     }
     {

--- a/shared/tests/expand-darwin/ctor_warn.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_warn.expanded.rs
@@ -1,24 +1,21 @@
 #[cfg(not(target_family = "wasm"))]
 #[allow(unused)]
 fn foo() {
-    #[doc(hidden)]
-    /// Internal module.
-    ///features=[]
     #[allow(unsafe_code)]
-    mod __ctor_internal {
+    {
         #[link_section = "__DATA,__mod_init_func"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
-                    super::foo();
+                    foo();
                     0
                 }
             }
-            foo
+            f
         };
     }
     {

--- a/shared/tests/expand-darwin/dtor.expanded.rs
+++ b/shared/tests/expand-darwin/dtor.expanded.rs
@@ -1,27 +1,27 @@
 #[allow(unused)]
 unsafe fn foo() {
     #[allow(unsafe_code)]
-    mod __dtor_internal {
+    {
         #[link_section = "__DATA,__mod_init_func"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
                     do_atexit(__dtor);
                     0
                 }
             }
-            foo
+            f
         };
         extern "C" fn __dtor(#[cfg(target_vendor = "apple")] _: *const u8) {
-            unsafe { super::foo() }
+            unsafe { foo() }
         }
         #[cfg(target_vendor = "apple")]
         #[inline(always)]
-        pub(super) unsafe fn do_atexit(cb: extern "C" fn(_: *const u8)) {
+        unsafe fn do_atexit(cb: extern "C" fn(_: *const u8)) {
             extern "C" {
                 static __dso_handle: *const u8;
                 fn __cxa_atexit(

--- a/shared/tests/expand-darwin/dtor_anon.expanded.rs
+++ b/shared/tests/expand-darwin/dtor_anon.expanded.rs
@@ -1,0 +1,45 @@
+const _: () = {
+    #[allow(unused)]
+    unsafe fn foo() {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = "__DATA,__mod_init_func"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> usize = {
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> usize {
+                    unsafe {
+                        do_atexit(__dtor);
+                        0
+                    }
+                }
+                f
+            };
+            extern "C" fn __dtor(#[cfg(target_vendor = "apple")] _: *const u8) {
+                unsafe { foo() }
+            }
+            #[cfg(target_vendor = "apple")]
+            #[inline(always)]
+            unsafe fn do_atexit(cb: extern "C" fn(_: *const u8)) {
+                extern "C" {
+                    static __dso_handle: *const u8;
+                    fn __cxa_atexit(
+                        cb: extern "C" fn(_: *const u8),
+                        arg: *const u8,
+                        dso_handle: *const u8,
+                    );
+                }
+                unsafe {
+                    __cxa_atexit(cb, core::ptr::null(), __dso_handle);
+                }
+            }
+        }
+        {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
+    }
+};

--- a/shared/tests/expand-darwin/dtor_anon.rs
+++ b/shared/tests/expand-darwin/dtor_anon.rs
@@ -1,0 +1,6 @@
+shared::dtor_parse!(
+    #[dtor(anonymous)]
+    unsafe fn foo() {
+        println!("foo");
+    }
+);

--- a/shared/tests/expand-darwin/dtor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/dtor_doc.expanded.rs
@@ -3,27 +3,27 @@
 #[allow(unused)]
 unsafe fn foo() {
     #[allow(unsafe_code)]
-    mod __dtor_internal {
+    {
         #[link_section = "__DATA,__mod_init_func"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]
-        static foo: extern "C" fn() -> usize = {
+        static f: extern "C" fn() -> usize = {
             #[allow(non_snake_case)]
-            extern "C" fn foo() -> usize {
+            extern "C" fn f() -> usize {
                 unsafe {
                     do_atexit(__dtor);
                     0
                 }
             }
-            foo
+            f
         };
         extern "C" fn __dtor(#[cfg(target_vendor = "apple")] _: *const u8) {
-            unsafe { super::foo() }
+            unsafe { foo() }
         }
         #[cfg(target_vendor = "apple")]
         #[inline(always)]
-        pub(super) unsafe fn do_atexit(cb: extern "C" fn(_: *const u8)) {
+        unsafe fn do_atexit(cb: extern "C" fn(_: *const u8)) {
             extern "C" {
                 static __dso_handle: *const u8;
                 fn __cxa_atexit(

--- a/tests/edition-2024/Cargo.toml
+++ b/tests/edition-2024/Cargo.toml
@@ -3,10 +3,10 @@ name = "tests-edition-2024"
 version = "0.1.0"
 edition = "2024"
 publish = false
+rust-version = "1.85"
 
 [features]
 used_linker = ["ctor/used_linker"]
 
 [dependencies]
 ctor = "*"
-

--- a/tests/system/src/lib.rs
+++ b/tests/system/src/lib.rs
@@ -88,7 +88,10 @@ mod test {
 
         // Move from tests -> root dir so we match the behaviour of running
         // --example
-        let out = cmd.current_dir(&root).output().expect(&format!("failed to run {path:?}"));
+        let out = cmd
+            .current_dir(&root)
+            .output()
+            .expect(&format!("failed to run {path:?}"));
         assert_eq!("", std::str::from_utf8(out.stdout.as_slice()).unwrap());
 
         // Welcome to permutation hell...

--- a/tests/system/src/lib.rs
+++ b/tests/system/src/lib.rs
@@ -89,9 +89,9 @@ mod test {
         // Move from tests -> root dir so we match the behaviour of running
         // --example
         let out = cmd
-            .current_dir(&root)
+            .current_dir(root)
             .output()
-            .expect(&format!("failed to run {path:?}"));
+            .unwrap_or_else(|_| panic!("failed to run {path:?}"));
         assert_eq!("", std::str::from_utf8(out.stdout.as_slice()).unwrap());
 
         // Welcome to permutation hell...


### PR DESCRIPTION
Fully fixes #332 by offering two methods of generating anonymous constructors:

```rust
#[ctor(anonymous)]
unsafe fn foo() { }

/// Allowed because this ctor is anonymous
#[ctor(anonymous)]
unsafe fn foo() { }
```

or

```rust
const _: () = { 
  #[ctor]
  unsafe fn foo() { }
}

const _: () = { 
  #[ctor]
  unsafe fn foo() { }
}
```
