### PR TITLE
Support wasm without wasm_bindgen

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,4 +51,4 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: RUSTFLAGS="-C target-feature=+crt-static" cargo run --example example --target x86_64-unknown-linux-gnu --verbose
     - name: Run Wasm tests
-      run: cargo install wasmtime-cli && cargo build --target wasm32-unknown-unknown -p tests-wasm && wasmtime run target/wasm32-unknown-unknown/debug/tests_wasm.wasm
+      run: cargo install wasmtime-cli && rustup target add wasm32-unknown-unknown && cargo build --target wasm32-unknown-unknown -p tests-wasm && wasmtime run target/wasm32-unknown-unknown/debug/tests_wasm.wasm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,9 +50,5 @@ jobs:
     - name: Build with static CRT
       if: matrix.os == 'ubuntu-latest'
       run: RUSTFLAGS="-C target-feature=+crt-static" cargo run --example example --target x86_64-unknown-linux-gnu --verbose
-    - name: Install wasm-pack
-      if: matrix.os == 'ubuntu-latest'
-      run: cargo install wasm-pack
-    - name: Build Wasm tests
-      if: matrix.os == 'ubuntu-latest'
-      run: wasm-pack build --target web tests/wasm/
+    - name: Run Wasm tests
+      run: cargo install wasmtime-cli && cargo build --target wasm32-unknown-unknown -p tests-wasm && wasmtime run target/wasm32-unknown-unknown/debug/tests_wasm.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,18 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "ctor"
 version = "0.4.1"
 dependencies = [
@@ -133,12 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
 name = "macrotest"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,12 +141,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "once_cell"
-version = "1.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "prettyplease"
@@ -211,12 +187,6 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2 1.0.93",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -347,7 +317,6 @@ name = "tests-wasm"
 version = "0.1.0"
 dependencies = [
  "ctor",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -410,64 +379,6 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
-dependencies = [
- "quote 1.0.38",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
-dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
 
 [[package]]
 name = "winapi"

--- a/tests/wasm/Cargo.toml
+++ b/tests/wasm/Cargo.toml
@@ -8,5 +8,4 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2"
 ctor = "*"

--- a/tests/wasm/src/lib.rs
+++ b/tests/wasm/src/lib.rs
@@ -7,6 +7,7 @@ pub fn init() {
     STATE.fetch_add(1, Ordering::Relaxed);
 }
 
+#[cfg(target_family = "wasm")]
 #[unsafe(no_mangle)]
 pub extern "C" fn _start() {
     assert_eq!(STATE.load(Ordering::Relaxed), 1);

--- a/tests/wasm/src/lib.rs
+++ b/tests/wasm/src/lib.rs
@@ -1,13 +1,13 @@
-#[cfg(target_family = "wasm")]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static STATE: AtomicUsize = AtomicUsize::new(0);
+
 #[ctor::ctor]
-unsafe fn hello() {
-    use wasm_bindgen::prelude::wasm_bindgen;
+pub fn init() {
+    STATE.fetch_add(1, Ordering::Relaxed);
+}
 
-    #[wasm_bindgen]
-    extern "C" {
-        #[wasm_bindgen(js_namespace = console)]
-        fn log(s: &str);
-    }
-
-    log("hello!");
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() {
+    assert_eq!(STATE.load(Ordering::Relaxed), 1);
 }


### PR DESCRIPTION
closes: https://github.com/mmastrac/rust-ctor/issues/336

You can test with: 
```rs
use ctor::ctor;

#[ctor]
pub fn init() {
    println!("Hello");
}

#[unsafe(no_mangle)]
pub extern "C" fn _start() {
    println!("Start");
}
```

```sh
cargo build --target wasm32-wasip1
wasmer run target/wasm32-wasip1/debug/xxx.wasm
```

But according to [inventory](https://github.com/dtolnay/inventory/blob/5e915d4d197432b73375ad21e08a1ee8275d8309/src/lib.rs#L543), `.init_array` only support wasm after rust 1.85 stable. We should check this and provide a fallback strategy(`wasm_bindgen` or panic).

Any suggestion?