### PR TITLE
README.md: mismatched closing delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The above example translates into the following Rust code (approximately):
 
 ```rust
     #[used]
-    #[cfg_attr(target_os = "linux"), link_section = ".init_array")]
+    #[cfg_attr(target_os = "linux", link_section = ".init_array")]
     #[cfg_attr(target_vendor = "apple", link_section = "__DATA,__mod_init_func")]
     #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
     /* ... other platforms elided ... */


### PR DESCRIPTION
just an one-char typo