### PR TITLE
Add macOS `mod_init_funcs` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The above example translates into the following Rust code (approximately):
 ```rust
     #[used]
     #[cfg_attr(target_os = "linux", link_section = ".init_array")]
-    #[cfg_attr(target_vendor = "apple", link_section = "__DATA,__mod_init_func")]
+    #[cfg_attr(target_vendor = "apple", link_section = "__DATA,__mod_init_func,mod_init_funcs")]
     #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
     /* ... other platforms elided ... */
     static FOO: extern fn() = {

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -170,7 +170,7 @@ pub mod declarative {
 /// # fn my_init_fn() {}
 /// #[used]
 /// #[cfg_attr(target_os = "linux", link_section = ".init_array")]
-/// #[cfg_attr(target_vendor = "apple", link_section = "__DATA,__mod_init_func")]
+/// #[cfg_attr(target_vendor = "apple", link_section = "__DATA,__mod_init_func,mod_init_funcs")]
 /// #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
 /// /* ... other platforms elided ... */
 /// static INIT_FN: extern fn() = {

--- a/shared/src/macros/mod.rs
+++ b/shared/src/macros/mod.rs
@@ -530,7 +530,7 @@ macro_rules! __ctor_link_section_attr {
                     target_os = "haiku",
                     target_family = "wasm"
                 ), ".init_array"],
-                [target_vendor = "apple", "__DATA,__mod_init_func"],
+                [target_vendor = "apple", "__DATA,__mod_init_func,mod_init_funcs"],
                 [windows, ".CRT$XCU"]],
                 #[$used]
                 $item

--- a/shared/tests/expand-darwin/ctor.expanded.rs
+++ b/shared/tests/expand-darwin/ctor.expanded.rs
@@ -2,7 +2,7 @@
 unsafe fn foo() {
     #[allow(unsafe_code)]
     {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]

--- a/shared/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_anon.expanded.rs
@@ -3,7 +3,7 @@ const _: () = {
     unsafe fn foo() {
         #[allow(unsafe_code)]
         {
-            #[link_section = "__DATA,__mod_init_func"]
+            #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
             #[used]
             #[allow(non_upper_case_globals, non_snake_case)]
             #[doc(hidden)]
@@ -30,7 +30,7 @@ const _: () = {
     unsafe fn foo() {
         #[allow(unsafe_code)]
         {
-            #[link_section = "__DATA,__mod_init_func"]
+            #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
             #[used]
             #[allow(non_upper_case_globals, non_snake_case)]
             #[doc(hidden)]

--- a/shared/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_doc.expanded.rs
@@ -4,7 +4,7 @@
 unsafe fn foo() {
     #[allow(unsafe_code)]
     {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]

--- a/shared/tests/expand-darwin/ctor_static.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_static.expanded.rs
@@ -2,7 +2,7 @@ static STATIC_CTOR: STATIC_CTOR::Static<HashMap<u32, &'static str>> = STATIC_CTO
     HashMap<u32, &'static str>,
 > {
     _storage: {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]

--- a/shared/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -2,7 +2,7 @@
 unsafe fn foo() {
     #[allow(unsafe_code)]
     {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]

--- a/shared/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -2,7 +2,7 @@
 fn foo() {
     #[allow(unsafe_code)]
     {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used(linker)]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]

--- a/shared/tests/expand-darwin/ctor_warn.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_warn.expanded.rs
@@ -2,7 +2,7 @@
 fn foo() {
     #[allow(unsafe_code)]
     {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]

--- a/shared/tests/expand-darwin/dtor.expanded.rs
+++ b/shared/tests/expand-darwin/dtor.expanded.rs
@@ -2,7 +2,7 @@
 unsafe fn foo() {
     #[allow(unsafe_code)]
     {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]

--- a/shared/tests/expand-darwin/dtor_anon.expanded.rs
+++ b/shared/tests/expand-darwin/dtor_anon.expanded.rs
@@ -3,7 +3,7 @@ const _: () = {
     unsafe fn foo() {
         #[allow(unsafe_code)]
         {
-            #[link_section = "__DATA,__mod_init_func"]
+            #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
             #[used]
             #[allow(non_upper_case_globals, non_snake_case)]
             #[doc(hidden)]

--- a/shared/tests/expand-darwin/dtor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/dtor_doc.expanded.rs
@@ -4,7 +4,7 @@
 unsafe fn foo() {
     #[allow(unsafe_code)]
     {
-        #[link_section = "__DATA,__mod_init_func"]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
         #[allow(non_upper_case_globals, non_snake_case)]
         #[doc(hidden)]


### PR DESCRIPTION
`ctor` fails to run on cranelift partially because it is missing an explicit link section flag: https://github.com/rust-lang/rustc_codegen_cranelift/issues/1588#issuecomment-3047959818

The fully-correct link section should be `__DATA,__mod_init_func,mod_init_funcs`

Partial fix for #339