### PR TITLE
refactor: use `::core` instead of `core`

### DIFF
--- a/shared/src/macros/mod.rs
+++ b/shared/src/macros/mod.rs
@@ -295,8 +295,8 @@ macro_rules! __ctor_entry {
 
             #[cfg(target_family = "wasm")]
             {
-                static __CTOR__INITILIZED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
-                if __CTOR__INITILIZED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+                static __CTOR__INITILIZED: ::core::sync::atomic::AtomicBool = ::core::sync::atomic::AtomicBool::new(false);
+                if __CTOR__INITILIZED.swap(true, ::core::sync::atomic::Ordering::Relaxed) {
                     return;
                 }
             }
@@ -438,7 +438,7 @@ macro_rules! __dtor_entry {
                         fn __cxa_atexit(cb: /*unsafe*/ extern "C" fn(_: *const u8), arg: *const u8, dso_handle: *const u8);
                     }
                     unsafe {
-                        __cxa_atexit(cb, core::ptr::null(), __dso_handle);
+                        __cxa_atexit(cb, ::core::ptr::null(), __dso_handle);
                     }
                 }
             }
@@ -468,7 +468,7 @@ macro_rules! __ctor_call {
                     #[allow(non_snake_case)]
                     /*unsafe*/ extern "C" fn f() -> $crate::__support::CtorRetType {
                         $($block)+;
-                        core::default::Default::default()
+                        ::core::default::Default::default()
                     }
                 );
 

--- a/shared/tests/expand-darwin/ctor.expanded.rs
+++ b/shared/tests/expand-darwin/ctor.expanded.rs
@@ -12,7 +12,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_anon.expanded.rs
@@ -13,7 +13,7 @@ const _: () = {
                     unsafe {
                         foo();
                     };
-                    core::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 f
             };
@@ -40,7 +40,7 @@ const _: () = {
                     unsafe {
                         foo();
                     };
-                    core::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 f
             };

--- a/shared/tests/expand-darwin/ctor_attribute.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_attribute.expanded.rs
@@ -13,7 +13,7 @@ fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_doc.expanded.rs
@@ -14,7 +14,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/ctor_mutli_attr.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_mutli_attr.expanded.rs
@@ -13,7 +13,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/ctor_static.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_static.expanded.rs
@@ -10,7 +10,7 @@ static STATIC_CTOR: STATIC_CTOR::Static<HashMap<u32, &'static str>> = STATIC_CTO
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::shared::__support::CtorRetType {
                 _ = &*STATIC_CTOR;
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -12,7 +12,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -12,7 +12,7 @@ fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/ctor_warn.expanded.rs
+++ b/shared/tests/expand-darwin/ctor_warn.expanded.rs
@@ -12,7 +12,7 @@ fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-darwin/dtor.expanded.rs
+++ b/shared/tests/expand-darwin/dtor.expanded.rs
@@ -12,7 +12,7 @@ unsafe fn foo() {
                 unsafe {
                     do_atexit(__dtor);
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };
@@ -30,7 +30,7 @@ unsafe fn foo() {
                 );
             }
             unsafe {
-                __cxa_atexit(cb, core::ptr::null(), __dso_handle);
+                __cxa_atexit(cb, ::core::ptr::null(), __dso_handle);
             }
         }
     }

--- a/shared/tests/expand-darwin/dtor_anon.expanded.rs
+++ b/shared/tests/expand-darwin/dtor_anon.expanded.rs
@@ -13,7 +13,7 @@ const _: () = {
                     unsafe {
                         do_atexit(__dtor);
                     };
-                    core::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 f
             };
@@ -31,7 +31,7 @@ const _: () = {
                     );
                 }
                 unsafe {
-                    __cxa_atexit(cb, core::ptr::null(), __dso_handle);
+                    __cxa_atexit(cb, ::core::ptr::null(), __dso_handle);
                 }
             }
         }

--- a/shared/tests/expand-darwin/dtor_doc.expanded.rs
+++ b/shared/tests/expand-darwin/dtor_doc.expanded.rs
@@ -14,7 +14,7 @@ unsafe fn foo() {
                 unsafe {
                     do_atexit(__dtor);
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };
@@ -32,7 +32,7 @@ unsafe fn foo() {
                 );
             }
             unsafe {
-                __cxa_atexit(cb, core::ptr::null(), __dso_handle);
+                __cxa_atexit(cb, ::core::ptr::null(), __dso_handle);
             }
         }
     }

--- a/shared/tests/expand-linux/ctor.expanded.rs
+++ b/shared/tests/expand-linux/ctor.expanded.rs
@@ -13,7 +13,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/ctor_anon.expanded.rs
+++ b/shared/tests/expand-linux/ctor_anon.expanded.rs
@@ -14,7 +14,7 @@ const _: () = {
                     unsafe {
                         foo();
                     };
-                    core::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 f
             };
@@ -42,7 +42,7 @@ const _: () = {
                     unsafe {
                         foo();
                     };
-                    core::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 f
             };

--- a/shared/tests/expand-linux/ctor_attribute.expanded.rs
+++ b/shared/tests/expand-linux/ctor_attribute.expanded.rs
@@ -14,7 +14,7 @@ fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/ctor_doc.expanded.rs
+++ b/shared/tests/expand-linux/ctor_doc.expanded.rs
@@ -15,7 +15,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/ctor_mutli_attr.expanded.rs
+++ b/shared/tests/expand-linux/ctor_mutli_attr.expanded.rs
@@ -14,7 +14,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/ctor_static.expanded.rs
+++ b/shared/tests/expand-linux/ctor_static.expanded.rs
@@ -11,7 +11,7 @@ static STATIC_CTOR: STATIC_CTOR::Static<HashMap<u32, &'static str>> = STATIC_CTO
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::shared::__support::CtorRetType {
                 _ = &*STATIC_CTOR;
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/ctor_unsafe.expanded.rs
+++ b/shared/tests/expand-linux/ctor_unsafe.expanded.rs
@@ -13,7 +13,7 @@ unsafe fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/ctor_used_linker_attr.expanded.rs
+++ b/shared/tests/expand-linux/ctor_used_linker_attr.expanded.rs
@@ -13,7 +13,7 @@ fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/ctor_warn.expanded.rs
+++ b/shared/tests/expand-linux/ctor_warn.expanded.rs
@@ -13,7 +13,7 @@ fn foo() {
                 unsafe {
                     foo();
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/dtor.expanded.rs
+++ b/shared/tests/expand-linux/dtor.expanded.rs
@@ -13,7 +13,7 @@ unsafe fn foo() {
                 unsafe {
                     do_atexit(__dtor);
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };

--- a/shared/tests/expand-linux/dtor_anon.expanded.rs
+++ b/shared/tests/expand-linux/dtor_anon.expanded.rs
@@ -14,7 +14,7 @@ const _: () = {
                     unsafe {
                         do_atexit(__dtor);
                     };
-                    core::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 f
             };

--- a/shared/tests/expand-linux/dtor_doc.expanded.rs
+++ b/shared/tests/expand-linux/dtor_doc.expanded.rs
@@ -15,7 +15,7 @@ unsafe fn foo() {
                 unsafe {
                     do_atexit(__dtor);
                 };
-                core::default::Default::default()
+                ::core::default::Default::default()
             }
             f
         };


### PR DESCRIPTION
Same reason as #296, we have a `core` module which interferes with `core::default::Default::default()`; prefix as `::core` to avoid this clash.