### PR TITLE
Miri hardening

### DIFF
--- a/.github/jobs/build.sh
+++ b/.github/jobs/build.sh
@@ -3,5 +3,6 @@ set -xeuo pipefail
 
 # Remove Cargo.lock for testing down-level Rust versions
 rm Cargo.lock
-cargo build
+# May need to rebuild when beta/nightly changes
+cargo build || (cargo clean && cargo build)
 cargo run -p ctor --example example

--- a/.github/jobs/build.sh
+++ b/.github/jobs/build.sh
@@ -4,5 +4,6 @@ set -xeuo pipefail
 # Remove Cargo.lock for testing down-level Rust versions
 rm Cargo.lock
 # May need to rebuild when beta/nightly changes
-cargo build || (cargo clean && cargo build)
+cargo clean
+cargo build
 cargo run -p ctor --example example

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -3,6 +3,8 @@ set -xeuo pipefail
 
 # https://blog.rust-lang.org/2022/09/15/const-eval-safety-rule-revision/
 export RUSTFLAGS="-Z extra-const-ub-checks"
+# https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance
+export MIRIFLAGS="-Zmiri-permissive-provenance"
 
 cargo miri test
 

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -12,6 +12,10 @@ cd tests/ctor/edition-2018
 cargo miri run
 cd ../../..
 
+cd tests/ctor/priority
+cargo miri run
+cd ../../..
+
 cd tests/link_section/basic
 cargo miri run
 cd ../../..

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+cargo miri test
+
 cd tests/ctor/edition-2018
 cargo miri run
-cargo miri test

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+# https://blog.rust-lang.org/2022/09/15/const-eval-safety-rule-revision/
+export RUSTFLAGS="-Z extra-const-ub-checks"
+
 cargo miri test
 
 cd tests/ctor/edition-2018

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -3,3 +3,4 @@ set -xeuo pipefail
 
 cd tests/ctor/edition-2018
 cargo miri run
+cargo miri test

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -8,5 +8,5 @@ cargo miri run
 cd ../../..
 
 cd tests/link_section/basic
-cargo miri test
+cargo miri run
 cd ../../..

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -5,3 +5,8 @@ cargo miri test
 
 cd tests/ctor/edition-2018
 cargo miri run
+cd ../../..
+
+cd tests/link_section/basic
+cargo miri test
+cd ../../..

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
                 job: [lint, test, miri]
               windows:
                 os: windows-latest
-                job: [lint, test]
+                job: [lint, test, miri]
           config: |
             github: ${{ toJSON(github) }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -173,33 +173,34 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
+checksum = "c1c888a2a4f677017373fb6c01e13e318dd9e78758445ed5eb985e355d3f8281"
 dependencies = [
- "ctor-proc-macro 0.0.7",
- "dtor 0.3.0",
+ "ctor-proc-macro 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtor 0.6.0",
+ "link-section 0.0.12",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ctor-proc-macro 0.0.12",
- "dtor 0.6.0",
+ "dtor 0.7.0",
  "libc-print",
- "link-section",
+ "link-section 0.2.0",
 ]
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+version = "0.0.12"
 
 [[package]]
 name = "ctor-proc-macro"
 version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
 
 [[package]]
 name = "derive-io"
@@ -271,16 +272,16 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+checksum = "30e4690622ab6700ced40fc370a3f07b7d111f0154bb6fb08f73b4c8834f75b6"
 dependencies = [
- "dtor-proc-macro 0.0.6",
+ "dtor-proc-macro 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "dtor"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dtor-proc-macro 0.0.12",
  "libc-print",
@@ -288,13 +289,13 @@ dependencies = [
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+version = "0.0.12"
 
 [[package]]
 name = "dtor-proc-macro"
 version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131"
 
 [[package]]
 name = "dunce"
@@ -396,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -426,12 +427,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -480,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -490,6 +491,12 @@ dependencies = [
 [[package]]
 name = "link-section"
 version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52437d47b0358721ec869cc7374b2a21f7b2237af9b439c0391341a1fbfbf1b"
+
+[[package]]
+name = "link-section"
+version = "0.2.0"
 dependencies = [
  "link-section-proc-macro",
 ]
@@ -613,9 +620,9 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "prettyplease"
@@ -780,8 +787,8 @@ dependencies = [
 name = "shared"
 version = "0.1.0"
 dependencies = [
- "ctor 0.8.0",
- "link-section",
+ "ctor 0.9.1",
+ "link-section 0.2.0",
  "macrotest",
  "trybuild",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ repository = "https://github.com/mmastrac/rust-ctor"
 
 [workspace.dependencies]
 ctor = { path = "ctor", default-features = false }
-dtor = { path = "dtor", version = "0.6.0", default-features = false }
-link-section = { path = "link-section", version = "=0.0.12", default-features = false }
+dtor = { path = "dtor", version = "0.7.0", default-features = false }
+link-section = { path = "link-section", version = "0.2.0", default-features = false }
 
 # Bump all these together
 dtor-proc-macro = { path = "dtor-proc-macro", version = "=0.0.12" }

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "0.9.1"
+version = "0.10.0"
 authors.workspace = true
 edition = "2021"
 description = "__attribute__((constructor)) for Rust"

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -34,7 +34,7 @@ pub use macros::features;
 /// macros.
 ///
 /// ```rust
-/// # mod test { use ctor::*; use libc_print::*;
+/// # mod test { use ctor::*; use libc_print::*; #[cfg(all(miri, windows))] use println as libc_println;
 /// ctor::declarative::ctor! {
 ///   #[ctor]
 ///   fn foo() {

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -106,8 +106,8 @@ pub mod declarative {
 ///
 /// ```rust
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
-/// # use ctor::*;
 /// # #[cfg(not(miri))] mod test {
+/// # use ctor::ctor;
 /// use libc_print::std_name::println;
 ///
 /// #[ctor(unsafe)]

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -34,7 +34,7 @@ pub use macros::features;
 /// macros.
 ///
 /// ```rust
-/// # mod test { use ctor::*; use libc_print::*; #[cfg(all(miri, windows))] use println as libc_println;
+/// # #[cfg(not(miri))] mod test { use ctor::*; use libc_print::*;
 /// ctor::declarative::ctor! {
 ///   #[ctor]
 ///   fn foo() {
@@ -108,6 +108,7 @@ pub mod declarative {
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
 /// # extern crate ctor;
 /// # use ctor::*;
+/// # #[cfg(not(miri))] mod test {
 /// use libc_print::std_name::println;
 ///
 /// #[ctor(unsafe)]
@@ -118,7 +119,7 @@ pub mod declarative {
 ///
 /// # fn main() {
 /// println!("main()");
-/// # }
+/// # }}
 /// ```
 ///
 /// Make changes to `static` variables:

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -74,10 +74,10 @@ pub mod declarative {
 /// Multiple startup functions/statics are supported, but the invocation order
 /// is not guaranteed.
 ///
-/// The `ctor` crate assumes it is available as a direct dependency, with
-/// `extern crate ctor`. If you re-export `ctor` items as part of your crate,
-/// you can use the `crate_path` parameter to redirect the macro's output to the
-/// correct crate.
+/// The `ctor` crate assumes it is available as a direct dependency, If you
+/// re-export `ctor` items as part of your crate, you can use the `crate_path`
+/// parameter to redirect the macro's output to the correct crate, or use the
+/// [`declarative::ctor`] form.
 ///
 /// # Attribute parameters
 ///
@@ -106,7 +106,6 @@ pub mod declarative {
 ///
 /// ```rust
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
-/// # extern crate ctor;
 /// # use ctor::*;
 /// # #[cfg(not(miri))] mod test {
 /// use libc_print::std_name::println;
@@ -126,7 +125,6 @@ pub mod declarative {
 ///
 /// ```rust
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
-/// # extern crate ctor;
 /// # mod test {
 /// # use ctor::*;
 /// # use std::sync::atomic::{AtomicBool, Ordering};
@@ -143,7 +141,6 @@ pub mod declarative {
 ///
 /// ```rust
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
-/// # extern crate ctor;
 /// # mod test {
 /// # use std::collections::HashMap;
 /// # use ctor::*;
@@ -169,7 +166,6 @@ pub mod declarative {
 ///
 /// ```rust
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
-/// # extern crate ctor;
 /// # mod test {
 /// # use ctor::*;
 /// #[ctor(unsafe)]
@@ -199,7 +195,6 @@ pub mod declarative {
 /// default `std` feature.
 ///
 /// ```rust
-/// # extern crate ctor;
 /// # mod test {
 /// # use ctor::*;
 /// # use std::collections::HashMap;
@@ -218,7 +213,6 @@ pub mod declarative {
 /// which eagerly initializes the `HashMap` inside a `OnceLock` at startup time:
 ///
 /// ```rust
-/// # extern crate ctor;
 /// # mod test {
 /// # use ctor::ctor;
 /// # use std::collections::HashMap;

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -45,7 +45,7 @@ pub use macros::features;
 ///
 /// // ... the above is identical to:
 ///
-/// # mod test_2 { use ctor::*; use libc_print::*;
+/// # #[cfg(not(miri))] mod test_2 { use ctor::*; use libc_print::*;
 /// #[ctor]
 /// fn foo() {
 ///   libc_println!("Hello, world!");

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtor"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 edition = "2021"
 description = "__attribute__((destructor)) for Rust"

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -32,7 +32,6 @@ pub use macros::__support;
 ///
 /// ```rust
 /// # #![cfg_attr(feature="used_linker", feature(used_with_arg))]
-/// # extern crate dtor;
 /// # use dtor::dtor;
 /// # fn main() {}
 ///

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.0.12"
+version = "0.2.0"
 authors.workspace = true
 edition = "2021"
 description = "Low-level link-section macro support for Rust"

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -286,71 +286,92 @@ pub mod __support {
     }
 
     #[cfg(all(miri, target_vendor = "apple"))]
-    #[doc(hidden)]
-    #[macro_export]
-    macro_rules! __get_section {
-        (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
-            // Disable link sections for miri (`extern static `␁section$start$__DATA$CTOR` is not supported by Miri`)
-            {
-                extern "C" {
-                    #[no_mangle]
-                    pub fn getsectbyname(segname: *const u8, sectname: *const u8) -> *const u8;
-                }
-                // unsafe { getsectbyname(b"__DATA\0".as_ptr(), b"section$start$__DATA$CTOR\0".as_ptr()) };
+    mod section {
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! __get_section {
+            (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
+                // Disable link sections for miri (`extern static `␁section$start$__DATA$CTOR` is not supported by Miri`)
+                {
+                    extern "C" {
+                        #[no_mangle]
+                        pub fn getsectbyname(segname: *const u8, sectname: *const u8) -> *const u8;
+                    }
+                    // unsafe { getsectbyname(b"__DATA\0".as_ptr(), b"section$start$__DATA$CTOR\0".as_ptr()) };
 
-                (std::ptr::null_mut(), std::ptr::null_mut())
-            }
-        };
+                    (std::ptr::null_mut(), std::ptr::null_mut())
+                }
+            };
+        }
+
+        /// On Apple platforms, the linker provides a pointer to the start and end
+        /// of the section regardless of the section's name.
+        pub type SectionPtr<T> = *const ::core::marker::PhantomData<T>;
     }
 
     #[cfg(target_family = "wasm")]
-    #[doc(hidden)]
-    #[macro_export]
-    macro_rules! __get_section {
-        (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
-            {
-                static __START: ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>> = unsafe {
-                    ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>>::new(::core::ptr::null_mut())
-                };
-                static __END: ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>> = unsafe {
-                    ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>>::new(::core::ptr::null_mut())
-                };
+    mod section {
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! __get_section {
+            (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
+                {
+                    static __START: ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>> = unsafe {
+                        ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>>::new(::core::ptr::null_mut())
+                    };
+                    static __END: ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>> = unsafe {
+                        ::core::sync::atomic::AtomicPtr::<::core::marker::PhantomData<$generic_ty>>::new(::core::ptr::null_mut())
+                    };
 
-                $crate::__support::ident_concat!((#[no_mangle]pub extern "C" fn) (register_link_section_ $ident) ((data_ptr: *const u8, data_len: usize) {
-                    unsafe {
-                        __START.store(data_ptr as *mut ::core::marker::PhantomData<$generic_ty>, ::core::sync::atomic::Ordering::Relaxed);
-                        __END.store(data_ptr.add(data_len) as *mut ::core::marker::PhantomData<$generic_ty>, ::core::sync::atomic::Ordering::Relaxed);
-                    }
-                }));
+                    $crate::__support::ident_concat!((#[no_mangle]pub extern "C" fn) (register_link_section_ $ident) ((data_ptr: *const u8, data_len: usize) {
+                        unsafe {
+                            __START.store(data_ptr as *mut ::core::marker::PhantomData<$generic_ty>, ::core::sync::atomic::Ordering::Relaxed);
+                            __END.store(data_ptr.add(data_len) as *mut ::core::marker::PhantomData<$generic_ty>, ::core::sync::atomic::Ordering::Relaxed);
+                        }
+                    }));
 
-                (&__START, &__END)
+                    (&__START, &__END)
+                }
             }
         }
+
+        /// On WASM, we use an atomic pointer to the start and end of the
+        /// section. The host environment is responsible for registering the
+        /// section with the runtime.
+        pub type SectionPtr<T> =
+            &'static ::core::sync::atomic::AtomicPtr<::core::marker::PhantomData<T>>;
     }
 
     #[cfg(target_vendor = "pc")]
-    #[doc(hidden)]
-    #[macro_export]
-    macro_rules! __get_section {
-        (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
-            {
-                $crate::__support::add_section_link_attribute!(
-                    data start $ident $($aux)?
-                    #[link_section = __]
-                    static __START: [$generic_ty; 0] = [];
-                );
-                $crate::__support::add_section_link_attribute!(
-                    data end $ident $($aux)?
-                    #[link_section = __]
-                    static __END: [$generic_ty; 0] = [];
-                );
+    mod section {
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! __get_section {
+            (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
+                {
+                    $crate::__support::add_section_link_attribute!(
+                        data start $ident $($aux)?
+                        #[link_section = __]
+                        static __START: [$generic_ty; 0] = [];
+                    );
+                    $crate::__support::add_section_link_attribute!(
+                        data end $ident $($aux)?
+                        #[link_section = __]
+                        static __END: [$generic_ty; 0] = [];
+                    );
 
-                (
-                    unsafe { &raw const __START as $crate::__support::SectionPtr<$generic_ty> },
-                    unsafe { &raw const __END as $crate::__support::SectionPtr<$generic_ty> },
-                )
+                    (
+                        unsafe { &raw const __START as $crate::__support::SectionPtr<$generic_ty> },
+                        unsafe { &raw const __END as $crate::__support::SectionPtr<$generic_ty> },
+                    )
+                }
             }
         }
+
+        /// On Windows platforms we don't have start/end symbols, but we do have
+        /// section sorting so we drop a [T; 0] at the start and end of the
+        /// section.
+        pub type SectionPtr<T> = *const [T; 0];
     }
 
     #[cfg(all(
@@ -358,32 +379,38 @@ pub mod __support {
         not(target_family = "wasm"),
         not(target_vendor = "pc")
     ))]
-    #[doc(hidden)]
-    #[macro_export]
-    macro_rules! __get_section {
-        (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
-            {
-                extern "C" {
-                    $crate::__support::add_section_link_attribute!(
-                        data start $ident $($aux)?
-                        #[link_name = __]
-                        static __START: $crate::__support::SectionPtr<$generic_ty>;
-                    );
-                }
-                extern "C" {
-                    $crate::__support::add_section_link_attribute!(
-                        data end $ident $($aux)?
-                        #[link_name = __]
-                        static __END: $crate::__support::SectionPtr<$generic_ty>;
-                    );
-                }
+    mod section {
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! __get_section {
+            (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
+                {
+                    extern "C" {
+                        $crate::__support::add_section_link_attribute!(
+                            data start $ident $($aux)?
+                            #[link_name = __]
+                            static __START: $crate::__support::SectionPtr<$generic_ty>;
+                        );
+                    }
+                    extern "C" {
+                        $crate::__support::add_section_link_attribute!(
+                            data end $ident $($aux)?
+                            #[link_name = __]
+                            static __END: $crate::__support::SectionPtr<$generic_ty>;
+                        );
+                    }
 
-                (
-                    unsafe { &raw const __START as $crate::__support::SectionPtr<$generic_ty> },
-                    unsafe { &raw const __END as $crate::__support::SectionPtr<$generic_ty> },
-                )
+                    (
+                        unsafe { &raw const __START as $crate::__support::SectionPtr<$generic_ty> },
+                        unsafe { &raw const __END as $crate::__support::SectionPtr<$generic_ty> },
+                    )
+                }
             }
         }
+
+        /// On LLVM/GCC platforms we can use orphan sections with _start and
+        /// _end symbols.
+        pub type SectionPtr<T> = *const ::core::marker::PhantomData<T>;
     }
 
     /// Export a symbol into a link section.
@@ -530,19 +557,7 @@ pub mod __support {
         type Item = T;
     }
 
-    /// On Apple platforms, the linker provides a pointer to the start and end
-    /// of the section regardless of the section's name.
-    #[cfg(all(not(target_vendor = "pc"), not(target_family = "wasm")))]
-    pub type SectionPtr<T> = *const ::core::marker::PhantomData<T>;
-    /// On LLVM/GCC/MSVC platforms, we cannot use start/end symbols for sections
-    /// without C-compatible names, so instead we drop a [T; 0] at the start and
-    /// end of the section.
-    #[cfg(target_vendor = "pc")]
-    pub type SectionPtr<T> = *const [T; 0];
-    /// On WASM, we use an atomic pointer to the start and end of the section.
-    #[cfg(target_family = "wasm")]
-    pub type SectionPtr<T> =
-        &'static ::core::sync::atomic::AtomicPtr<::core::marker::PhantomData<T>>;
+    pub use section::SectionPtr;
 }
 
 /// Define a link section.

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -723,6 +723,14 @@ impl<T: 'static> TypedSection<T> {
 #[cfg(not(target_family = "wasm"))]
 impl<T: 'static> TypedSection<T> {
     /// The start address of the section.
+    #[cfg(miri)]
+    pub fn start_ptr(&self) -> *const T {
+        // Wash away provenance for Miri
+        self.start_ptr() as usize as *const T
+    }
+
+    /// The start address of the section.
+    #[cfg(not(miri))]
     pub fn start_ptr(&self) -> *const T {
         self.start as *const T
     }

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -300,7 +300,7 @@ pub mod __support {
         pub type SectionPtr<T> = *const ::core::marker::PhantomData<T>;
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(miri), target_family = "wasm"))]
     mod section {
         #[doc(hidden)]
         #[macro_export]
@@ -333,7 +333,7 @@ pub mod __support {
             &'static ::core::sync::atomic::AtomicPtr<::core::marker::PhantomData<T>>;
     }
 
-    #[cfg(target_vendor = "pc")]
+    #[cfg(all(not(miri), target_vendor = "pc"))]
     mod section {
         #[doc(hidden)]
         #[macro_export]
@@ -365,7 +365,7 @@ pub mod __support {
         pub type SectionPtr<T> = *const [T; 0];
     }
 
-    #[cfg(all(not(target_family = "wasm"), not(target_vendor = "pc")))]
+    #[cfg(all(not(miri), not(target_family = "wasm"), not(target_vendor = "pc")))]
     mod section {
         #[doc(hidden)]
         #[macro_export]
@@ -606,15 +606,7 @@ impl Section {
 
     /// The byte length of the section.
     pub fn byte_len(&self) -> usize {
-        // Wash away provenance for Miri
-        #[cfg(miri)]
-        {
-            return self.end_ptr() as usize - self.start_ptr() as usize;
-        }
-        #[cfg(not(miri))]
-        unsafe {
-            (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize
-        }
+        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
     }
 }
 
@@ -711,21 +703,11 @@ impl<T: 'static> TypedSection<T> {
 impl<T: 'static> TypedSection<T> {
     /// The start address of the section.
     pub fn start_ptr(&self) -> *const T {
-        // Wash away provenance for Miri
-        #[cfg(miri)]
-        {
-            return self.start as usize as *const T;
-        }
         self.start as usize as *const T
     }
 
     /// The end address of the section.
     pub fn end_ptr(&self) -> *const T {
-        // Wash away provenance for Miri
-        #[cfg(miri)]
-        {
-            return self.end as usize as *const T;
-        }
         self.end as *const T
     }
 }
@@ -757,15 +739,7 @@ impl<T: 'static> TypedSection<T> {
 
     /// The byte length of the section.
     pub fn byte_len(&self) -> usize {
-        // Wash away provenance for Miri
-        #[cfg(miri)]
-        {
-            return self.end_ptr() as usize - self.start_ptr() as usize;
-        }
-        #[cfg(not(miri))]
-        unsafe {
-            (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize
-        }
+        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
     }
 
     /// The number of elements in the section.

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -290,11 +290,9 @@ pub mod __support {
         #[doc(hidden)]
         #[macro_export]
         macro_rules! __get_section {
-            (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
-                {
-                    (std::ptr::null_mut(), std::ptr::null_mut())
-                }
-            };
+            (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {{
+                (std::ptr::null_mut(), std::ptr::null_mut())
+            }};
         }
 
         /// On Apple platforms, the linker provides a pointer to the start and end
@@ -367,10 +365,7 @@ pub mod __support {
         pub type SectionPtr<T> = *const [T; 0];
     }
 
-    #[cfg(all(
-        not(target_family = "wasm"),
-        not(target_vendor = "pc")
-    ))]
+    #[cfg(all(not(target_family = "wasm"), not(target_vendor = "pc")))]
     mod section {
         #[doc(hidden)]
         #[macro_export]

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -353,7 +353,11 @@ pub mod __support {
         }
     }
 
-    #[cfg(all(not(all(miri, target_vendor = "apple")), not(target_family = "wasm"), not(target_vendor = "pc")))]
+    #[cfg(all(
+        not(all(miri, target_vendor = "apple")),
+        not(target_family = "wasm"),
+        not(target_vendor = "pc")
+    ))]
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __get_section {

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -622,10 +622,12 @@ impl Section {
         // Wash away provenance for Miri
         #[cfg(miri)]
         {
-            return unsafe { self.end_ptr() as usize - self.start_ptr() as usize };
+            return self.end_ptr() as usize - self.start_ptr() as usize;
         }
         #[cfg(not(miri))]
-        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
+        unsafe {
+            (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize
+        }
     }
 }
 

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -619,6 +619,12 @@ impl Section {
 
     /// The byte length of the section.
     pub fn byte_len(&self) -> usize {
+        // Wash away provenance for Miri
+        #[cfg(miri)]
+        {
+            return unsafe { self.end_ptr() as usize - self.start_ptr() as usize };
+        }
+        #[cfg(not(miri))]
         unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
     }
 }

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -285,7 +285,7 @@ pub mod __support {
         };
     }
 
-    #[cfg(miri)]
+    #[cfg(all(miri, target_vendor = "apple"))]
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __get_section {
@@ -296,14 +296,14 @@ pub mod __support {
                     #[no_mangle]
                     pub fn getsectbyname(segname: *const u8, sectname: *const u8) -> *const u8;
                 }
-                unsafe { getsectbyname(b"__DATA\0".as_ptr(), b"section$start$__DATA$CTOR\0".as_ptr()) };
+                // unsafe { getsectbyname(b"__DATA\0".as_ptr(), b"section$start$__DATA$CTOR\0".as_ptr()) };
 
                 (std::ptr::null_mut(), std::ptr::null_mut())
             }
         };
     }
 
-    #[cfg(all(not(miri), target_family = "wasm"))]
+    #[cfg(target_family = "wasm")]
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __get_section {
@@ -328,7 +328,7 @@ pub mod __support {
         }
     }
 
-    #[cfg(all(not(miri), target_vendor = "pc"))]
+    #[cfg(target_vendor = "pc")]
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __get_section {
@@ -353,7 +353,7 @@ pub mod __support {
         }
     }
 
-    #[cfg(all(not(miri), not(target_family = "wasm"), not(target_vendor = "pc")))]
+    #[cfg(all(not(all(miri, target_vendor = "apple")), not(target_family = "wasm"), not(target_vendor = "pc")))]
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __get_section {

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -760,7 +760,15 @@ impl<T: 'static> TypedSection<T> {
 
     /// The byte length of the section.
     pub fn byte_len(&self) -> usize {
-        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
+        // Wash away provenance for Miri
+        #[cfg(miri)]
+        {
+            return self.end_ptr() as usize - self.start_ptr() as usize;
+        }
+        #[cfg(not(miri))]
+        unsafe {
+            (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize
+        }
     }
 
     /// The number of elements in the section.

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -536,7 +536,7 @@ pub mod __support {
 }
 
 /// Define a link section.
-/// 
+///
 /// The definition site generates two items: a static section struct that is
 /// used to access the section, and a macro that is used to place items into the
 /// section. The macro is used by the [`in_section`] procedural macro.
@@ -548,7 +548,7 @@ pub mod __support {
 ///   name of the section.
 /// - `aux = <name>`: Specifies that this section is an auxiliary section, and
 ///   that the section is named `<name>+<aux>`.
-/// 
+///
 /// # Example
 /// ```rust
 /// use link_section::{in_section, section};

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -292,6 +292,12 @@ pub mod __support {
         (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
             // Disable link sections for miri (`extern static `␁section$start$__DATA$CTOR` is not supported by Miri`)
             {
+                extern "C" {
+                    #[no_mangle]
+                    pub fn getsectbyname(segname: *const u8, sectname: *const u8) -> *const u8;
+                }
+                unsafe { getsectbyname(b"__DATA\0".as_ptr(), b"section$start$__DATA$CTOR\0".as_ptr()) };
+
                 (std::ptr::null_mut(), std::ptr::null_mut())
             }
         };

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -206,6 +206,12 @@ pub mod __support {
             $crate::__section_parse!(@parsed #[section $($args)*] $(#[$meta])* $vis static $ident: ( $(:: $path_prefix ::)? $($path)::* ;) ( () > ; ) __in_section_helper_macro_no_generic);
         };
         // Both end up here...
+        (@parsed #[section(aux = $name:ident, no_macro)] $(#[$meta:meta])* $vis:vis static $ident:ident : ($ty:ty ;) ( $generic_ty:ty > ; ) $generic_macro:ident) => {
+            $crate::__section_parse!(@generate #[section(aux = $name)] $(#[$meta])* $vis static $ident: $ty, $generic_ty, $generic_macro);
+        };
+        (@parsed #[section(no_macro)] $(#[$meta:meta])* $vis:vis static $ident:ident : ($ty:ty ;) ( $generic_ty:ty > ; ) $generic_macro:ident) => {
+            $crate::__section_parse!(@generate #[section] $(#[$meta])* $vis static $ident: $ty, $generic_ty, $generic_macro);
+        };
         (@parsed #[section $($args:tt)*] $(#[$meta:meta])* $vis:vis static $ident:ident : ($ty:ty ;) ( $generic_ty:ty > ; ) $generic_macro:ident) => {
             $crate::__declare_macro!($vis $ident $generic_macro ($($args)*));
             $crate::__section_parse!(@generate #[section $($args)*] $(#[$meta])* $vis static $ident: $ty, $generic_ty, $generic_macro);
@@ -530,7 +536,19 @@ pub mod __support {
 }
 
 /// Define a link section.
+/// 
+/// The definition site generates two items: a static section struct that is
+/// used to access the section, and a macro that is used to place items into the
+/// section. The macro is used by the [`in_section`] procedural macro.
 ///
+/// # Attributes
+///
+/// - `no_macro`: Does not generate the submission macro at the definition site.
+///   This will require any associated [`in_section`] invocations to use the raw
+///   name of the section.
+/// - `aux = <name>`: Specifies that this section is an auxiliary section, and
+///   that the section is named `<name>+<aux>`.
+/// 
 /// # Example
 /// ```rust
 /// use link_section::{in_section, section};
@@ -573,6 +591,11 @@ impl Section {
     ) -> Self {
         Self { name, start, end }
     }
+
+    /// The byte length of the section.
+    pub fn byte_len(&self) -> usize {
+        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
+    }
 }
 
 #[cfg(target_family = "wasm")]
@@ -599,25 +622,17 @@ impl Section {
         }
         ptr
     }
-    /// The byte length of the section.
-    pub fn byte_len(&self) -> usize {
-        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
-    }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl Section {
     /// The start address of the section.
-    pub const fn start_ptr(&self) -> *const () {
+    pub fn start_ptr(&self) -> *const () {
         self.start as *const ()
     }
     /// The end address of the section.
-    pub const fn end_ptr(&self) -> *const () {
+    pub fn end_ptr(&self) -> *const () {
         self.end as *const ()
-    }
-    /// The byte length of the section.
-    pub const fn byte_len(&self) -> usize {
-        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
     }
 }
 
@@ -670,66 +685,18 @@ impl<T: 'static> TypedSection<T> {
         }
         ptr
     }
-
-    /// The byte length of the section.
-    pub fn byte_len(&self) -> usize {
-        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
-    }
-
-    /// The number of elements in the section.
-    pub fn len(&self) -> usize {
-        self.byte_len() / self.stride()
-    }
-
-    /// True if the section is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// The section as a slice.
-    pub fn as_slice(&self) -> &[T] {
-        if self.is_empty() {
-            &[]
-        } else {
-            unsafe { ::core::slice::from_raw_parts(self.start_ptr(), self.len()) }
-        }
-    }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<T: 'static> TypedSection<T> {
     /// The start address of the section.
-    pub const fn start_ptr(&self) -> *const T {
+    pub fn start_ptr(&self) -> *const T {
         self.start as *const T
     }
 
     /// The end address of the section.
-    pub const fn end_ptr(&self) -> *const T {
+    pub fn end_ptr(&self) -> *const T {
         self.end as *const T
-    }
-
-    /// The byte length of the section.
-    pub const fn byte_len(&self) -> usize {
-        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
-    }
-
-    /// The number of elements in the section.
-    pub const fn len(&self) -> usize {
-        self.byte_len() / self.stride()
-    }
-
-    /// True if the section is empty.
-    pub const fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// The section as a slice.
-    pub const fn as_slice(&self) -> &[T] {
-        if self.is_empty() {
-            &[]
-        } else {
-            unsafe { ::core::slice::from_raw_parts(self.start_ptr(), self.len()) }
-        }
     }
 }
 
@@ -756,6 +723,30 @@ impl<T: 'static> TypedSection<T> {
                 && ::core::mem::size_of::<T>() * 2 == ::core::mem::size_of::<[T; 2]>()
         );
         ::core::mem::size_of::<T>()
+    }
+
+    /// The byte length of the section.
+    pub fn byte_len(&self) -> usize {
+        unsafe { (self.end_ptr() as *const u8).offset_from(self.start_ptr() as *const u8) as usize }
+    }
+
+    /// The number of elements in the section.
+    pub fn len(&self) -> usize {
+        self.byte_len() / self.stride()
+    }
+
+    /// True if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The section as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        if self.is_empty() {
+            &[]
+        } else {
+            unsafe { ::core::slice::from_raw_parts(self.start_ptr(), self.len()) }
+        }
     }
 
     /// The offset of the item in the section, if it is in the section.

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -723,20 +723,22 @@ impl<T: 'static> TypedSection<T> {
 #[cfg(not(target_family = "wasm"))]
 impl<T: 'static> TypedSection<T> {
     /// The start address of the section.
-    #[cfg(miri)]
     pub fn start_ptr(&self) -> *const T {
         // Wash away provenance for Miri
-        self.start_ptr() as usize as *const T
-    }
-
-    /// The start address of the section.
-    #[cfg(not(miri))]
-    pub fn start_ptr(&self) -> *const T {
-        self.start as *const T
+        #[cfg(miri)]
+        {
+            return self.start as usize as *const T;
+        }
+        self.start as usize as *const T
     }
 
     /// The end address of the section.
     pub fn end_ptr(&self) -> *const T {
+        // Wash away provenance for Miri
+        #[cfg(miri)]
+        {
+            return self.end as usize as *const T;
+        }
         self.end as *const T
     }
 }

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -285,7 +285,7 @@ pub mod __support {
         };
     }
 
-    #[cfg(all(miri, target_vendor = "apple"))]
+    #[cfg(miri)]
     mod section {
         #[doc(hidden)]
         #[macro_export]
@@ -375,7 +375,6 @@ pub mod __support {
     }
 
     #[cfg(all(
-        not(all(miri, target_vendor = "apple")),
         not(target_family = "wasm"),
         not(target_vendor = "pc")
     ))]

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -291,14 +291,7 @@ pub mod __support {
         #[macro_export]
         macro_rules! __get_section {
             (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
-                // Disable link sections for miri (`extern static `␁section$start$__DATA$CTOR` is not supported by Miri`)
                 {
-                    extern "C" {
-                        #[no_mangle]
-                        pub fn getsectbyname(segname: *const u8, sectname: *const u8) -> *const u8;
-                    }
-                    // unsafe { getsectbyname(b"__DATA\0".as_ptr(), b"section$start$__DATA$CTOR\0".as_ptr()) };
-
                     (std::ptr::null_mut(), std::ptr::null_mut())
                 }
             };

--- a/shared/src/macros/mod.rs
+++ b/shared/src/macros/mod.rs
@@ -535,7 +535,7 @@ macro_rules! __dtor_entry {
                     ) { unsafe { $ident() } }
                 );
 
-                #[cfg(not(target_vendor = "apple"))]
+                #[cfg(all(not(miri), not(target_vendor = "apple")))]
                 #[inline(always)]
                 unsafe fn do_atexit(cb: unsafe extern fn()) {
                     /*unsafe*/ extern "C" {
@@ -547,7 +547,7 @@ macro_rules! __dtor_entry {
                 }
 
                 // For platforms that have __cxa_atexit, we register the dtor as scoped to dso_handle
-                #[cfg(target_vendor = "apple")]
+                #[cfg(all(not(miri), target_vendor = "apple"))]
                 #[inline(always)]
                 unsafe fn do_atexit(cb: /*unsafe*/ extern "C" fn(_: *const u8)) {
                     /*unsafe*/ extern "C" {
@@ -557,6 +557,11 @@ macro_rules! __dtor_entry {
                     unsafe {
                         __cxa_atexit(cb, ::core::ptr::null(), __dso_handle);
                     }
+                }
+
+                #[cfg(miri)]
+                unsafe fn do_atexit(_cb: unsafe extern fn(#[cfg(target_vendor = "apple")] _: *const u8)) {
+                    // no-op on miri
                 }
             }
 

--- a/shared/tests/macrotest.rs
+++ b/shared/tests/macrotest.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 //! To overwrite the Linux expansion tests on macOS, run:
 //!
 //! ```bash

--- a/tests/ctor/system/src/lib.rs
+++ b/tests/ctor/system/src/lib.rs
@@ -3,11 +3,6 @@
 #![allow(unused_features)]
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 
-// Prevent a spurious 'unused_imports' warning
-#[allow(unused_imports)]
-#[macro_use]
-extern crate ctor;
-
 #[cfg(test)]
 mod test {
     use libc_print::*;

--- a/tests/link_section/basic/src/main.rs
+++ b/tests/link_section/basic/src/main.rs
@@ -73,7 +73,13 @@ pub static DEBUGGABLE_FUNCTION: fn() = {
     &(debuggable_function as fn())
 };
 
-/// Dumps the various sections.
+#[cfg(miri)]
+pub fn main() {
+    eprintln!("Miri is not supported for this test");
+    assert_eq!(TYPED_LINK_SECTION.len(), 0);
+}
+
+#[cfg(not(miri))]
 pub fn main() {
     eprintln!("LINK_SECTION: {:?}", LINK_SECTION);
     link_section_function();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,7 @@
 //! `clitest` tests.
 
+#![cfg(not(miri))]
+
 /// `ctor` tests
 #[cfg(test)]
 mod ctor;


### PR DESCRIPTION
Multiple changes for miri hardening:

 - Removing `const` from section functions - these are technically const, but using them in a const context is pretty much impossible
 - Run miri under Windows
 - Add `no_macro` support for sections
 - When running under Miri, wash the provenance of the start and end pointers to prevent Miri thinking the allocation size is zero
 - Removed legacy `extern crate` declarations