### PR TITLE
Test `cargo zigbuild` on macOS

### DIFF
--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -5,10 +5,10 @@ cargo zigbuild --workspace --bins --examples --target "$TARGET"
 
 # Same smoke test as build.sh: run the ctor example (runtime ctor registration).
 echo "Running basic example..."
-exec "target/${TARGET}/debug/examples/basic"
+target/${TARGET}/debug/examples/basic
 
 echo "Running example..."
-exec "target/${TARGET}/debug/examples/example"
+target/${TARGET}/debug/examples/example
 
 echo "Running link-section example..."
-exec "target/${TARGET}/debug/examples/link-section-example"
+target/${TARGET}/debug/examples/link-section-example

--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -4,11 +4,17 @@ set -xeuo pipefail
 cargo zigbuild --workspace --bins --examples --target "$TARGET"
 
 # Same smoke test as build.sh: run the ctor example (runtime ctor registration).
+sleep .1
 echo "Running basic example..."
+sleep .1
 target/${TARGET}/debug/examples/basic
 
+sleep .1
 echo "Running example..."
+sleep .1
 target/${TARGET}/debug/examples/example
 
+sleep .1
 echo "Running link-section example..."
+sleep .1
 target/${TARGET}/debug/examples/link-section-example

--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-cargo zigbuild --workspace --target "$TARGET"
+cargo zigbuild --workspace --bins --examples --target "$TARGET"
 
 # Same smoke test as build.sh: run the ctor example (runtime ctor registration).
+find target/
 exec "target/${TARGET}/debug/examples/example"

--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+cargo zigbuild --workspace --target "$TARGET"
+
+# Same smoke test as build.sh: run the ctor example (runtime ctor registration).
+exec "target/${TARGET}/debug/examples/example"

--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -4,5 +4,11 @@ set -xeuo pipefail
 cargo zigbuild --workspace --bins --examples --target "$TARGET"
 
 # Same smoke test as build.sh: run the ctor example (runtime ctor registration).
-find target/
+echo "Running basic example..."
+exec "target/${TARGET}/debug/examples/basic"
+
+echo "Running example..."
 exec "target/${TARGET}/debug/examples/example"
+
+echo "Running link-section example..."
+exec "target/${TARGET}/debug/examples/link-section-example"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
       if: ${{ matrix.job == 'zigbuild' }}
       uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
       with:
-        version: 0.14.0
+        version: 0.15.2
 
     - name: Cache Rust files
       uses: actions/cache@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
                 target: x86_64-unknown-linux-musl
               macos:
                 os: macOS-latest
-                job: [lint, test, miri]
+                job: [lint, test, miri, zigbuild]
                 target: aarch64-apple-darwin
               windows:
                 os: windows-latest
@@ -102,6 +102,18 @@ jobs:
         toolchain: ${{ matrix.rust-toolchain }}
         components: ${{ matrix.rust-components }}
         target: ${{ matrix.rust-extra-target }}
+
+    - name: Install Zig
+      if: ${{ matrix.job == 'zigbuild' }}
+      uses: mlugg/setup-zig@v2
+      with:
+        version: 0.13.0
+
+    - name: Install cargo-zigbuild
+      if: ${{ matrix.job == 'zigbuild' }}
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-zigbuild@2
 
     - name: Cache Rust files
       uses: actions/cache@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
               $match:
                 "this.job == 'wasm'": "wasmtime-cli"
                 "this.job == 'test'": "cargo-expand"
+                "this.job == 'zigbuild'": "cargo-zigbuild"
             rust-toolchain:
               $match:
                 "this.job == 'miri'": nightly
@@ -108,12 +109,6 @@ jobs:
       uses: mlugg/setup-zig@v2
       with:
         version: 0.13.0
-
-    - name: Install cargo-zigbuild
-      if: ${{ matrix.job == 'zigbuild' }}
-      uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-zigbuild@2
 
     - name: Cache Rust files
       uses: actions/cache@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Install Zig
       if: ${{ matrix.job == 'zigbuild' }}
-      uses: mlugg/setup-zig@v2
+      uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
       with:
         version: 0.13.0
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
       if: ${{ matrix.job == 'zigbuild' }}
       uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
       with:
-        version: 0.13.0
+        version: 0.14.0
 
     - name: Cache Rust files
       uses: actions/cache@v5

--- a/ctor/examples/basic.rs
+++ b/ctor/examples/basic.rs
@@ -1,0 +1,10 @@
+use ctor::ctor;
+
+#[ctor(unsafe)]
+fn ctor() {
+    println!("ctor");
+}
+
+fn main() {
+    println!("main");
+}

--- a/ctor/examples/basic.rs
+++ b/ctor/examples/basic.rs
@@ -1,3 +1,5 @@
+//! Basic example of using the `ctor` crate.
+
 use ctor::ctor;
 
 #[ctor(unsafe)]

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -373,6 +373,7 @@ pub mod __support {
             (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
                 {
                     extern "C" {
+                        #[used]
                         $crate::__support::add_section_link_attribute!(
                             data start $ident $($aux)?
                             #[link_name = __]
@@ -380,19 +381,13 @@ pub mod __support {
                         );
                     }
                     extern "C" {
+                        #[used]
                         $crate::__support::add_section_link_attribute!(
                             data end $ident $($aux)?
                             #[link_name = __]
                             static __END: $crate::__support::SectionPtr<$generic_ty>;
                         );
                     }
-
-                    #[used]
-                    $crate::__support::add_section_link_attribute!(
-                        data section $ident $($aux)?
-                        #[link_section = __]
-                        static __USED: [$generic_ty; 0] = [];
-                    );
 
                     (
                         unsafe { &raw const __START as $crate::__support::SectionPtr<$generic_ty> },

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -98,7 +98,7 @@ pub mod __support {
             data section => ("__DATA,") __ (",regular,no_dead_strip");
             code section => ("__TEXT,") __ (",regular,no_dead_strip");
             data start =>   ("\x01section$start$__DATA$") __ ();
-            data end =>     ("\x01section$end$__DATA$") __ ();
+            data end =>     ("\x01section$stop$__DATA$") __ ();
         }
         AUXILIARY = "_";
         MAX_LENGTH = 16;

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -98,7 +98,7 @@ pub mod __support {
             data section => ("__DATA,") __ (",regular,no_dead_strip");
             code section => ("__TEXT,") __ (",regular,no_dead_strip");
             data start =>   ("\x01section$start$__DATA$") __ ();
-            data end =>     ("\x01section$stop$__DATA$") __ ();
+            data end =>     ("\x01section$end$__DATA$") __ ();
         }
         AUXILIARY = "_";
         MAX_LENGTH = 16;

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -387,6 +387,13 @@ pub mod __support {
                         );
                     }
 
+                    #[used]
+                    $crate::__support::add_section_link_attribute!(
+                        data section $ident $($aux)?
+                        #[link_section = __]
+                        static __USED: [$generic_ty; 0] = [];
+                    );
+
                     (
                         unsafe { &raw const __START as $crate::__support::SectionPtr<$generic_ty> },
                         unsafe { &raw const __END as $crate::__support::SectionPtr<$generic_ty> },

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -373,7 +373,6 @@ pub mod __support {
             (name=$ident:ident, type=$generic_ty:ty, aux=$($aux:ident)?) => {
                 {
                     extern "C" {
-                        #[used]
                         $crate::__support::add_section_link_attribute!(
                             data start $ident $($aux)?
                             #[link_name = __]
@@ -381,7 +380,6 @@ pub mod __support {
                         );
                     }
                     extern "C" {
-                        #[used]
                         $crate::__support::add_section_link_attribute!(
                             data end $ident $($aux)?
                             #[link_name = __]


### PR DESCRIPTION
We should be testing all OS combinations with zigbuild, but for now just add a placeholder macOS one to ensure things work as expected.