### PR TITLE
Add AIX Support for ctor and dtor Macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Module initialization/teardown functions for Rust (like
 `__attribute__((constructor))` in C/C++) for Linux, OSX, FreeBSD, NetBSD,
-Illumos, OpenBSD, DragonFlyBSD, Android, iOS, WASM, and Windows.
+Illumos, OpenBSD, DragonFlyBSD, AIX, Android, iOS, WASM, and Windows.
 
 ## MSRV
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Module initialization/teardown functions for Rust (like
 `__attribute__((constructor))` in C/C++) for Linux, OSX, FreeBSD, NetBSD,
-Illumos, OpenBSD, DragonFlyBSD, AIX, Android, iOS, WASM, and Windows.
+Illumos, OpenBSD, DragonFlyBSD, Android, iOS, WASM, and Windows.
 
 ## MSRV
 

--- a/shared/src/macros/mod.rs
+++ b/shared/src/macros/mod.rs
@@ -370,12 +370,52 @@ macro_rules! __ctor_entry {
         $crate::__support::if_has_feature!(anonymous, $features, {
             $crate::__support::ctor_entry!(unnamed, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         }, {
+            // AIX requires special handling
+            #[cfg(target_os = "aix")]
+            $crate::__support::ctor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+            
+            #[cfg(not(target_os = "aix"))]
             $crate::__support::ctor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         });
     };
     (unnamed,features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
         const _: () = {
+            #[cfg(target_os = "aix")]
+            $crate::__support::ctor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+            
+            #[cfg(not(target_os = "aix"))]
             $crate::__support::ctor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+        };
+    };
+    (aix, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
+        $(#[$fnmeta])*
+        #[allow(unused)]
+        $($vis)* $($unsafe)? fn $ident() $block
+
+        // AIX-specific constructor wrapper using __sinit naming convention
+        // The function name must start with __sinit80000000_ for AIX to recognize it as a constructor
+        // We wrap in a const block to create a unique namespace and avoid module name collisions
+        const _: () = {
+            #[unsafe(no_mangle)]
+            #[export_name = concat!("__sinit80000000_", module_path!(), "_", stringify!($ident), "_L", line!(), "C", column!())]
+            extern "C" fn aix_ctor_wrapper() {
+                #[allow(unsafe_code)]
+                {
+                    $crate::__support::if_unsafe!($($unsafe)?, {}, {
+                        $crate::__support::if_has_feature!( __no_warn_on_missing_unsafe, $features, {
+                            #[deprecated="ctor deprecation note:\n\n \
+                            Use of #[ctor] without `unsafe fn` is deprecated. As code execution before main\n\
+                            is unsupported by most Rust runtime functions, these functions must be marked\n\
+                            `unsafe`."]
+                                const fn ctor_without_unsafe_is_deprecated() {}
+                                #[allow(unused)]
+                                static UNSAFE_WARNING: () = ctor_without_unsafe_is_deprecated();
+                        }, {});
+                    });
+
+                    unsafe { $ident(); }
+                }
+            }
         };
     };
     (named, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
@@ -614,6 +654,7 @@ macro_rules! __ctor_link_section {
             target_os = "dragonfly",
             target_os = "illumos",
             target_os = "haiku",
+            target_os = "aix",
             target_vendor = "apple",
             target_family = "wasm",
             target_arch = "xtensa",

--- a/shared/src/macros/mod.rs
+++ b/shared/src/macros/mod.rs
@@ -534,12 +534,53 @@ macro_rules! __dtor_entry {
         $crate::__support::if_has_feature!(anonymous, $features, {
             $crate::__support::dtor_entry!(unnamed, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         }, {
+            // AIX requires special handling
+            #[cfg(target_os = "aix")]
+            $crate::__support::dtor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+            
+            #[cfg(not(target_os = "aix"))]
             $crate::__support::dtor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         });
     };
     (unnamed, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
         const _: () = {
+            #[cfg(target_os = "aix")]
+            $crate::__support::dtor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+            
+            #[cfg(not(target_os = "aix"))]
             $crate::__support::dtor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
+        };
+    };
+    (aix, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {
+        $(#[$fnmeta])*
+        #[allow(unused)]
+        $($vis)* $($unsafe)? fn $ident() $block
+
+        // AIX-specific destructor wrapper using __sterm naming convention
+        // The function name must start with __sterm80000000_ for AIX to recognize it as a destructor
+        // We wrap in a const block to create a unique namespace and avoid module name collisions
+        // We use line!() and column!() to generate a unique export name for each destructor
+        const _: () = {
+            #[unsafe(no_mangle)]
+            #[export_name = concat!("__sterm80000000_", module_path!(), "_", stringify!($ident), "_L", line!(), "C", column!())]
+            extern "C" fn aix_dtor_wrapper() {
+                #[allow(unsafe_code)]
+                {
+                    $crate::__support::if_unsafe!($($unsafe)?, {}, {
+                        $crate::__support::if_has_feature!( __no_warn_on_missing_unsafe, $features, {
+                            #[deprecated="dtor deprecation note:\n\n \
+                            Use of #[dtor] without `unsafe fn` is deprecated. As code execution after main\n\
+                            is unsupported by most Rust runtime functions, these functions must be marked\n\
+                            `unsafe`."]
+                                const fn dtor_without_unsafe_is_deprecated() {}
+                                #[allow(unused)]
+                                static UNSAFE_WARNING: () = dtor_without_unsafe_is_deprecated();
+                        }, {});
+                    });
+
+                    unsafe { $ident(); }
+                }
+            }
         };
     };
     (named, features=$features:tt, imeta=$(#[$fnmeta:meta])*, vis=[$($vis:tt)*], unsafe=$($unsafe:ident)?, item=fn $ident:ident() $block:block) => {

--- a/shared/src/macros/mod.rs
+++ b/shared/src/macros/mod.rs
@@ -373,7 +373,7 @@ macro_rules! __ctor_entry {
             // AIX requires special handling
             #[cfg(target_os = "aix")]
             $crate::__support::ctor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
-            
+
             #[cfg(not(target_os = "aix"))]
             $crate::__support::ctor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         });
@@ -382,7 +382,7 @@ macro_rules! __ctor_entry {
         const _: () = {
             #[cfg(target_os = "aix")]
             $crate::__support::ctor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
-            
+
             #[cfg(not(target_os = "aix"))]
             $crate::__support::ctor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         };
@@ -537,7 +537,7 @@ macro_rules! __dtor_entry {
             // AIX requires special handling
             #[cfg(target_os = "aix")]
             $crate::__support::dtor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
-            
+
             #[cfg(not(target_os = "aix"))]
             $crate::__support::dtor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         });
@@ -546,7 +546,7 @@ macro_rules! __dtor_entry {
         const _: () = {
             #[cfg(target_os = "aix")]
             $crate::__support::dtor_entry!(aix, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
-            
+
             #[cfg(not(target_os = "aix"))]
             $crate::__support::dtor_entry!(named, features=$features, imeta=$(#[$fnmeta])*, vis=[$($vis)*], unsafe=$($unsafe)?, item=fn $ident() $block);
         };

--- a/shared/tests/expand-aix/ctor.expanded.rs
+++ b/shared/tests/expand-aix/ctor.expanded.rs
@@ -1,0 +1,23 @@
+#[allow(unused)]
+unsafe fn foo() {
+    {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+mod __aix_ctor_impl {
+    use super::*;
+    #[unsafe(no_mangle)]
+    #[export_name = concat!("__sinit80000000_", stringify!(foo))]
+    extern "C" fn aix_ctor_wrapper() {
+        #[allow(unsafe_code)]
+        {
+            unsafe {
+                foo();
+            }
+        }
+    }
+}

--- a/shared/tests/expand-aix/ctor.rs
+++ b/shared/tests/expand-aix/ctor.rs
@@ -1,0 +1,6 @@
+shared::ctor_parse!(
+    #[ctor]
+    unsafe fn foo() {
+        println!("foo");
+    }
+);

--- a/shared/tests/expand-aix/dtor.expanded.rs
+++ b/shared/tests/expand-aix/dtor.expanded.rs
@@ -1,0 +1,29 @@
+#[allow(unused)]
+unsafe fn foo() {
+    {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
+}
+const _: () = {
+    #[unsafe(no_mangle)]
+    #[export_name = concat!(
+        "__sterm80000000_",
+        module_path!(),
+        "_",
+        stringify!(foo),
+        "_L",
+        line!(),
+        "C",
+        column!()
+    )]
+    extern "C" fn aix_dtor_wrapper() {
+        #[allow(unsafe_code)]
+        {
+            unsafe {
+                foo();
+            }
+        }
+    }
+};

--- a/shared/tests/expand-aix/dtor.rs
+++ b/shared/tests/expand-aix/dtor.rs
@@ -1,0 +1,6 @@
+shared::dtor_parse!(
+    #[dtor]
+    unsafe fn foo() {
+        println!("foo");
+    }
+);


### PR DESCRIPTION
This PR adds support for IBM AIX to the ctor and dtor macros. AIX requires special function naming conventions for constructors (__sinit prefix) and destructors (__sterm prefix). This PR only supports ctor and dtor macros, not link-section and ctor priority.
