### PR TITLE
Support `Self::`-style ctors and dtors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## ctor [0.12.0] - Unreleased
 
+### Added
+
+- Support for `#[ctor]` on `impl` items. To be valid, the `fn` must have no
+  `self` parameter and must not access any generic parameters from the outer
+  item.
+
 ### Removed
 
 - deprecated `dtor` feature and crate dependency from `ctor` crate (use the `dtor` crate directly).
 
 ## dtor [0.12.0] - Unreleased
+
+### Added
+
+- Support for `#[dtor]` on `impl` items. To be valid, the `fn` must have no
+  `self` parameter and must not access any generic parameters from the outer
+  item.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ fn print_numbers() {
 
 ## Contributing
 
-Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for details.
+Contributions are welcome! 
 
 ## License
 

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -80,10 +80,13 @@ difficult to understand. For example, thread-local storage on OSX will affect
 this (see
 [this comment](https://github.com/rust-lang/rust/issues/28794#issuecomment-368693049)).
 
-## Examples
+## Usage
 
-Marks the function `foo` as a module constructor, called when a static library
-is loaded or an executable is started:
+`#[ctor]` decorates a function item to be called as a module constructor. Both
+free (a global `fn()`) and impl functions (`Self::method()`) are supported.
+
+The example below marks the function `foo` as a module constructor, called when
+a static library is loaded or an executable is started:
 
 ```rust
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -91,24 +94,47 @@ use ctor::ctor;
 
 static INITED: AtomicBool = AtomicBool::new(false);
 
-#[ctor]
+#[ctor(unsafe)]
 fn foo() {
+    // ... (do something)
     INITED.store(true, Ordering::SeqCst);
 }
 ```
 
-Creates a `HashMap` populated with strings when a static library is loaded or an
-executable is started (new in `0.1.7`):
+Implementation methods can also be decorated with `#[ctor]`, as long as they
+have no `self` parameter:
 
-`static` items are equivalent to `std::sync::OnceLock`, with an automatic deref
-implementation and eager initialization at startup time. `#[ctor]` on `static`
-items requires the default `std` feature.
+```rust
+use ctor::ctor;
+
+struct MyStruct {
+    // ...
+}
+
+impl MyStruct {
+    /// Ensure the required C library is loaded at startup time.
+    #[ctor(unsafe)]
+    fn load_required_c_library() {
+        // ... (do something)
+    }
+}
+```
+
+### `static` items
+
+The `#[ctor]` macro also supports decorating `static` items, which are
+initialized at startup time. `static` items declared in this way must not be
+accessed from other threads before the module constructors have run (if this is
+done without caution, the initializer may panic).
+
+The below example creates a `HashMap` populated with strings, which would
+normally not be possible with `const` items:
 
 ```rust
 use std::collections::HashMap;
 use ctor::ctor;
 
-#[ctor]
+#[ctor(unsafe)]
 /// This is an immutable static, evaluated at init time
 static STATIC_CTOR: HashMap<u32, &'static str> = {
     let mut m = HashMap::new();
@@ -117,20 +143,6 @@ static STATIC_CTOR: HashMap<u32, &'static str> = {
     m.insert(2, "baz");
     m
 };
-```
-
-Print a message at shutdown time. Note that Rust may have shut down some stdlib
-services at this time.
-
-```rust,ignore
-use libc::printf;
-use ctor::dtor;
-
-#[dtor]
-unsafe fn shutdown() {
-    // Using println or eprintln here will panic as Rust has shut down
-    libc::printf(c"Shutting down!\n" as _);
-}
 ```
 
 ## Under the Hood

--- a/ctor/docs/PREAMBLE.md
+++ b/ctor/docs/PREAMBLE.md
@@ -71,10 +71,13 @@ difficult to understand. For example, thread-local storage on OSX will affect
 this (see
 [this comment](https://github.com/rust-lang/rust/issues/28794#issuecomment-368693049)).
 
-## Examples
+## Usage
 
-Marks the function `foo` as a module constructor, called when a static library
-is loaded or an executable is started:
+`#[ctor]` decorates a function item to be called as a module constructor. Both
+free (a global `fn()`) and impl functions (`Self::method()`) are supported.
+
+The example below marks the function `foo` as a module constructor, called when
+a static library is loaded or an executable is started:
 
 ```rust
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -82,24 +85,47 @@ use ctor::ctor;
 
 static INITED: AtomicBool = AtomicBool::new(false);
 
-#[ctor]
+#[ctor(unsafe)]
 fn foo() {
+    // ... (do something)
     INITED.store(true, Ordering::SeqCst);
 }
 ```
 
-Creates a `HashMap` populated with strings when a static library is loaded or an
-executable is started (new in `0.1.7`):
+Implementation methods can also be decorated with `#[ctor]`, as long as they
+have no `self` parameter:
 
-`static` items are equivalent to `std::sync::OnceLock`, with an automatic deref
-implementation and eager initialization at startup time. `#[ctor]` on `static`
-items requires the default `std` feature.
+```rust
+use ctor::ctor;
+
+struct MyStruct {
+    // ...
+}
+
+impl MyStruct {
+    /// Ensure the required C library is loaded at startup time.
+    #[ctor(unsafe)]
+    fn load_required_c_library() {
+        // ... (do something)
+    }
+}
+```
+
+### `static` items
+
+The `#[ctor]` macro also supports decorating `static` items, which are
+initialized at startup time. `static` items declared in this way must not be
+accessed from other threads before the module constructors have run (if this is
+done without caution, the initializer may panic).
+
+The below example creates a `HashMap` populated with strings, which would
+normally not be possible with `const` items:
 
 ```rust
 use std::collections::HashMap;
 use ctor::ctor;
 
-#[ctor]
+#[ctor(unsafe)]
 /// This is an immutable static, evaluated at init time
 static STATIC_CTOR: HashMap<u32, &'static str> = {
     let mut m = HashMap::new();
@@ -108,20 +134,6 @@ static STATIC_CTOR: HashMap<u32, &'static str> = {
     m.insert(2, "baz");
     m
 };
-```
-
-Print a message at shutdown time. Note that Rust may have shut down some stdlib
-services at this time.
-
-```rust,ignore
-use libc::printf;
-use ctor::dtor;
-
-#[dtor]
-unsafe fn shutdown() {
-    // Using println or eprintln here will panic as Rust has shut down
-    libc::printf(c"Shutting down!\n" as _);
-}
 ```
 
 ## Under the Hood

--- a/ctor/examples/ctor-example.rs
+++ b/ctor/examples/ctor-example.rs
@@ -72,18 +72,19 @@ pub mod module {
     };
 }
 
-#[allow(unused)]
-struct Foo;
+#[derive(Default)]
+struct Foo<T> {
+    _t: ::std::marker::PhantomData<T>,
+}
 
-impl Foo {
+impl<T: Default> Foo<T> {
+    fn generic(self) {
+        _ = T::default();
+    }
+
     #[ctor(unsafe)]
     fn ctor() {
         libc_eprintln!("Foo::ctor");
-    }
-
-    #[ctor]
-    unsafe fn unsafe_ctor() {
-        libc_eprintln!("Foo::dtor");
     }
 }
 
@@ -93,4 +94,9 @@ pub fn main() {
     libc_println!("main!");
     libc_println!("STATIC_CTOR = {:?}", *STATIC_CTOR);
     libc_println!("module::STATIC_CTOR = {:?}", *module::STATIC_CTOR);
+
+    // Only one ctor call will occur for both generic types, and no generics are
+    // available in the ctor body.
+    Foo::<u32>::default().generic();
+    Foo::<u64>::default().generic();
 }

--- a/ctor/examples/ctor-example.rs
+++ b/ctor/examples/ctor-example.rs
@@ -72,6 +72,21 @@ pub mod module {
     };
 }
 
+#[allow(unused)]
+struct Foo;
+
+impl Foo {
+    #[ctor(unsafe)]
+    fn ctor() {
+        libc_eprintln!("Foo::ctor");
+    }
+
+    #[ctor]
+    unsafe fn unsafe_ctor() {
+        libc_eprintln!("Foo::dtor");
+    }
+}
+
 /// Executable main which demonstrates the various types of ctor/dtor.
 pub fn main() {
     use libc_print::*;

--- a/ctor/examples/ctor-example.rs
+++ b/ctor/examples/ctor-example.rs
@@ -79,7 +79,7 @@ struct Foo<T> {
 
 impl<T: Default> Foo<T> {
     fn generic(self) {
-        _ = T::default();
+        drop(T::default());
     }
 
     #[ctor(unsafe)]

--- a/ctor/src/parse.rs
+++ b/ctor/src/parse.rs
@@ -576,9 +576,16 @@ macro_rules! __ctor_parse_impl {
         })
     ) ) => {
         $($meta)*
+        #[allow(dead_code)]
         $vis $($unsafe)* $( extern $abi )? fn $name () {
-            $crate::__ctor_parse_impl!(@ctor $link_args body={ $($unsafe)* { $name() } });
-            $($body)*
+            // The outer function may be attached to a struct, so we generate an
+            // inner function that is freestanding and call it from both places.
+            $($unsafe)* $( extern $abi )? fn __ctor_private_inner() {
+                $($body)*
+            }
+
+            $crate::__ctor_parse_impl!(@ctor $link_args body={ $($unsafe)* { __ctor_private_inner() } });
+            $($unsafe)* { __ctor_private_inner() }
         }
     };
 

--- a/ctor/tests/errors/ctor_bad_shape.rs
+++ b/ctor/tests/errors/ctor_bad_shape.rs
@@ -1,0 +1,33 @@
+use ctor::ctor;
+
+#[ctor]
+fn foo() -> u32 {
+    1
+}
+
+#[ctor]
+fn foo(_x: u32) {
+}
+
+struct Foo;
+
+impl Foo {
+    #[ctor]
+    fn foo(self) {
+    }
+}
+
+struct FooGeneric<T> {
+    _t: ::std::marker::PhantomData<T>,
+}
+
+impl<T: Default> FooGeneric<T> {
+    #[ctor]
+    fn foo() {
+        // can't use generic parameters from outer item
+        _ = T::default();
+    }
+}
+
+fn main() {
+}

--- a/ctor/tests/errors/ctor_bad_shape.stderr
+++ b/ctor/tests/errors/ctor_bad_shape.stderr
@@ -1,0 +1,50 @@
+error: Invalid ctor item. Expected a function with no args, return value, or type parameters or a static variable.
+       Valid forms are:
+       - [pub] [unsafe] [extern $abi] fn $name() { ... }
+       - static $name : $ty = [unsafe] { ... };
+ --> tests/errors/ctor_bad_shape.rs:3:1
+  |
+3 | #[ctor]
+  | ^^^^^^^
+  |
+  = note: this error originates in the macro `$crate::__ctor_parse_impl` which comes from the expansion of the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid ctor item. Expected a function with no args, return value, or type parameters or a static variable.
+       Valid forms are:
+       - [pub] [unsafe] [extern $abi] fn $name() { ... }
+       - static $name : $ty = [unsafe] { ... };
+ --> tests/errors/ctor_bad_shape.rs:8:1
+  |
+8 | #[ctor]
+  | ^^^^^^^
+  |
+  = note: this error originates in the macro `$crate::__ctor_parse_impl` which comes from the expansion of the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid ctor item. Expected a function with no args, return value, or type parameters or a static variable.
+       Valid forms are:
+       - [pub] [unsafe] [extern $abi] fn $name() { ... }
+       - static $name : $ty = [unsafe] { ... };
+  --> tests/errors/ctor_bad_shape.rs:15:5
+   |
+15 |     #[ctor]
+   |     ^^^^^^^
+   |
+   = note: this error originates in the macro `$crate::__ctor_parse_impl` which comes from the expansion of the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0401]: can't use generic parameters from outer item
+  --> tests/errors/ctor_bad_shape.rs:28:13
+   |
+24 | impl<T: Default> FooGeneric<T> {
+   |      - type parameter from outer item
+25 |     #[ctor]
+   |     ------- generic parameter used in this inner function
+...
+28 |         _ = T::default();
+   |             ^ use of generic parameter from outer item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+help: try introducing a local generic parameter here
+  --> src/parse.rs
+   |
+   |             $($unsafe)* $( extern $abi )? fn __ctor_private_inner<T>() {
+   |                                                                  +++

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
@@ -7,12 +13,10 @@ unsafe fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { unsafe { foo() } }
+                { unsafe { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -1,6 +1,12 @@
 use ctor::ctor;
 const _: () = {
+    #[allow(dead_code)]
     unsafe fn foo() {
+        unsafe fn __ctor_private_inner() {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
         const _: () = {
             #[allow(unsafe_code)]
             #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
@@ -8,18 +14,22 @@ const _: () = {
             static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
                 #[allow(unused_unsafe)]
                 extern "C" fn __ctor_private() {
-                    { unsafe { foo() } }
+                    { unsafe { __ctor_private_inner() } }
                 }
                 __ctor_private
             };
         };
-        {
-            ::std::io::_print(format_args!("foo\n"));
-        };
+        unsafe { __ctor_private_inner() }
     }
 };
 const _: () = {
+    #[allow(dead_code)]
     unsafe fn foo() {
+        unsafe fn __ctor_private_inner() {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
         const _: () = {
             #[allow(unsafe_code)]
             #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
@@ -27,13 +37,11 @@ const _: () = {
             static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
                 #[allow(unused_unsafe)]
                 extern "C" fn __ctor_private() {
-                    { unsafe { foo() } }
+                    { unsafe { __ctor_private_inner() } }
                 }
                 __ctor_private
             };
         };
-        {
-            ::std::io::_print(format_args!("foo\n"));
-        };
+        unsafe { __ctor_private_inner() }
     }
 };

--- a/ctor/tests/expand-darwin/ctor_attribute.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_attribute.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = ".ctors"]
@@ -7,12 +13,10 @@ fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { { foo() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -1,7 +1,13 @@
 use ctor::ctor;
 /// Doc 1
 /// Doc 2
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
@@ -9,12 +15,10 @@ unsafe fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { unsafe { foo() } }
+                { unsafe { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -1,15 +1,19 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unused_unsafe)]
         fn __ctor_private() {
-            { { foo() } }
+            { { __ctor_private_inner() } }
         }
         #[link_section = "__DATA,CTOR,regular,no_dead_strip"]
         #[used]
         static __CTOR_ENTRY: (fn(), u16) = (__ctor_private, 1);
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
@@ -7,12 +13,10 @@ unsafe fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { unsafe { foo() } }
+                { unsafe { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
@@ -7,12 +13,10 @@ fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { { foo() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-darwin/ctor_warn.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_warn.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
@@ -7,12 +13,10 @@ fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { { foo() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_anon.expanded.rs
@@ -1,6 +1,12 @@
 use ctor::ctor;
 const _: () = {
+    #[allow(dead_code)]
     unsafe fn foo() {
+        unsafe fn __ctor_private_inner() {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
         const _: () = {
             #[allow(unsafe_code)]
             #[link_section = ".init_array"]
@@ -8,18 +14,22 @@ const _: () = {
             static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
                 #[allow(unused_unsafe)]
                 extern "C" fn __ctor_private() {
-                    { unsafe { foo() } }
+                    { unsafe { __ctor_private_inner() } }
                 }
                 __ctor_private
             };
         };
-        {
-            ::std::io::_print(format_args!("foo\n"));
-        };
+        unsafe { __ctor_private_inner() }
     }
 };
 const _: () = {
+    #[allow(dead_code)]
     unsafe fn foo() {
+        unsafe fn __ctor_private_inner() {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
         const _: () = {
             #[allow(unsafe_code)]
             #[link_section = ".init_array"]
@@ -27,13 +37,11 @@ const _: () = {
             static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
                 #[allow(unused_unsafe)]
                 extern "C" fn __ctor_private() {
-                    { unsafe { foo() } }
+                    { unsafe { __ctor_private_inner() } }
                 }
                 __ctor_private
             };
         };
-        {
-            ::std::io::_print(format_args!("foo\n"));
-        };
+        unsafe { __ctor_private_inner() }
     }
 };

--- a/ctor/tests/expand-linux/ctor_attribute.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_attribute.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = ".ctors"]
@@ -7,12 +13,10 @@ fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { { foo() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_doc.expanded.rs
@@ -1,7 +1,13 @@
 use ctor::ctor;
 /// Doc 1
 /// Doc 2
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = ".init_array"]
@@ -9,12 +15,10 @@ unsafe fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { unsafe { foo() } }
+                { unsafe { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_priority.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = ".init_array.001"]
@@ -7,12 +13,10 @@ fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { { foo() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_used_linker_attr.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = ".init_array"]
@@ -7,12 +13,10 @@ fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { { foo() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor_warn.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_warn.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = ".init_array"]
@@ -7,12 +13,10 @@ fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { { foo() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand/ctor_mutli_attr.expanded.rs
+++ b/ctor/tests/expand/ctor_mutli_attr.expanded.rs
@@ -1,5 +1,11 @@
 use ctor::ctor;
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[allow(unsafe_code)]
         #[link_section = ".ctors"]
@@ -7,12 +13,10 @@ unsafe fn foo() {
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]
             extern "C" fn __ctor_private() {
-                { unsafe { foo() } }
+                { unsafe { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __ctor_private_inner() }
 }

--- a/ctor/tests/expand/ctor_struct.expanded.rs
+++ b/ctor/tests/expand/ctor_struct.expanded.rs
@@ -1,0 +1,7 @@
+struct Foo {}
+impl Foo {
+    #[ctor(unsafe, link_section = ".ctors")]
+    fn ctor() {
+        (/*ERROR*/);
+    }
+}

--- a/ctor/tests/expand/ctor_struct.rs
+++ b/ctor/tests/expand/ctor_struct.rs
@@ -1,0 +1,9 @@
+struct Foo {
+}
+
+impl Foo {
+    #[ctor(unsafe, link_section = ".ctors")]
+    fn ctor() {
+        libc_eprintln!("Foo::ctor");
+    }
+}

--- a/ctor/tests/target-test/ctor/powerpc64-ibm-aix.rs
+++ b/ctor/tests/target-test/ctor/powerpc64-ibm-aix.rs
@@ -1,6 +1,8 @@
 use ctor::declarative::ctor;
 
+#[allow(dead_code)]
 fn foo() {
+    fn __ctor_private_inner() {}
     const _: () =
         {
             #[allow(unsafe_code)]
@@ -8,9 +10,13 @@ fn foo() {
                 {
                     #[allow(unused_unsafe)]
                     #[no_mangle]
-                    #[export_name = "__sinit0_expand_probe_expand_probe_foo_L5C1"]
-                    extern "C" fn __ctor_private() { { { foo() } } }
+                    #[export_name =
+                    "__sinit0_expand_probe_expand_probe_foo_L5C1"]
+                    extern "C" fn __ctor_private() {
+                        { { __ctor_private_inner() } }
+                    }
                     __ctor_private
                 };
         };
+    { __ctor_private_inner() }
 }

--- a/dtor/src/parse.rs
+++ b/dtor/src/parse.rs
@@ -363,7 +363,14 @@ macro_rules! __dtor_parse_impl {
         })
     ) ) => {
         $($meta)*
+        #[allow(dead_code)]
         $vis $($unsafe)* $( extern $abi )? fn $name $args {
+            // The outer function may be attached to a struct, so we generate an
+            // inner function that is freestanding and call it from both places.
+            $($unsafe)* $( extern $abi )? fn __dtor_private_inner $args {
+                $($body)*
+            }
+
             $crate::__dtor_parse_impl!(@dtor next=$next[$next_args], input=(
                 features = (
                     ctor_export_name_prefix = $ctor_export_name_prefix,
@@ -373,11 +380,10 @@ macro_rules! __dtor_parse_impl {
                     method = $method,
                     used_linker_meta = (#$used_linker_meta),
                 ),
-                item = $name,
-                unsafe = ($($unsafe)*)
+                item = ($($unsafe)* { __dtor_private_inner() })
             ));
 
-            $($body)*
+            $($unsafe)* { __dtor_private_inner() }
         }
     };
 
@@ -392,15 +398,14 @@ macro_rules! __dtor_parse_impl {
             method = linker,
             used_linker_meta = (#$used_linker_meta:tt),
         ),
-        item = $name:ident,
-        unsafe = ($($unsafe:tt)*)
+        item = ($($item:tt)*)
     ) ) => {
         const _: () = {
             #[link_section = $link_section]
             #$used_linker_meta
             static __DTOR_PRIVATE_REF: extern "C" fn() = {
                 extern "C" fn __dtor_private() {
-                    $($unsafe)* { $name() }
+                    $($item)*
                 }
                 __dtor_private
             };
@@ -416,8 +421,7 @@ macro_rules! __dtor_parse_impl {
             method = linker,
             used_linker_meta = (#$used_linker_meta:tt),
         ),
-        item = $name:ident,
-        unsafe = ($($unsafe:tt)*)
+        item = ($($item:tt)*)
     ) ) => {
         const _: () = {
             #[no_mangle]
@@ -432,7 +436,7 @@ macro_rules! __dtor_parse_impl {
                 "C",
                 column!())]
             extern "C" fn __dtor_private() {
-                $($unsafe)* { $name() }
+                $($item)*
             }
         };
     };
@@ -446,8 +450,7 @@ macro_rules! __dtor_parse_impl {
             method = $method:ident,
             used_linker_meta = (#$used_linker_meta:tt),
         ),
-        item = $name:ident,
-        unsafe = ($($unsafe:tt)*)
+        item = ($($item:tt)*)
     ) ) => {
         const _: () = {
             #[link_section = $ctor_link_section]
@@ -457,7 +460,7 @@ macro_rules! __dtor_parse_impl {
                     $crate::__support::$method(__dtor_private);
                 }
                 extern "C" fn __dtor_private() {
-                    $($unsafe)* { $name() }
+                    $($item)*
                 }
                 __ctor_private
             };
@@ -473,8 +476,7 @@ macro_rules! __dtor_parse_impl {
             method = $method:ident,
             used_linker_meta = (#$used_linker_meta:tt),
         ),
-        item = $name:ident,
-        unsafe = ($($unsafe:tt)*)
+        item = ($($item:tt)*)
     ) ) => {
         const _: () = {
             #[no_mangle]
@@ -493,7 +495,7 @@ macro_rules! __dtor_parse_impl {
             }
 
             extern "C" fn __dtor_private() {
-                $($unsafe)* { $name() }
+                $($item)*
             }
         };
     };

--- a/dtor/tests/expand-darwin/dtor.expanded.rs
+++ b/dtor/tests/expand-darwin/dtor.expanded.rs
@@ -1,5 +1,11 @@
 use dtor::dtor;
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
@@ -8,12 +14,10 @@ unsafe fn foo() {
                 ::dtor::__support::at_module_exit(__dtor_private);
             }
             extern "C" fn __dtor_private() {
-                unsafe { foo() }
+                unsafe { __dtor_private_inner() }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __dtor_private_inner() }
 }

--- a/dtor/tests/expand-darwin/dtor_anon.expanded.rs
+++ b/dtor/tests/expand-darwin/dtor_anon.expanded.rs
@@ -1,6 +1,12 @@
 use dtor::dtor;
 const _: () = {
+    #[allow(dead_code)]
     unsafe fn foo() {
+        unsafe fn __dtor_private_inner() {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
         const _: () = {
             #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
             #[used]
@@ -9,13 +15,11 @@ const _: () = {
                     ::dtor::__support::at_module_exit(__dtor_private);
                 }
                 extern "C" fn __dtor_private() {
-                    unsafe { foo() }
+                    unsafe { __dtor_private_inner() }
                 }
                 __ctor_private
             };
         };
-        {
-            ::std::io::_print(format_args!("foo\n"));
-        };
+        unsafe { __dtor_private_inner() }
     }
 };

--- a/dtor/tests/expand-darwin/dtor_doc.expanded.rs
+++ b/dtor/tests/expand-darwin/dtor_doc.expanded.rs
@@ -1,7 +1,13 @@
 use dtor::dtor;
 /// Doc 1
 /// Doc 2
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
@@ -10,12 +16,10 @@ unsafe fn foo() {
                 ::dtor::__support::at_module_exit(__dtor_private);
             }
             extern "C" fn __dtor_private() {
-                unsafe { foo() }
+                unsafe { __dtor_private_inner() }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __dtor_private_inner() }
 }

--- a/dtor/tests/expand-darwin/dtor_unsafe.expanded.rs
+++ b/dtor/tests/expand-darwin/dtor_unsafe.expanded.rs
@@ -1,5 +1,11 @@
 use dtor::dtor;
+#[allow(dead_code)]
 fn foo() {
+    fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
         #[used]
@@ -8,12 +14,10 @@ fn foo() {
                 ::dtor::__support::at_module_exit(__dtor_private);
             }
             extern "C" fn __dtor_private() {
-                { foo() }
+                { __dtor_private_inner() }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __dtor_private_inner() }
 }

--- a/dtor/tests/expand-linux/dtor.expanded.rs
+++ b/dtor/tests/expand-linux/dtor.expanded.rs
@@ -1,16 +1,20 @@
 use dtor::dtor;
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".fini_array"]
         #[used]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                unsafe { foo() }
+                unsafe { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __dtor_private_inner() }
 }

--- a/dtor/tests/expand-linux/dtor_anon.expanded.rs
+++ b/dtor/tests/expand-linux/dtor_anon.expanded.rs
@@ -1,18 +1,22 @@
 use dtor::dtor;
 const _: () = {
+    #[allow(dead_code)]
     unsafe fn foo() {
+        unsafe fn __dtor_private_inner() {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
         const _: () = {
             #[link_section = ".fini_array"]
             #[used]
             static __DTOR_PRIVATE_REF: extern "C" fn() = {
                 extern "C" fn __dtor_private() {
-                    unsafe { foo() }
+                    unsafe { __dtor_private_inner() }
                 }
                 __dtor_private
             };
         };
-        {
-            ::std::io::_print(format_args!("foo\n"));
-        };
+        unsafe { __dtor_private_inner() }
     }
 };

--- a/dtor/tests/expand-linux/dtor_doc.expanded.rs
+++ b/dtor/tests/expand-linux/dtor_doc.expanded.rs
@@ -1,18 +1,22 @@
 use dtor::dtor;
 /// Doc 1
 /// Doc 2
+#[allow(dead_code)]
 unsafe fn foo() {
+    unsafe fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".fini_array"]
         #[used]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                unsafe { foo() }
+                unsafe { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __dtor_private_inner() }
 }

--- a/dtor/tests/expand-windows/dtor.expanded.rs
+++ b/dtor/tests/expand-windows/dtor.expanded.rs
@@ -1,4 +1,5 @@
 use dtor::dtor;
+#[allow(dead_code)]
 unsafe fn foo() {
     unsafe fn __dtor_private_inner() {
         {

--- a/dtor/tests/expand-windows/dtor.expanded.rs
+++ b/dtor/tests/expand-windows/dtor.expanded.rs
@@ -1,11 +1,11 @@
 use dtor::dtor;
 unsafe fn foo() {
-        unsafe fn __dtor_private_inner() {
-            {
-                ::std::io::_print(format_args!("foo\n"));
-            };
-        }
-        const _: () = {
+    unsafe fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
+    const _: () = {
         #[link_section = ".CRT$XCU"]
         #[used]
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {

--- a/dtor/tests/expand-windows/dtor.expanded.rs
+++ b/dtor/tests/expand-windows/dtor.expanded.rs
@@ -1,6 +1,11 @@
 use dtor::dtor;
 unsafe fn foo() {
-    const _: () = {
+        unsafe fn __dtor_private_inner() {
+            {
+                ::std::io::_print(format_args!("foo\n"));
+            };
+        }
+        const _: () = {
         #[link_section = ".CRT$XCU"]
         #[used]
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
@@ -8,12 +13,10 @@ unsafe fn foo() {
                 ::dtor::__support::at_module_exit(__dtor_private);
             }
             extern "C" fn __dtor_private() {
-                unsafe { foo() }
+                unsafe { __dtor_private_inner() }
             }
             __ctor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    unsafe { __dtor_private_inner() }
 }

--- a/dtor/tests/expand/dtor_complex_path.expanded.rs
+++ b/dtor/tests/expand/dtor_complex_path.expanded.rs
@@ -1,30 +1,38 @@
+#[allow(dead_code)]
 fn foo() {
+    fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".dtors"]
         #[used]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                { foo() }
+                { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __dtor_private_inner() }
 }
+#[allow(dead_code)]
 fn bar() {
+    fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".dtors"]
         #[used]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                { bar() }
+                { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __dtor_private_inner() }
 }

--- a/dtor/tests/expand/dtor_declarative.expanded.rs
+++ b/dtor/tests/expand/dtor_declarative.expanded.rs
@@ -8,18 +8,22 @@ const _: () = {
     #[allow(unused)]
     static UNSAFE_WARNING: () = { dtor_without_unsafe_is_deprecated() };
 };
+#[allow(dead_code)]
 fn foo() {
+    fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".dtors"]
         #[used]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                { foo() }
+                { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __dtor_private_inner() }
 }

--- a/dtor/tests/expand/dtor_link_section.expanded.rs
+++ b/dtor/tests/expand/dtor_link_section.expanded.rs
@@ -1,16 +1,20 @@
 use dtor::dtor;
+#[allow(dead_code)]
 fn foo() {
+    fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".dtors"]
         #[used]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                { foo() }
+                { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __dtor_private_inner() }
 }

--- a/dtor/tests/expand/dtor_used_linker.expanded.rs
+++ b/dtor/tests/expand/dtor_used_linker.expanded.rs
@@ -1,16 +1,20 @@
 use dtor::dtor;
+#[allow(dead_code)]
 fn foo() {
+    fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".dtors"]
         #[used(linker)]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                { foo() }
+                { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __dtor_private_inner() }
 }

--- a/dtor/tests/expand/dtor_warn.expanded.rs
+++ b/dtor/tests/expand/dtor_warn.expanded.rs
@@ -8,18 +8,22 @@ const _: () = {
     #[allow(unused)]
     static UNSAFE_WARNING: () = { dtor_without_unsafe_is_deprecated() };
 };
+#[allow(dead_code)]
 fn foo() {
+    fn __dtor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
     const _: () = {
         #[link_section = ".dtors"]
         #[used]
         static __DTOR_PRIVATE_REF: extern "C" fn() = {
             extern "C" fn __dtor_private() {
-                { foo() }
+                { __dtor_private_inner() }
             }
             __dtor_private
         };
     };
-    {
-        ::std::io::_print(format_args!("foo\n"));
-    };
+    { __dtor_private_inner() }
 }

--- a/dtor/tests/target-test/dtor/powerpc64-ibm-aix.rs
+++ b/dtor/tests/target-test/dtor/powerpc64-ibm-aix.rs
@@ -1,11 +1,14 @@
 use dtor::declarative::dtor;
 
+#[allow(dead_code)]
 fn foo() {
+    fn __dtor_private_inner() {}
     const _: () =
         {
             #[no_mangle]
             #[export_name =
-            "__sterm80000000_expand_probe_expand_probe_foo_L5C1"]
-            extern "C" fn __dtor_private() { { foo() } }
+            "__sterm80000000_expand_probe_expand_probe_$name_L5C1"]
+            extern "C" fn __dtor_private() { { __dtor_private_inner() } }
         };
+    { __dtor_private_inner() }
 }

--- a/dtor/tests/target-test/dtor_module_exit/powerpc64-ibm-aix.rs
+++ b/dtor/tests/target-test/dtor_module_exit/powerpc64-ibm-aix.rs
@@ -1,14 +1,17 @@
 use dtor::declarative::dtor;
 
+#[allow(dead_code)]
 fn foo_exit() {
+    fn __dtor_private_inner() {}
     const _: () =
         {
             #[no_mangle]
             #[export_name =
-            "__sinit80000000_expand_probe_expand_probe_foo_exit_L5C1"]
+            "__sinit80000000_expand_probe_expand_probe_$name_L5C1"]
             unsafe extern "C" fn __ctor_private() {
                 ::dtor::__support::at_module_exit(__dtor_private);
             }
-            extern "C" fn __dtor_private() { { foo_exit() } }
+            extern "C" fn __dtor_private() { { __dtor_private_inner() } }
         };
+    { __dtor_private_inner() }
 }

--- a/tests/ctor/mod.rs
+++ b/tests/ctor/mod.rs
@@ -163,7 +163,10 @@ $ cargo build --lib --examples --quiet
 $ find $CARGO_TARGET_DIR
 *
 $ cargo run --example dylib_load --quiet
-! + ctor bin
+unordered {
+    ! + Foo::ctor
+    ! + ctor bin
+}
 ! ++ main start
 unordered {
     ! +++ ctor STATIC_INT
@@ -173,7 +176,10 @@ unordered {
     ! -- main end
     ! --- dtor lib
 }
-! - dtor bin
+unordered {
+    ! - Foo::dtor
+    ! - dtor bin
+}
 "#
 );
 

--- a/tests/ctor/mod.rs
+++ b/tests/ctor/mod.rs
@@ -121,7 +121,10 @@ defer {
 $ cargo build --lib --examples --quiet
 *
 $ cargo run --example dylib_load --quiet
-! + ctor bin
+unordered {
+    ! + Foo::ctor
+    ! + ctor bin
+}
 ! ++ main start
 unordered {
     ! +++ ctor STATIC_INT
@@ -131,7 +134,10 @@ unordered {
     ! -- main end
     ! --- dtor lib
 }
-! - dtor bin
+unordered {
+    ! - Foo::dtor
+    ! - dtor bin
+}
 "#
 );
 

--- a/tests/ctor/system/src/dylib_load.rs
+++ b/tests/ctor/system/src/dylib_load.rs
@@ -7,6 +7,21 @@ use dtor::dtor;
 use dlopen::raw::Library;
 use libc_print::*;
 
+#[allow(unused)]
+struct Foo;
+
+impl Foo {
+    #[ctor(unsafe)]
+    fn ctor() {
+        libc_eprintln!("Foo::ctor");
+    }
+
+    #[dtor(unsafe)]
+    fn dtor() {
+        libc_eprintln!("Foo::dtor");
+    }
+}
+
 #[ctor]
 #[cfg(not(test))]
 #[allow(unsafe_code)]

--- a/tests/ctor/system/src/dylib_load.rs
+++ b/tests/ctor/system/src/dylib_load.rs
@@ -13,12 +13,12 @@ struct Foo;
 impl Foo {
     #[ctor(unsafe)]
     fn ctor() {
-        libc_eprintln!("Foo::ctor");
+        libc_eprintln!("+ Foo::ctor");
     }
 
     #[dtor(unsafe)]
     fn dtor() {
-        libc_eprintln!("Foo::dtor");
+        libc_eprintln!("- Foo::dtor");
     }
 }
 

--- a/tests/ctor/warn-unsafe/src/main.rs
+++ b/tests/ctor/warn-unsafe/src/main.rs
@@ -37,12 +37,10 @@ struct Foo {
 impl Foo {
     #[ctor(unsafe)]
     fn ctor() {
-        println!("Foo::ctor");
     }
 
     #[ctor]
     unsafe fn unsafe_ctor() {
-        println!("Foo::dtor");
     }
 }
 

--- a/tests/ctor/warn-unsafe/src/main.rs
+++ b/tests/ctor/warn-unsafe/src/main.rs
@@ -30,5 +30,21 @@ pub static FOO_UNSAFE: u32 = {
     42
 };
 
+
+struct Foo {
+}
+
+impl Foo {
+    #[ctor(unsafe)]
+    fn ctor() {
+        println!("Foo::ctor");
+    }
+
+    #[ctor]
+    unsafe fn unsafe_ctor() {
+        println!("Foo::dtor");
+    }
+}
+
 fn main() {
 }


### PR DESCRIPTION
Allow `ctor` and `dtor` for `impl` items, fixing #330.