### PR TITLE
Release 1.0 (🎉)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cfg-if"
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.13.1"
+version = "1.0.0"
 dependencies = [
  "libc-print",
  "link-section",
@@ -451,9 +451,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libc-print"
@@ -1042,11 +1042,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1340,9 +1340,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -1352,6 +1352,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "linktime"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "ctor",
  "dtor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "0.13.1", default-features = false }
+ctor = { path = "ctor", version = "1.0.0", default-features = false }
 dtor = { path = "dtor", version = "0.13.1", default-features = false }
 link-section = { path = "link-section", version = "0.13.1", default-features = false }
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Identical to 0.13.1. Stabilized (yay!). Thanks to all the contributors who
   helped along the way!
+- For those upgrading from earlier versions, the major changes for you to note
+  are:
+    - `dtor` was split into the `dtor` crate. You'll need to add it to your
+      dependencies like so:
+      ```toml
+      [dependencies]
+      dtor = "0.13.1" # or later
+      ```
+    - `#[ctor(unsafe)]` is now required for `#[ctor]` items.
+    - The `ctor::declarative::ctor!` macro should be preferred over
+      `#[ctor(crate_path = ...)]`.
 
 ## [0.13.1] - 2026-05-02
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -20,18 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       [dependencies]
       dtor = "0.13.1" # or later
       ```
-    - `#[ctor(unsafe)]` is now required for `#[ctor]` items. If you are building
-    a binary, you can use `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"`
-    (or alternatively, specify this in your `config.toml` file) to bypass the
-    error.
-    - The `ctor::declarative::ctor!` macro should be preferred over
-      `#[ctor(crate_path = ...)]`.
+    - `#[ctor(unsafe)]` is now required for `#[ctor]` items. If you are building a
+      binary, you can use `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"`
+      (or alternatively, specify this in your `config.toml` file) to bypass the
+      error.
+    - For those re-exporting `ctor` from their own crates: the
+      `ctor::declarative::ctor!` macro should be preferred over
+      `#[ctor(crate_path = ...)]`. The latter form will continue to work, but
+      the declarative macro is far more stable for most use cases. See
+      <https://docs.rs/ctor/latest/ctor/declarative/macro.ctor.html> for more
+      details.
 
 ## [0.13.1] - 2026-05-02
 
 ### Changed
 
-- Crate examples reorganized.
+- Crate examples were reorganized.
 
 ### Fixed
 
@@ -64,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- deprecated `dtor` feature and crate dependency from `ctor` crate (use the `dtor` crate directly).
+- Deprecated `dtor` feature and crate dependency from `ctor` crate (use the
+  `dtor` crate directly).
 
 ### Fixed
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Identical to 0.13.1. Stabilized (yay!). Thanks to all the contributors who
+- Stabilized (yay!). Identical to 0.13.1. Thanks to all the contributors who
   helped along the way! Please file any upgrade issues in
   <https://github.com/mmastrac/linktime/issues>.
 - For those upgrading from earlier versions, the major changes for you to note

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2026-05-03
 
+### Changed
+
 - Identical to 0.13.1. Stabilized (yay!). Thanks to all the contributors who
-  helped along the way!
+  helped along the way! Please file any upgrade issues in
+  <https://github.com/mmastrac/linktime/issues>.
 - For those upgrading from earlier versions, the major changes for you to note
   are:
     - `dtor` was split into the `dtor` crate. You'll need to add it to your
@@ -17,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       [dependencies]
       dtor = "0.13.1" # or later
       ```
-    - `#[ctor(unsafe)]` is now required for `#[ctor]` items.
+    - `#[ctor(unsafe)]` is now required for `#[ctor]` items. If you are building
+    a binary, you can use `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"`
+    (or alternatively, specify this in your `config.toml` file) to bypass the
+    error.
     - The `ctor::declarative::ctor!` macro should be preferred over
       `#[ctor(crate_path = ...)]`.
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-05-03
+
+- Identical to 0.13.1. Stabilized (yay!). Thanks to all the contributors who
+  helped along the way!
+
 ## [0.13.1] - 2026-05-02
 
 ### Changed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "0.13.1"
+version = "1.0.0"
 authors.workspace = true
 edition = "2021"
 description = "__attribute__((constructor)) for Rust"

--- a/linktime/CHANGELOG.md
+++ b/linktime/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-05-03
+
+- Stabilized the `ctor` crate.
+
 ## [0.13.1] - 2026-05-02
 
 ### Changed

--- a/linktime/Cargo.toml
+++ b/linktime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linktime"
-version = "0.13.1"
+version = "0.14.0"
 authors.workspace = true
 edition = "2021"
 description = "Link-time tricks for Rust"

--- a/macro-magic/tests/test_item.rs
+++ b/macro-magic/tests/test_item.rs
@@ -9,7 +9,7 @@ __declare_features!(
     std {
         feature: "std";
     };
-    /// Marks a ctor/dtor as unsafe. This will become a warning in 1.0.
+    /// Marks a ctor/dtor as unsafe.
     unsafe {
         attr: [(unsafe) => (unsafe)];
     };


### PR DESCRIPTION
Assuming no problems with the latest ctor 0.13.1, this is `ctor 1.0`

TODO:

 - [x] Fix the release date in CHANGELOG

Closes #160