### PR TITLE
Pre-1.0 doc and typo fixes, release 0.13.1

### DIFF
--- a/.github/jobs/build.sh
+++ b/.github/jobs/build.sh
@@ -7,4 +7,5 @@ rm Cargo.lock
 cargo clean
 cargo build
 cargo run -p ctor --example ctor-example --target $TARGET
+cargo run -p ctor --example ctor-advanced --target $TARGET
 

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -6,6 +6,9 @@ export RUSTFLAGS="-Z extra-const-ub-checks"
 # https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance
 export MIRIFLAGS="-Zmiri-permissive-provenance"
 
+# May need to rebuild when beta/nightly changes
+cargo clean
+
 cargo miri test
 
 cd tests/ctor/edition-2018

--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -2,4 +2,5 @@
 set -xeuo pipefail
 
 RUSTFLAGS="-Z sanitizer=address" cargo +nightly run -p ctor --example ctor-example --target $TARGET
+RUSTFLAGS="-Z sanitizer=address" cargo +nightly run -p ctor --example ctor-advanced --target $TARGET
 RUSTFLAGS="-Z sanitizer=address" cargo +nightly run -p link-section --example link-section-example --target $TARGET

--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -15,6 +15,11 @@ sleep .1
 target/${TARGET}/debug/examples/ctor-example
 
 sleep .1
+echo "Running advanced ctor example..."
+sleep .1
+target/${TARGET}/debug/examples/ctor-advanced
+
+sleep .1
 echo "Running link-section example..."
 sleep .1
 target/${TARGET}/debug/examples/link-section-example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 This workspace publishes multiple crates. Each crate maintains its own changelog:
 
+- [`linktime/CHANGELOG.md`](linktime/CHANGELOG.md)
 - [`ctor/CHANGELOG.md`](ctor/CHANGELOG.md)
 - [`dtor/CHANGELOG.md`](dtor/CHANGELOG.md)
 - [`link-section/CHANGELOG.md`](link-section/CHANGELOG.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "libc-print",
  "link-section",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "libc-print",
  "linktime-proc-macro",
@@ -475,14 +475,14 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "linktime-proc-macro",
 ]
 
 [[package]]
 name = "linktime"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ctor",
  "dtor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "0.13.0", default-features = false }
-dtor = { path = "dtor", version = "0.13.0", default-features = false }
-link-section = { path = "link-section", version = "0.13.0", default-features = false }
+ctor = { path = "ctor", version = "0.13.1", default-features = false }
+dtor = { path = "dtor", version = "0.13.1", default-features = false }
+link-section = { path = "link-section", version = "0.13.1", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-05-02
+
+### Fixed
+
+- Documentation fixes (`--cfg` flags were incorrect).
+- Incorrect crate feature in docs.
+
 ## [0.13.0] - 2026-05-02
 
 ### Changed
@@ -12,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `#[ctor(priority = naked)]` is now `#[ctor(naked)]`.
 - `unsafe` is now required for `#[ctor]` items and the
   `no_warn_on_missing_unsafe` feature is gone.
-  - `RUSTFLAGS="--cfg no_fail_on_missing_unsafe"` can bypass the error.
+  - `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` can bypass the error.
 - `used_linker` feature moved to `--cfg linktime_used_linker` flag.
 
 ### Added

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.1] - 2026-05-02
 
+### Changed
+
+- Crate examples reorganized.
+
 ### Fixed
 
 - Documentation fixes (`--cfg` flags were incorrect).

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "0.13.0"
+version = "0.13.1"
 authors.workspace = true
 edition = "2021"
 description = "__attribute__((constructor)) for Rust"

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 categories = ["no-std"]
 rust-version = "1.60"
 
+exclude = ["tests"]
+
 [features]
 default = ["std", "proc_macro", "priority"]
 

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -30,7 +30,7 @@ MSRV for WASM targets is **Rust >= 1.85**.
 
 ## Lightweight
 
-`ctor` has no dependencies other than the `ctor-proc-macro` and `link-section`
+`ctor` has no dependencies other than the `linktime-proc-macro` and `link-section`
 crates. The proc-macro is only used to delegate to the declarative macro and
 should have minimal effect on compilation time.
 
@@ -209,7 +209,7 @@ The idea for `ctor` was originally inspired by the Neon project.
 
 | Cargo feature | Description |
 | --- | --- |
-| `priority_enabled` |  Enable support for the priority parameter. |
+| `priority` |  Enable support for the priority parameter. |
 | `proc_macro` |  Enable support for the proc-macro `#[ctor]` attribute. The declarative form (`ctor!(...)`) is always available. It is recommended that crates re-exporting the `ctor` macro disable this feature and only use the declarative form. |
 | `std` |  Enable support for the standard library. |
 
@@ -290,8 +290,8 @@ The idea for `ctor` was originally inspired by the Neon project.
 
  Priority is specified as an isize, string literal, or the identifiers
  `early` or `late`. The integer value will be clamped to a
- platform-defined range (typically 0-65535), while the string value will
- unprocessed.
+ platform-defined range (typically 0-65535), while string priorities are
+ passed through unprocessed.
 
  Priority is applied as follows:
 
@@ -314,28 +314,27 @@ The idea for `ctor` was originally inspired by the Neon project.
 
  Marks a ctor as unsafe. Required.
 
- The `ctor` crate will warn if there is no unsafe flag in the `ctor`
- annotation. This warning for a missing unsafe keyword can be hidden
- by passing `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to
- Cargo.
+ The `ctor` crate rejects `#[ctor]` without marking the item unsafe;
+ that error can be suppressed by passing
+ `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to Cargo.
 
 
 </td></tr>
 <tr><td><code>used(linker)</code></td><td>
 
 
- Mark generated functions pointers `used(linker)`. Requires nightly
+ Mark generated function pointers `used(linker)`. Requires nightly
  for the nightly-only feature `feature(used_with_arg)` (see
  <https://github.com/rust-lang/rust/issues/93798>).
 
- The can be made the default by using the `cfg` flag
+ This can be made the default by using the `cfg` flag
  `linktime_used_linker` (`RUSTFLAGS="--cfg linktime_used_linker"`).
 
  For a crate using this macro to function correctly with and without
  this flag, it is recommended to add the following line to the top of
  lib.rs in the crate root:
 
- `![cfg_attr(linktime_used_linker, feature(used_with_arg))]`
+ `#![cfg_attr(linktime_used_linker, feature(used_with_arg))]`
 
 
 </td></tr>

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -53,7 +53,7 @@ Contributions to support other platforms or improve testing are welcome.
 | DragonFlyBSD | ✅        | -         |
 | Illumos      | ✅        | -         |
 | Android      | ✅        | -         |
-| iOS/tvOS/etc | ✅        | -         |
+| iOS          | ✅        | -         |
 | AIX          | ✅        | -         |
 | Haiku        | ✅        | -         |
 | VxWorks      | ✅        | -         |

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -10,7 +10,7 @@ The crate is part of the [`linktime`](https://crates.io/crates/linktime) project
 | `link-section` | [![docs.rs](https://docs.rs/link-section/badge.svg)](https://docs.rs/link-section) | [![crates.io](https://img.shields.io/crates/v/link-section.svg)](https://crates.io/crates/link-section) |
 # ctor
 Module initialization functions for Rust (like `__attribute__((constructor))` in
-C/C++) for Linux, OSX, Windows, WASM, BSD-likes, and many others.
+C/C++) for Linux, macOS, Windows, WASM, BSD-likes, and many others.
 
 ```rust
 use ctor::ctor;
@@ -36,7 +36,7 @@ should have minimal effect on compilation time.
 
 ## Support
 
-This library works and is regularly tested on Linux, OSX, Windows, and FreeBSD,
+This library works and is regularly tested on Linux, macOS, Windows, and FreeBSD,
 with both `+crt-static` and `-crt-static` and `bin`/`cdylib` outputs.
 
 Contributions to support other platforms or improve testing are welcome.
@@ -44,7 +44,7 @@ Contributions to support other platforms or improve testing are welcome.
 | OS           | Supported | CI Tested |
 | ------------ | --------- | --------- |
 | Linux        | ✅        | ✅        |
-| OSX          | ✅        | ✅        |
+| macOS        | ✅        | ✅        |
 | Windows      | ✅        | ✅        |
 | FreeBSD      | ✅        | ✅        |
 | WASM         | ✅        | ✅        |
@@ -53,7 +53,7 @@ Contributions to support other platforms or improve testing are welcome.
 | DragonFlyBSD | ✅        | -         |
 | Illumos      | ✅        | -         |
 | Android      | ✅        | -         |
-| iOS          | ✅        | -         |
+| iOS/tvOS/etc | ✅        | -         |
 | AIX          | ✅        | -         |
 | Haiku        | ✅        | -         |
 | VxWorks      | ✅        | -         |

--- a/ctor/docs/GENERATED.md
+++ b/ctor/docs/GENERATED.md
@@ -3,7 +3,7 @@
 
 | Cargo feature | Description |
 | --- | --- |
-| `priority_enabled` |  Enable support for the priority parameter. |
+| `priority` |  Enable support for the priority parameter. |
 | `proc_macro` |  Enable support for the proc-macro `#[ctor]` attribute. The declarative form (`ctor!(...)`) is always available. It is recommended that crates re-exporting the `ctor` macro disable this feature and only use the declarative form. |
 | `std` |  Enable support for the standard library. |
 
@@ -84,8 +84,8 @@
 
  Priority is specified as an isize, string literal, or the identifiers
  `early` or `late`. The integer value will be clamped to a
- platform-defined range (typically 0-65535), while the string value will
- unprocessed.
+ platform-defined range (typically 0-65535), while string priorities are
+ passed through unprocessed.
 
  Priority is applied as follows:
 
@@ -108,28 +108,27 @@
 
  Marks a ctor as unsafe. Required.
 
- The `ctor` crate will warn if there is no unsafe flag in the `ctor`
- annotation. This warning for a missing unsafe keyword can be hidden
- by passing `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to
- Cargo.
+ The `ctor` crate rejects `#[ctor]` without marking the item unsafe;
+ that error can be suppressed by passing
+ `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to Cargo.
 
 
 </td></tr>
 <tr><td><code>used(linker)</code></td><td>
 
 
- Mark generated functions pointers `used(linker)`. Requires nightly
+ Mark generated function pointers `used(linker)`. Requires nightly
  for the nightly-only feature `feature(used_with_arg)` (see
  <https://github.com/rust-lang/rust/issues/93798>).
 
- The can be made the default by using the `cfg` flag
+ This can be made the default by using the `cfg` flag
  `linktime_used_linker` (`RUSTFLAGS="--cfg linktime_used_linker"`).
 
  For a crate using this macro to function correctly with and without
  this flag, it is recommended to add the following line to the top of
  lib.rs in the crate root:
 
- `![cfg_attr(linktime_used_linker, feature(used_with_arg))]`
+ `#![cfg_attr(linktime_used_linker, feature(used_with_arg))]`
 
 
 </td></tr>

--- a/ctor/docs/PREAMBLE.md
+++ b/ctor/docs/PREAMBLE.md
@@ -19,7 +19,7 @@ MSRV for WASM targets is **Rust >= 1.85**.
 
 ## Lightweight
 
-`ctor` has no dependencies other than the `ctor-proc-macro` and `link-section`
+`ctor` has no dependencies other than the `linktime-proc-macro` and `link-section`
 crates. The proc-macro is only used to delegate to the declarative macro and
 should have minimal effect on compilation time.
 

--- a/ctor/docs/PREAMBLE.md
+++ b/ctor/docs/PREAMBLE.md
@@ -1,5 +1,5 @@
 Module initialization functions for Rust (like `__attribute__((constructor))` in
-C/C++) for Linux, OSX, Windows, WASM, BSD-likes, and many others.
+C/C++) for Linux, macOS, Windows, WASM, BSD-likes, and many others.
 
 ```rust
 use ctor::ctor;
@@ -25,7 +25,7 @@ should have minimal effect on compilation time.
 
 ## Support
 
-This library works and is regularly tested on Linux, OSX, Windows, and FreeBSD,
+This library works and is regularly tested on Linux, macOS, Windows, and FreeBSD,
 with both `+crt-static` and `-crt-static` and `bin`/`cdylib` outputs.
 
 Contributions to support other platforms or improve testing are welcome.
@@ -33,7 +33,7 @@ Contributions to support other platforms or improve testing are welcome.
 | OS           | Supported | CI Tested |
 | ------------ | --------- | --------- |
 | Linux        | ✅        | ✅        |
-| OSX          | ✅        | ✅        |
+| macOS        | ✅        | ✅        |
 | Windows      | ✅        | ✅        |
 | FreeBSD      | ✅        | ✅        |
 | WASM         | ✅        | ✅        |

--- a/ctor/examples/ctor-advanced.rs
+++ b/ctor/examples/ctor-advanced.rs
@@ -6,6 +6,7 @@ use ctor::ctor;
 use libc_print::*;
 use std::collections::HashMap;
 
+/// A global hashmap (allocation before main).
 #[ctor(unsafe)]
 pub static SHOWCASE_GLOBAL: HashMap<u32, &'static str> = {
     let mut m = HashMap::new();
@@ -16,19 +17,21 @@ pub static SHOWCASE_GLOBAL: HashMap<u32, &'static str> = {
     m
 };
 
+/// Anonymous `#[ctor]` function.
 #[ctor(unsafe, anonymous)]
 fn anonymous_ctor() {
     libc_println!("ctor_anonymous (#1)");
     let _f = anonymous_ctor;
 }
 
+/// Anonymous `#[ctor]` function.
 #[ctor(unsafe, anonymous)]
 fn anonymous_ctor() {
     libc_println!("ctor_anonymous (#2)");
 }
 
-// Equivalent to the above.
 const _: () = {
+    /// Equivalent to the `anonymous_ctor` function above.
     #[ctor(unsafe)]
     fn anonymous_ctor() {
         libc_println!("ctor_anonymous (#3)");
@@ -36,25 +39,23 @@ const _: () = {
     }
 };
 
+/// Regular `#[ctor]` function.
 #[ctor(unsafe)]
 fn ctor() {
     libc_println!("ctor");
 }
 
+/// Priority 1 `#[ctor]` function.
 #[ctor(unsafe, priority = 1)]
 fn ctor_priority_one() {
     libc_println!("ctor_priority_one");
-}
-
-#[ctor(unsafe)]
-fn ctor_unsafe() {
-    libc_println!("ctor_unsafe");
 }
 
 pub mod module {
     use ctor::*;
     use libc_print::*;
 
+    /// A `static` item in a nested module.
     #[ctor(unsafe)]
     pub(crate) static STATIC_CTOR: u8 = {
         libc_println!("module::STATIC_CTOR");
@@ -62,16 +63,19 @@ pub mod module {
     };
 }
 
+/// A generic `impl` with a `#[ctor]` method.
 #[derive(Default)]
 struct Foo<T> {
     _t: ::std::marker::PhantomData<T>,
 }
 
 impl<T: Default> Foo<T> {
+    /// Drop the default value of the generic type.
     fn generic(self) {
         drop(T::default());
     }
 
+    /// A `#[ctor]` method in a generic `impl`.
     #[ctor(unsafe)]
     fn ctor() {
         libc_eprintln!("Foo::ctor");

--- a/ctor/examples/ctor-advanced.rs
+++ b/ctor/examples/ctor-advanced.rs
@@ -1,5 +1,5 @@
-//! Constructors beyond the basic ones: anonymous `#[ctor]`, priorities, a nested module,
-//! inherent `#[ctor]` methods in a generic `impl`, and a ctor inside a module-level `const`.
+//! Constructors beyond `ctor-basic` / `ctor-example`: anonymous `#[ctor]`, priorities, nested modules,
+//! inherent `#[ctor]` methods on generic `impl`s, and ctors under a module-level `const`.
 #![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 
 use ctor::ctor;
@@ -17,21 +17,21 @@ pub static SHOWCASE_GLOBAL: HashMap<u32, &'static str> = {
     m
 };
 
-/// Anonymous `#[ctor]` function.
+/// Anonymous ctor (#1 of 2 with the same Rust name).
 #[ctor(unsafe, anonymous)]
 fn anonymous_ctor() {
     libc_println!("ctor_anonymous (#1)");
     let _f = anonymous_ctor;
 }
 
-/// Anonymous `#[ctor]` function.
+/// Anonymous ctor (#2 of 2 with the same Rust name).
 #[ctor(unsafe, anonymous)]
 fn anonymous_ctor() {
     libc_println!("ctor_anonymous (#2)");
 }
 
 const _: () = {
-    /// Equivalent to the `anonymous_ctor` function above.
+    /// Anonymous ctor inside a `const` scope (#3).
     #[ctor(unsafe)]
     fn anonymous_ctor() {
         libc_println!("ctor_anonymous (#3)");

--- a/ctor/examples/ctor-advanced.rs
+++ b/ctor/examples/ctor-advanced.rs
@@ -51,6 +51,7 @@ fn ctor_priority_one() {
     libc_println!("ctor_priority_one");
 }
 
+/// A nested module with a `static` item.
 pub mod module {
     use ctor::*;
     use libc_print::*;

--- a/ctor/examples/ctor-advanced.rs
+++ b/ctor/examples/ctor-advanced.rs
@@ -1,0 +1,89 @@
+//! Constructors beyond the basic ones: anonymous `#[ctor]`, priorities, a nested module,
+//! inherent `#[ctor]` methods in a generic `impl`, and a ctor inside a module-level `const`.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+
+use ctor::ctor;
+use libc_print::*;
+use std::collections::HashMap;
+
+#[ctor(unsafe)]
+pub static SHOWCASE_GLOBAL: HashMap<u32, &'static str> = {
+    let mut m = HashMap::new();
+    _ = m.insert(0, "foo");
+    _ = m.insert(1, "bar");
+    _ = m.insert(2, "baz");
+    libc_println!("SHOWCASE_GLOBAL");
+    m
+};
+
+#[ctor(unsafe, anonymous)]
+fn anonymous_ctor() {
+    libc_println!("ctor_anonymous (#1)");
+    let _f = anonymous_ctor;
+}
+
+#[ctor(unsafe, anonymous)]
+fn anonymous_ctor() {
+    libc_println!("ctor_anonymous (#2)");
+}
+
+// Equivalent to the above.
+const _: () = {
+    #[ctor(unsafe)]
+    fn anonymous_ctor() {
+        libc_println!("ctor_anonymous (#3)");
+        let _f = anonymous_ctor;
+    }
+};
+
+#[ctor(unsafe)]
+fn ctor() {
+    libc_println!("ctor");
+}
+
+#[ctor(unsafe, priority = 1)]
+fn ctor_priority_one() {
+    libc_println!("ctor_priority_one");
+}
+
+#[ctor(unsafe)]
+fn ctor_unsafe() {
+    libc_println!("ctor_unsafe");
+}
+
+pub mod module {
+    use ctor::*;
+    use libc_print::*;
+
+    #[ctor(unsafe)]
+    pub(crate) static STATIC_CTOR: u8 = {
+        libc_println!("module::STATIC_CTOR");
+        42
+    };
+}
+
+#[derive(Default)]
+struct Foo<T> {
+    _t: ::std::marker::PhantomData<T>,
+}
+
+impl<T: Default> Foo<T> {
+    fn generic(self) {
+        drop(T::default());
+    }
+
+    #[ctor(unsafe)]
+    fn ctor() {
+        libc_eprintln!("Foo::ctor");
+    }
+}
+
+fn main() {
+    libc_println!("main!");
+    libc_println!("SHOWCASE_GLOBAL = {:?}", *SHOWCASE_GLOBAL);
+    libc_println!("module::STATIC_CTOR = {:?}", *module::STATIC_CTOR);
+
+    // Only one ctor call runs across monomorphizations; generics are unavailable in ctor bodies.
+    Foo::<u32>::default().generic();
+    Foo::<u64>::default().generic();
+}

--- a/ctor/examples/ctor-basic.rs
+++ b/ctor/examples/ctor-basic.rs
@@ -1,4 +1,4 @@
-//! Same code as the `ctor` crate README introduction (`cargo run --example ctor-basic`).
+//! Matches the `ctor` README introduction (`cargo run --example ctor-basic`).
 #![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 
 use ctor::ctor;

--- a/ctor/examples/ctor-basic.rs
+++ b/ctor/examples/ctor-basic.rs
@@ -1,13 +1,14 @@
-//! Basic example of using the `ctor` crate.
+//! Same code as the `ctor` crate README introduction (`cargo run --example ctor-basic`).
 #![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 
 use ctor::ctor;
+use libc_print::*;
 
 #[ctor(unsafe)]
-fn ctor() {
-    println!("ctor");
+fn foo() {
+    libc_println!("Life before main!");
 }
 
 fn main() {
-    println!("main");
+    libc_println!("main");
 }

--- a/ctor/examples/ctor-example.rs
+++ b/ctor/examples/ctor-example.rs
@@ -1,99 +1,28 @@
-//! This example demonstrates the various types of ctor/dtor in an executable
-//! context.
-
+//! Examples from the `README`.
 #![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 
 use ctor::ctor;
-use libc_print::*;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static INITED: AtomicBool = AtomicBool::new(false);
 
 #[ctor(unsafe)]
-/// This is an immutable static, evaluated at init time
+fn foo() {
+    INITED.store(true, Ordering::SeqCst);
+}
+
+#[ctor(unsafe)]
+/// This is an immutable static, evaluated at init time.
 static STATIC_CTOR: HashMap<u32, &'static str> = {
     let mut m = HashMap::new();
-    _ = m.insert(0, "foo");
-    _ = m.insert(1, "bar");
-    _ = m.insert(2, "baz");
-    libc_println!("STATIC_CTOR");
+    m.insert(0, "foo");
+    m.insert(1, "bar");
+    m.insert(2, "baz");
     m
 };
 
-#[ctor(unsafe, anonymous)]
-fn anonymous_ctor() {
-    libc_println!("ctor_anonymous (#1)");
-    // We can still reference the function itself
-    let _f = anonymous_ctor;
-}
-
-#[ctor(unsafe, anonymous)]
-fn anonymous_ctor() {
-    libc_println!("ctor_anonymous (#2)");
-}
-
-const _: () = {
-    #[ctor(unsafe)]
-    fn anonymous_ctor() {
-        libc_println!("ctor_anonymous (#3)");
-        let _f = anonymous_ctor;
-    }
-};
-
-#[ctor(unsafe)]
-fn ctor() {
-    libc_println!("ctor");
-    // We can still reference the function itself
-    let _f = ctor;
-}
-
-#[ctor(unsafe, priority = 1)]
-fn ctor_priority_one() {
-    libc_println!("ctor_priority_one");
-    // We can still reference the function itself
-    let _f = ctor_priority_one;
-}
-
-#[ctor(unsafe)]
-fn ctor_unsafe() {
-    libc_println!("ctor_unsafe");
-}
-
-/// A module with a static ctor/dtor
-pub mod module {
-    use ctor::*;
-    use libc_print::*;
-
-    #[ctor]
-    pub(crate) static STATIC_CTOR: u8 = unsafe {
-        libc_println!("module::STATIC_CTOR");
-        42
-    };
-}
-
-#[derive(Default)]
-struct Foo<T> {
-    _t: ::std::marker::PhantomData<T>,
-}
-
-impl<T: Default> Foo<T> {
-    fn generic(self) {
-        drop(T::default());
-    }
-
-    #[ctor(unsafe)]
-    fn ctor() {
-        libc_eprintln!("Foo::ctor");
-    }
-}
-
-/// Executable main which demonstrates the various types of ctor/dtor.
-pub fn main() {
-    use libc_print::*;
-    libc_println!("main!");
-    libc_println!("STATIC_CTOR = {:?}", *STATIC_CTOR);
-    libc_println!("module::STATIC_CTOR = {:?}", *module::STATIC_CTOR);
-
-    // Only one ctor call will occur for both generic types, and no generics are
-    // available in the ctor body.
-    Foo::<u32>::default().generic();
-    Foo::<u64>::default().generic();
+fn main() {
+    assert!(INITED.load(Ordering::SeqCst));
+    assert_eq!(STATIC_CTOR.get(&1), Some(&"bar"));
 }

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -87,7 +87,7 @@ pub mod collect {
     /// the constructors will not have been guaranteed to have run.
     #[allow(unsafe_code)]
     pub(crate) unsafe fn run_constructors() {
-        // Mutliple ctor crates may contribute multiple guards, but there will
+        // Multiple ctor crates may contribute multiple guards, but there will
         // only ever be one "first" guard.
         let Some(guard) = _CTR0GR_ISIZE_FN.first() else {
             return;
@@ -179,7 +179,7 @@ pub mod collect {
     );
 }
 
-///Declarative form of the `#[ctor]` macro.
+/// Declarative form of the `#[ctor]` macro.
 pub mod declarative {
     /// Declarative form of the [`#[ctor]`](crate::ctor) macro.
     ///
@@ -480,8 +480,8 @@ __declare_features!(
     ///
     /// Priority is specified as an isize, string literal, or the identifiers
     /// `early` or `late`. The integer value will be clamped to a
-    /// platform-defined range (typically 0-65535), while the string value will
-    /// unprocessed.
+    /// platform-defined range (typically 0-65535), while string priorities are
+    /// passed through unprocessed.
     ///
     /// Priority is applied as follows:
     ///
@@ -525,10 +525,9 @@ __declare_features!(
         ///
         /// Marks a ctor as unsafe. Required.
         ///
-        /// The `ctor` crate will warn if there is no unsafe flag in the `ctor`
-        /// annotation. This warning for a missing unsafe keyword can be hidden
-        /// by passing `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to
-        /// Cargo.
+        /// The `ctor` crate rejects `#[ctor]` without marking the item unsafe;
+        /// that error can be suppressed by passing
+        /// `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to Cargo.
         attr: [(unsafe) => (no_fail_on_missing_unsafe)];
         default {
             (linktime_no_fail_on_missing_unsafe) => (no_fail_on_missing_unsafe),
@@ -538,18 +537,18 @@ __declare_features!(
     used_linker {
         /// attr
         ///
-        /// Mark generated functions pointers `used(linker)`. Requires nightly
+        /// Mark generated function pointers `used(linker)`. Requires nightly
         /// for the nightly-only feature `feature(used_with_arg)` (see
         /// <https://github.com/rust-lang/rust/issues/93798>).
         ///
-        /// The can be made the default by using the `cfg` flag
+        /// This can be made the default by using the `cfg` flag
         /// `linktime_used_linker` (`RUSTFLAGS="--cfg linktime_used_linker"`).
         ///
         /// For a crate using this macro to function correctly with and without
         /// this flag, it is recommended to add the following line to the top of
         /// lib.rs in the crate root:
         ///
-        /// `![cfg_attr(linktime_used_linker, feature(used_with_arg))]`
+        /// `#![cfg_attr(linktime_used_linker, feature(used_with_arg))]`
         attr: [(used(linker)) => (used_linker)];
         default {
             (linktime_used_linker) => used_linker,

--- a/ctor/src/parse.rs
+++ b/ctor/src/parse.rs
@@ -235,7 +235,7 @@ macro_rules! __ctor_parse_impl {
 
     // Step 3: Compute no_fail_on_missing_unsafe
 
-    // warn iff no_fail_on_missing_unsafe is not present AND unsafe is not present
+    // Compile error iff no_fail_on_missing_unsafe is not present AND unsafe is not present
     ( @entry next=$next:path[$next_args:tt], input=(
         features = (
             anonymous = $anonymous:tt,
@@ -251,7 +251,7 @@ macro_rules! __ctor_parse_impl {
     ) ) => {
         compile_error!(concat!("Missing unsafe keyword in #[ctor] annotation. \
         Use #[ctor(unsafe)]. This error can be suppressed by passing \
-        `--cfg no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your \
+        `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your \
         `config.toml` file.\n\n\
         \n\
         #[ctor]\n\
@@ -273,7 +273,7 @@ macro_rules! __ctor_parse_impl {
     ) ) => {
         compile_error!(concat!("Missing unsafe keyword in #[ctor] annotation. \
         Use #[ctor(unsafe, ", stringify!($($self)*), ")]. This error can be suppressed by passing \
-        `--cfg no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your \
+        `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your \
         `config.toml` file.\n\n\
         \n\
         #[ctor(", stringify!($($self)*), ")]\n\

--- a/ctor/tests/errors/ctor_no_unsafe.stderr
+++ b/ctor/tests/errors/ctor_no_unsafe.stderr
@@ -1,4 +1,4 @@
-error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
+error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
 
        #[ctor]
        ^^^^^^^------- replace this with #[ctor(unsafe)]
@@ -10,7 +10,7 @@ error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This e
   |
   = note: this error originates in the macro `$crate::__ctor_parse_impl` which comes from the expansion of the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe, priority = 1)]. This error can be suppressed by passing `--cfg no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
+error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe, priority = 1)]. This error can be suppressed by passing `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
 
        #[ctor(priority = 1)]
        ^------- replace this with #[ctor(unsafe, priority = 1)]

--- a/ctor/tests/errors/ctor_no_unsafe_struct.stderr
+++ b/ctor/tests/errors/ctor_no_unsafe_struct.stderr
@@ -1,4 +1,4 @@
-error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
+error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
 
        #[ctor]
        ^^^^^^^------- replace this with #[ctor(unsafe)]

--- a/docs/LIFE_BEFORE_MAIN.md
+++ b/docs/LIFE_BEFORE_MAIN.md
@@ -71,9 +71,9 @@ resulting in them not being called
 ([rust-ctor #280](https://github.com/mmastrac/linktime/issues/280),
 [🦀 #99721](https://github.com/rust-lang/rust/issues/99721)).
 
-The `used_linker` feature for the `ctor` and `dtor` crates _may_ help - it
-applies `used(linker)` to the linker-generated items, but it requires a nightly
-Rust and `#![feature(used_with_arg)]`.
+Building with `--cfg linktime_used_linker` for the `ctor` and `dtor` crates
+_may_ help — it applies `used(linker)` to the linker-generated items, but it
+requires nightly Rust and `#![feature(used_with_arg)]` on the crate root.
 
 Often a **`use` of the module** that contains the missing registration is enough
 for the linker to retain the code.

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-05-02
+
+### Changed
+
+- Documentation polish and typo fixes.
+
 ## [0.13.0] - 2026-05-02
 
 ### Changed

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtor"
-version = "0.13.0"
+version = "0.13.1"
 authors.workspace = true
 edition = "2021"
 description = "__attribute__((destructor)) for Rust"

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 categories = ["no-std"]
 rust-version = "1.60"
 
+exclude = ["tests"]
+
 [features]
 default = ["std", "proc_macro"]
 std = []

--- a/dtor/README.md
+++ b/dtor/README.md
@@ -10,7 +10,7 @@ The crate is part of the [`linktime`](https://crates.io/crates/linktime) project
 | `link-section` | [![docs.rs](https://docs.rs/link-section/badge.svg)](https://docs.rs/link-section) | [![crates.io](https://img.shields.io/crates/v/link-section.svg)](https://crates.io/crates/link-section) |
 # dtor
 Shutdown functions for Rust (like `__attribute__((destructor))` in C/C++) for
-Linux, OSX, Windows, mobile (iOS/Android), WASM, BSD/BSD-likes and many other
+Linux, macOS, Windows, mobile (iOS/Android), WASM, BSD/BSD-likes and many other
 platforms.
 
 ```rust

--- a/dtor/docs/PREAMBLE.md
+++ b/dtor/docs/PREAMBLE.md
@@ -1,5 +1,5 @@
 Shutdown functions for Rust (like `__attribute__((destructor))` in C/C++) for
-Linux, OSX, Windows, mobile (iOS/Android), WASM, BSD/BSD-likes and many other
+Linux, macOS, Windows, mobile (iOS/Android), WASM, BSD/BSD-likes and many other
 platforms.
 
 ```rust

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-05-02
+
+### Changed
+
+- Documentation polish and typo fixes.
+
 ## [0.13.0] - 2026-05-02
 
 ### Changed

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.13.0"
+version = "0.13.1"
 authors.workspace = true
 edition = "2021"
 description = "Low-level link-section macro support for Rust"

--- a/linktime/CHANGELOG.md
+++ b/linktime/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.13.1] - 2026-05-02
+
+### Changed
+
+- User-facing docs prefer **macOS** over legacy “OSX”.

--- a/linktime/Cargo.toml
+++ b/linktime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linktime"
-version = "0.13.0"
+version = "0.13.1"
 authors.workspace = true
 edition = "2021"
 description = "Link-time tricks for Rust"

--- a/macro-magic/src/macros/features.rs
+++ b/macro-magic/src/macros/features.rs
@@ -946,7 +946,7 @@ macro_rules! __make_docs {
             #![doc = "\n\n# Crate Features\n\n| Cargo feature | Description |\n| --- | --- |"]
             $(
                 $(
-                    #![doc = concat!("\n| `", stringify!($feature_crate), "` | ", $( $crate_doc_lit, )* " |")]
+                    #![doc = concat!("\n| `", $feature_name, "` | ", $( $crate_doc_lit, )* " |")]
                 )?
             )*
             #![doc = "\n\n# Macro Attributes\n\n<table><tr><th>Attribute</th><th>Description</th></tr>\n"]

--- a/tests/ctor/mod.rs
+++ b/tests/ctor/mod.rs
@@ -229,7 +229,7 @@ ignore {
     !      Locking %{DATA} to latest compatible version%{DATA}
 }
 """
-error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
+error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
 
 
        #[ctor]
@@ -249,7 +249,7 @@ if TARGET_OS != "windows" {
   |
   = note: this error originates in the macro `$crate::__ctor_parse_impl` which comes from the expansion of the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
+error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
 
 
        #[ctor]


### PR DESCRIPTION
Found a bunch of typos, some inconsistencies, doc bugs, etc. Also cleaned up the `ctor` examples a bit.