### PR TITLE
Add more BSDs to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,10 +137,18 @@ jobs:
   success:
     runs-on: ubuntu-slim
     needs: build
+    if: always()
     steps:
-      - name: Report success
+      - name: Report success or fail the workflow
         run: |
+          echo "build matrix result: ${BUILD_RESULT}"
+          if [ "${BUILD_RESULT}" != success ]; then
+            echo "::error::Matrix job failed or did not succeed (result=${BUILD_RESULT})."
+            exit 1
+          fi
           echo "Success"
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
 
   # Tier-*BSD smoke tests (QEMU); see https://github.com/vmactions
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -190,3 +190,89 @@ jobs:
             cargo build
             cargo test
             cargo clean
+
+  vmactions-openbsd:
+    runs-on: ubuntu-latest
+    name: OpenBSD / test (stable)
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
+        with:
+          path: .cache/ci/vmactions/openbsd
+          key: vmactions-openbsd-7.8-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            vmactions-openbsd-7.8-
+      - name: Build and test
+        uses: vmactions/openbsd-vm@v1
+        with:
+          release: "7.8"
+          usesh: true
+          run: |
+            set -xe
+            if ! command -v cargo >/dev/null 2>&1; then
+              pkg_add rust
+            fi
+            export CARGO_HOME="${GITHUB_WORKSPACE}/.cache/ci/vmactions/openbsd/cargo-home"
+            mkdir -p "${CARGO_HOME}/bin"
+            export PATH="${CARGO_HOME}/bin:${PATH}"
+            if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
+              cargo install cargo-expand --locked
+            fi
+            cargo build
+            cargo test
+            cargo clean
+
+  vmactions-netbsd:
+    runs-on: ubuntu-latest
+    # Full `cargo test` needs `cargo-expand`; installing it pulls deps (e.g. mio) that fail on NetBSD kqueue (udata typing).
+    # Smoke-test examples only — same as DragonFly vmactions job.
+    name: NetBSD / examples (stable)
+    steps:
+      - uses: actions/checkout@v6
+      - name: Start VM
+        uses: vmactions/netbsd-vm@v1
+        with:
+          release: "10.1"
+          usesh: true
+      - name: Run crate examples
+        shell: netbsd {0}
+        run: |
+          set -xe
+          export PATH="/usr/pkg/sbin:/usr/pkg/bin:/usr/sbin:/usr/bin:${PATH}"
+          if [ -x /usr/pkg/bin/pkgin ]; then
+            /usr/pkg/bin/pkgin update
+            /usr/pkg/bin/pkgin -y install rust
+          else
+            export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/amd64/10.1/All"
+            /usr/sbin/pkg_add rust
+          fi
+          cargo build --examples -p ctor -p dtor -p link-section
+          for example in ctor-basic ctor-example ctor-advanced; do
+            cargo run -p ctor --example "$example"
+          done
+          cargo run -p dtor --example dtor-example
+          cargo run -p link-section --example link-section-example
+
+  vmactions-dragonflybsd:
+    runs-on: ubuntu-latest
+    # Packaged Rust is often behind crates.io; full `cargo test` needs `cargo-expand` (rustc 1.88+ as of 2025).
+    # Smoke-test published examples only (same spirit as zigbuild.sh).
+    name: DragonFly BSD / examples (stable)
+    steps:
+      - uses: actions/checkout@v6
+      - name: Start VM
+        uses: vmactions/dragonflybsd-vm@v1
+        with:
+          release: "6.4.2"
+          usesh: true
+      - name: Run crate examples
+        shell: dragonflybsd {0}
+        run: |
+          set -xe
+          pkg install -y rust
+          cargo build --examples -p ctor -p dtor -p link-section
+          for example in ctor-basic ctor-example ctor-advanced; do
+            cargo run -p ctor --example "$example"
+          done
+          cargo run -p dtor --example dtor-example
+          cargo run -p link-section --example link-section-example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "libc-print",
  "linktime-proc-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.2", default-features = false }
-dtor = { path = "dtor", version = "1.0.0", default-features = false }
+dtor = { path = "dtor", version = "1.0.1", default-features = false }
 link-section = { path = "link-section", version = "0.15.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -48,9 +48,9 @@ Contributions to support other platforms or improve testing are welcome.
 | Windows      | ✅        | ✅        |
 | WASM         | ✅        | ✅        |
 | FreeBSD      | ✅        | 💨        |
-| NetBSD       | ✅        | -         |
-| OpenBSD      | ✅        | -         |
-| DragonFlyBSD | ✅        | -         |
+| NetBSD       | ✅        | 💨         |
+| OpenBSD      | ✅        | 💨         |
+| DragonFlyBSD | ✅        | 💨         |
 | Illumos      | ✅        | -         |
 | Android      | ✅        | -         |
 | iOS          | ✅        | -         |

--- a/ctor/docs/PREAMBLE.md
+++ b/ctor/docs/PREAMBLE.md
@@ -37,9 +37,9 @@ Contributions to support other platforms or improve testing are welcome.
 | Windows      | ✅        | ✅        |
 | WASM         | ✅        | ✅        |
 | FreeBSD      | ✅        | 💨        |
-| NetBSD       | ✅        | -         |
-| OpenBSD      | ✅        | -         |
-| DragonFlyBSD | ✅        | -         |
+| NetBSD       | ✅        | 💨         |
+| OpenBSD      | ✅        | 💨         |
+| DragonFlyBSD | ✅        | 💨         |
 | Illumos      | ✅        | -         |
 | Android      | ✅        | -         |
 | iOS          | ✅        | -         |

--- a/ctor/tests/macrotest.rs
+++ b/ctor/tests/macrotest.rs
@@ -69,6 +69,8 @@ pub fn pass_linux() {
 #[test]
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
+    // TODO: whitespace issue in error tests
+    #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");
 }

--- a/ctor/tests/macrotest.rs
+++ b/ctor/tests/macrotest.rs
@@ -69,6 +69,8 @@ pub fn pass_linux() {
 #[test]
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
+    // TODO: whitespace issue (tabs?) in error tests
+    #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");
 }

--- a/ctor/tests/macrotest.rs
+++ b/ctor/tests/macrotest.rs
@@ -69,8 +69,6 @@ pub fn pass_linux() {
 #[test]
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
-    // TODO: whitespace issue in error tests
-    #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");
 }

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - Unreleased
+
+### Changed
+
+- OpenBSD support uses `method = at_module_exit` rather than `method = linker`
+  by default due to C library inconsistencies. When using `method = linker`,
+  the `link_section` is now `.dtors` rather than `.fini_array`.
+- Documentation improvements.
+
 ## [1.0.0] - 2026-05-03
 
 ### Changed

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtor"
-version = "1.0.0"
+version = "1.0.1"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible destructors for all platforms that run after main (like C/C++ __attribute__((destructor)))"

--- a/dtor/README.md
+++ b/dtor/README.md
@@ -325,10 +325,13 @@ export_name_prefix = ()
 link_section = "__DATA,__mod_term_func,mod_term_funcs"
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd",
-target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly",
-target_os = "illumos", target_os = "haiku", target_os = "vxworks", target_os =
-"nto", target_family = "wasm"))]
+target_os = "netbsd", target_os = "dragonfly", target_os = "illumos",
+target_os = "haiku", target_os = "vxworks", target_os = "nto", target_family =
+"wasm"))]
 link_section = ".fini_array"
+
+#[cfg(target_os = "openbsd")]
+link_section = ".dtors"
 
 #[cfg(target_os = "none")]
 link_section = ".fini_array"
@@ -360,6 +363,9 @@ method = at_module_exit
 
 #[cfg(target_family = "wasm")]
 method = at_binary_exit
+
+#[cfg(target_os = "openbsd")]
+method = at_module_exit
 
  // default
 method = linker

--- a/dtor/docs/GENERATED.md
+++ b/dtor/docs/GENERATED.md
@@ -225,11 +225,16 @@ link_section = "__DATA,__mod_term_func,mod_term_funcs"
  # ; };
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd",
-target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly",
-target_os = "illumos", target_os = "haiku", target_os = "vxworks", target_os =
-"nto", target_family = "wasm"))]
+target_os = "netbsd", target_os = "dragonfly", target_os = "illumos",
+target_os = "haiku", target_os = "vxworks", target_os = "nto", target_family =
+"wasm"))]
  # const _: () = { let
 link_section = ".fini_array"
+ # ; };
+
+#[cfg(target_os = "openbsd")]
+ # const _: () = { let
+link_section = ".dtors"
  # ; };
 
 #[cfg(target_os = "none")]
@@ -279,6 +284,11 @@ method = at_module_exit
 #[cfg(target_family = "wasm")]
  # const _: () = { let
 method = at_binary_exit
+ # ; };
+
+#[cfg(target_os = "openbsd")]
+ # const _: () = { let
+method = at_module_exit
  # ; };
 
  // default

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -242,7 +242,7 @@ __declare_features!(
             // WASI/Emscripten support atexit only
             // For wasm-unknown-unknown, you'll need to provide one
             (target_family = "wasm") => at_binary_exit,
-            // .fini_array works in dylibs, but does not appear to work in binaries
+            // OpenBSD's linker support is inconsistent
             (target_os = "openbsd") => at_module_exit,
             _ => linker,
         }

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -191,7 +191,6 @@ __declare_features!(
                 target_os = "android",
                 target_os = "freebsd",
                 target_os = "netbsd",
-                target_os = "openbsd",
                 target_os = "dragonfly",
                 target_os = "illumos",
                 target_os = "haiku",
@@ -199,6 +198,8 @@ __declare_features!(
                 target_os = "nto",
                 target_family = "wasm"
             )) => ".fini_array",
+            // OpenBSD only seems to support .fini_array for binaries
+            (target_os = "openbsd") => ".dtors",
             // No OS
             (target_os = "none") => ".fini_array",
             // xtensa targets: .dtors
@@ -241,6 +242,8 @@ __declare_features!(
             // WASI/Emscripten support atexit only
             // For wasm-unknown-unknown, you'll need to provide one
             (target_family = "wasm") => at_binary_exit,
+            // .fini_array works in dylibs, but does not appear to work in binaries
+            (target_os = "openbsd") => at_module_exit,
             _ => linker,
         }
     };

--- a/dtor/tests/macrotest.rs
+++ b/dtor/tests/macrotest.rs
@@ -76,8 +76,6 @@ pub fn pass_windows() {
 #[test]
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
-    // TODO: whitespace issue in error tests
-    #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");
 }

--- a/dtor/tests/macrotest.rs
+++ b/dtor/tests/macrotest.rs
@@ -76,6 +76,8 @@ pub fn pass_windows() {
 #[test]
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
+    // TODO: whitespace issue (tabs?) in error tests
+    #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");
 }

--- a/dtor/tests/macrotest.rs
+++ b/dtor/tests/macrotest.rs
@@ -76,6 +76,8 @@ pub fn pass_windows() {
 #[test]
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
+    // TODO: whitespace issue in error tests
+    #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");
 }

--- a/tests/ctor/mod.rs
+++ b/tests/ctor/mod.rs
@@ -18,7 +18,13 @@ $ rustc -vV
 $ cargo build --quiet --target $TARGET
 *
 $ cargo run --quiet --target $TARGET
-! +crt-static
+if TARGET_OS == "openbsd" {
+    # Appears to be a legit Rust/OpenBSD bug?
+    ! -crt-static
+}
+if TARGET_OS != "openbsd" {
+    ! +crt-static
+}
 ! main
 "#
 );

--- a/tests/dtor/mod.rs
+++ b/tests/dtor/mod.rs
@@ -37,6 +37,9 @@ if TARGET_OS == "linux" {
 if TARGET_OS == "freebsd" {
     ! dtor-link-section:dtor
 }
+if TARGET_OS == "openbsd" {
+    ! dtor-link-section:dtor
+}
 "#
 );
 


### PR DESCRIPTION
We started with just FreeBSD, but we can add OpenBSD/NetBSD and DragonFly at varying levels of builds. 