### PR TITLE
Fix wasm support in dtor and release 0.14.0

### DIFF
--- a/.github/jobs/wasm.sh
+++ b/.github/jobs/wasm.sh
@@ -12,7 +12,7 @@ cd "$ROOT"
 
 cd "$ROOT/tests/dtor/wasm"
 cargo build --target wasm32-unknown-unknown
-wasmtime run target/wasm32-unknown-unknown/debug/tests_dtor_wasm.wasm
+wasmtime run target/wasm32-unknown-unknown/debug/tests_dtor_wasm.wasm || (echo "WASM should not have succeeded" && exit 1)
 cargo build --target wasm32-wasip1
 wasmtime run target/wasm32-wasip1/debug/tests_dtor_wasm.wasm || echo "WASI failed"
 cd "$ROOT"

--- a/.github/jobs/wasm.sh
+++ b/.github/jobs/wasm.sh
@@ -12,7 +12,7 @@ cd "$ROOT"
 
 cd "$ROOT/tests/dtor/wasm"
 cargo build --target wasm32-unknown-unknown
-wasmtime run target/wasm32-unknown-unknown/debug/tests_dtor_wasm.wasm || (echo "WASM should not have succeeded" && exit 1)
+wasmtime run target/wasm32-unknown-unknown/debug/tests_dtor_wasm.wasm && (echo "WASM should not have succeeded" && exit 1)
 cargo build --target wasm32-wasip1
 wasmtime run target/wasm32-wasip1/debug/tests_dtor_wasm.wasm || echo "WASI failed"
 cd "$ROOT"

--- a/.github/jobs/wasm.sh
+++ b/.github/jobs/wasm.sh
@@ -5,9 +5,17 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 cd "$ROOT/tests/ctor/wasm"
 cargo build --target wasm32-unknown-unknown
-wasmtime run target/wasm32-unknown-unknown/debug/tests_wasm.wasm
+wasmtime run target/wasm32-unknown-unknown/debug/tests_ctor_wasm.wasm
 cargo build --target wasm32-wasip1
-wasmtime run target/wasm32-wasip1/debug/tests_wasm.wasm || echo "WASI failed"
+wasmtime run target/wasm32-wasip1/debug/tests_ctor_wasm.wasm || echo "WASI failed"
+cd "$ROOT"
+
+cd "$ROOT/tests/dtor/wasm"
+cargo build --target wasm32-unknown-unknown
+wasmtime run target/wasm32-unknown-unknown/debug/tests_dtor_wasm.wasm
+cargo build --target wasm32-wasip1
+wasmtime run target/wasm32-wasip1/debug/tests_dtor_wasm.wasm || echo "WASI failed"
+cd "$ROOT"
 
 # We don't have a way to initialize the runtime yet...
 cd "$ROOT/tests/link_section/wasm"
@@ -15,5 +23,6 @@ cargo build --target wasm32-unknown-unknown
 # wasmtime run target/wasm32-unknown-unknown/debug/tests_link_section_wasm.wasm
 cargo build --target wasm32-wasip1
 # wasmtime run target/wasm32-wasip1/debug/tests_link_section_wasm.wasm || echo "WASI failed"
+cd "$ROOT"
 
 echo "Done."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "libc-print",
  "linktime-proc-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.0", default-features = false }
-dtor = { path = "dtor", version = "0.13.1", default-features = false }
+dtor = { path = "dtor", version = "0.14.0", default-features = false }
 link-section = { path = "link-section", version = "0.13.1", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - WASM support now uses `atexit` on all platforms (including
   `wasm32-unknown-unknown`).
+- Typos and other documentation nits.
 
 ## [0.13.1] - 2026-05-02
 

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-05-03
+
+### Fixed
+
+- WASM support now uses `atexit` on all platforms (including
+  `wasm32-unknown-unknown`).
+
 ## [0.13.1] - 2026-05-02
 
 ### Changed

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtor"
-version = "0.13.1"
+version = "0.14.0"
 authors.workspace = true
 edition = "2021"
 description = "__attribute__((destructor)) for Rust"

--- a/dtor/README.md
+++ b/dtor/README.md
@@ -132,7 +132,9 @@ fn dtor_atexit() {
 <table><tr><th>Attribute</th><th>Description</th></tr>
 <tr><td><code>anonymous</code></td><td>
 
- Make the ctor function anonymous.
+ Do not give the destructor's registration entry a name in the generated
+ code (allows for multiple items with the same name). Equivalent to
+ wrapping the registration in an anonymous const (i.e.: `const _ = { ... };`).
 
 
 </td></tr>
@@ -144,9 +146,11 @@ fn dtor_atexit() {
 </td></tr>
 <tr><td><code>ctor(export_name_prefix = "ctor_")</code></td><td>
 
- Specify a custom export name prefix for the constructor function.
+ Specify a custom export name prefix for the generated constructor
+ function.
 
- If specified, an export with the given prefix will be generated in the form:
+ If specified, an export with the given prefix will be generated in the
+ form:
 
  `<prefix>_<unique_id>`
 
@@ -154,7 +158,8 @@ fn dtor_atexit() {
 </td></tr>
 <tr><td><code>ctor(link_section = ".ctors")</code></td><td>
 
- Place the initialization function pointer in a custom link section.
+ Place the generated registration constructor's function pointer in a
+ custom link section.
 
 
 </td></tr>
@@ -204,21 +209,20 @@ fn dtor_atexit() {
 
  Marks a dtor as unsafe. Required.
 
- The `ctor` crate will warn if there is no unsafe flag in the `ctor`
- annotation. This warning for a missing unsafe keyword can be hidden
- by passing `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to
- Cargo.
+ The `dtor` crate rejects `#[dtor]` without marking the item unsafe;
+ that error can be suppressed by passing
+ `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to Cargo.
 
 
 </td></tr>
 <tr><td><code>used(linker)</code></td><td>
 
 
- Mark generated functions pointers `used(linker)`. Requires nightly
+ Mark generated function pointers `used(linker)`. Requires nightly
  for the nightly-only feature `feature(used_with_arg)` (see
  <https://github.com/rust-lang/rust/issues/93798>).
 
- The can be made the default by using the `cfg` flag
+ This can be made the default by using the `cfg` flag
  `linktime_used_linker` (`RUSTFLAGS="--cfg linktime_used_linker"`).
 
  For a crate using this macro to function correctly with and without
@@ -341,6 +345,9 @@ method = at_module_exit
 
 #[cfg(target_vendor = "pc")]
 method = at_module_exit
+
+#[cfg(target_family = "wasm")]
+method = at_binary_exit
 
  // default
 method = linker

--- a/dtor/README.md
+++ b/dtor/README.md
@@ -43,7 +43,8 @@ fn shutdown() {
 | Linux                      | `.fini_array`                             | Yes (`atexit`) | Yes (`__cxa_atexit`) |
 | MacOS                      | `.mod_term_func` <sup><sup>🍎</sup></sup> | Yes (`atexit`) | Yes (`__cxa_atexit`) |
 | Windows                    | `.CRT$XPU` <sup><sup>🪟</sup></sup>       | No             | Yes (`atexit`)       |
-| AIX                        | No <sup><sup>🔵</sup></sup>               | Yes            | Yes                  |
+| WASM                       | No                                        | Yes            | No                   |
+| AIX                        | "Kind of" <sup><sup>🔵</sup></sup>        | Yes            | Yes                  |
 | Other POSIX-like platforms | `.fini_array`/`.dtors`                    | Yes (`atexit`) | Yes (`__cxa_atexit`) |
 
 Notes:
@@ -54,7 +55,8 @@ Notes:
   call functions in link sections, unless a binary is built with a static CRT.
 - <sup><sup>🔵</sup></sup> Link sections are not supported on AIX, but the
   platform calls functions with the prefix `__sinit` and `__sterm` at startup
-  and shutdown respectively.
+  and shutdown respectively. `__sterm`-prefixed functions are used when the
+  method is specified as `linker`.
 
 # Shutdown Method (`#[dtor(method = ...)]`)
 
@@ -69,7 +71,7 @@ The `#[dtor]` macro supports multiple registration strategies via
   termination method. Not recommended: code may be unloaded before the dtor
   runs.
 - `at_module_exit`: Register using `__cxa_atexit` (non-Windows) or `atexit`
-  (Windows) so the dtor runs when the module unloads.
+  (Windows) so the dtor runs when the module unloads. Unsupported on WASM.
 - `at_binary_exit`: Register to run at process exit (unsupported on Windows).
 - `linker`: Register using the platform's linker mechanism (`link_section` on
   all platforms with the exception of `export_name_prefix` on AIX). Unsupported
@@ -78,6 +80,8 @@ The `#[dtor]` macro supports multiple registration strategies via
 Default:
 
 - Apple and Windows default to `at_module_exit`
+- WASM defaults to `at_binary_exit` (note that you will need to provide your own
+  atexit implementation for `wasm32-unknown-unknown`)
 - Most other platforms default to `linker`
 
 Examples:

--- a/dtor/docs/GENERATED.md
+++ b/dtor/docs/GENERATED.md
@@ -11,7 +11,9 @@
 <table><tr><th>Attribute</th><th>Description</th></tr>
 <tr><td><code>anonymous</code></td><td>
 
- Make the ctor function anonymous.
+ Do not give the destructor's registration entry a name in the generated
+ code (allows for multiple items with the same name). Equivalent to
+ wrapping the registration in an anonymous const (i.e.: `const _ = { ... };`).
 
 
 </td></tr>
@@ -23,9 +25,11 @@
 </td></tr>
 <tr><td><code>ctor(export_name_prefix = "ctor_")</code></td><td>
 
- Specify a custom export name prefix for the constructor function.
+ Specify a custom export name prefix for the generated constructor
+ function.
 
- If specified, an export with the given prefix will be generated in the form:
+ If specified, an export with the given prefix will be generated in the
+ form:
 
  `<prefix>_<unique_id>`
 
@@ -33,7 +37,8 @@
 </td></tr>
 <tr><td><code>ctor(link_section = ".ctors")</code></td><td>
 
- Place the initialization function pointer in a custom link section.
+ Place the generated registration constructor's function pointer in a
+ custom link section.
 
 
 </td></tr>
@@ -83,21 +88,20 @@
 
  Marks a dtor as unsafe. Required.
 
- The `ctor` crate will warn if there is no unsafe flag in the `ctor`
- annotation. This warning for a missing unsafe keyword can be hidden
- by passing `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to
- Cargo.
+ The `dtor` crate rejects `#[dtor]` without marking the item unsafe;
+ that error can be suppressed by passing
+ `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to Cargo.
 
 
 </td></tr>
 <tr><td><code>used(linker)</code></td><td>
 
 
- Mark generated functions pointers `used(linker)`. Requires nightly
+ Mark generated function pointers `used(linker)`. Requires nightly
  for the nightly-only feature `feature(used_with_arg)` (see
  <https://github.com/rust-lang/rust/issues/93798>).
 
- The can be made the default by using the `cfg` flag
+ This can be made the default by using the `cfg` flag
  `linktime_used_linker` (`RUSTFLAGS="--cfg linktime_used_linker"`).
 
  For a crate using this macro to function correctly with and without
@@ -270,6 +274,11 @@ method = at_module_exit
 #[cfg(target_vendor = "pc")]
  # const _: () = { let
 method = at_module_exit
+ # ; };
+
+#[cfg(target_family = "wasm")]
+ # const _: () = { let
+method = at_binary_exit
  # ; };
 
  // default

--- a/dtor/docs/PREAMBLE.md
+++ b/dtor/docs/PREAMBLE.md
@@ -34,7 +34,8 @@ fn shutdown() {
 | Linux                      | `.fini_array`                             | Yes (`atexit`) | Yes (`__cxa_atexit`) |
 | MacOS                      | `.mod_term_func` <sup><sup>🍎</sup></sup> | Yes (`atexit`) | Yes (`__cxa_atexit`) |
 | Windows                    | `.CRT$XPU` <sup><sup>🪟</sup></sup>       | No             | Yes (`atexit`)       |
-| AIX                        | No <sup><sup>🔵</sup></sup>               | Yes            | Yes                  |
+| WASM                       | No                                        | Yes            | No                   |
+| AIX                        | "Kind of" <sup><sup>🔵</sup></sup>        | Yes            | Yes                  |
 | Other POSIX-like platforms | `.fini_array`/`.dtors`                    | Yes (`atexit`) | Yes (`__cxa_atexit`) |
 
 Notes:
@@ -45,7 +46,8 @@ Notes:
   call functions in link sections, unless a binary is built with a static CRT.
 - <sup><sup>🔵</sup></sup> Link sections are not supported on AIX, but the
   platform calls functions with the prefix `__sinit` and `__sterm` at startup
-  and shutdown respectively.
+  and shutdown respectively. `__sterm`-prefixed functions are used when the
+  method is specified as `linker`.
 
 # Shutdown Method (`#[dtor(method = ...)]`)
 
@@ -60,7 +62,7 @@ The `#[dtor]` macro supports multiple registration strategies via
   termination method. Not recommended: code may be unloaded before the dtor
   runs.
 - `at_module_exit`: Register using `__cxa_atexit` (non-Windows) or `atexit`
-  (Windows) so the dtor runs when the module unloads.
+  (Windows) so the dtor runs when the module unloads. Unsupported on WASM.
 - `at_binary_exit`: Register to run at process exit (unsupported on Windows).
 - `linker`: Register using the platform's linker mechanism (`link_section` on
   all platforms with the exception of `export_name_prefix` on AIX). Unsupported
@@ -69,6 +71,8 @@ The `#[dtor]` macro supports multiple registration strategies via
 Default:
 
 - Apple and Windows default to `at_module_exit`
+- WASM defaults to `at_binary_exit` (note that you will need to provide your own
+  atexit implementation for `wasm32-unknown-unknown`)
 - Most other platforms default to `linker`
 
 Examples:

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -28,7 +28,7 @@ pub use native::*;
 /// # use dtor::dtor;
 /// # fn main() {}
 ///
-/// #[dtor]
+/// #[dtor(unsafe)]
 /// fn shutdown() {
 ///   /* ... */
 /// }
@@ -47,7 +47,7 @@ pub use linktime_proc_macro::dtor;
 /// ```rust
 /// # #[cfg(any())] mod test { use dtor::*; use libc_print::*;
 /// dtor::declarative::dtor! {
-///   #[dtor]
+///   #[dtor(unsafe)]
 ///   fn foo() {
 ///     libc_println!("Goodbye, world!");
 ///   }
@@ -57,7 +57,7 @@ pub use linktime_proc_macro::dtor;
 /// // ... the above is identical to:
 ///
 /// # #[cfg(any())] mod test_2 { use dtor::*; use libc_print::*;
-/// #[dtor]
+/// #[dtor(unsafe)]
 /// fn foo() {
 ///   libc_println!("Goodbye, world!");
 /// }
@@ -82,7 +82,9 @@ pub mod __support {
 __declare_features!(
     dtor: __dtor_features;
 
-    /// Make the ctor function anonymous.
+    /// Do not give the destructor's registration entry a name in the generated
+    /// code (allows for multiple items with the same name). Equivalent to
+    /// wrapping the registration in an anonymous const (i.e.: `const _ = { ... };`).
     anonymous {
         attr: [(anonymous) => (anonymous)];
     };
@@ -91,7 +93,8 @@ __declare_features!(
         attr: [(crate_path = $path:pat) => (($path))];
         example: "crate_path = ::path::to::dtor::crate";
     };
-    /// Specify a custom export name prefix for the constructor function.
+    /// Specify a custom export name prefix for the generated `#[ctor]` that
+    /// registers this destructor (for example the AIX `__sinit` hook).
     ///
     /// If specified, an export with the given prefix will be generated in the form:
     ///
@@ -104,7 +107,8 @@ __declare_features!(
             _ => (),
         }
     };
-    /// Place the initialization function pointer in a custom link section.
+    /// Place the generated registration constructor's function pointer in a
+    /// custom link section.
     ctor_link_section {
         attr: [(ctor(link_section = $ctor_link_section_name:literal)) => ($ctor_link_section_name)];
         example: "ctor(link_section = \".ctors\")";
@@ -233,6 +237,9 @@ __declare_features!(
         default {
             (target_vendor = "apple") => at_module_exit,
             (target_vendor = "pc") => at_module_exit,
+            // WASI/Emscripten support atexit only
+            // For wasm-unknown-unknown, you'll need to provide one
+            (target_family = "wasm") => at_binary_exit,
             _ => linker,
         }
     };
@@ -252,10 +259,9 @@ __declare_features!(
         ///
         /// Marks a dtor as unsafe. Required.
         ///
-        /// The `ctor` crate will warn if there is no unsafe flag in the `ctor`
-        /// annotation. This warning for a missing unsafe keyword can be hidden
-        /// by passing `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to
-        /// Cargo.
+        /// The `dtor` crate rejects `#[dtor]` without marking the item unsafe;
+        /// that error can be suppressed by passing
+        /// `RUSTFLAGS="--cfg linktime_no_fail_on_missing_unsafe"` to Cargo.
         attr: [(unsafe) => (no_fail_on_missing_unsafe)];
         default {
             (linktime_no_fail_on_missing_unsafe) => (no_fail_on_missing_unsafe),
@@ -265,11 +271,11 @@ __declare_features!(
     used_linker {
         /// attr
         ///
-        /// Mark generated functions pointers `used(linker)`. Requires nightly
+        /// Mark generated function pointers `used(linker)`. Requires nightly
         /// for the nightly-only feature `feature(used_with_arg)` (see
         /// <https://github.com/rust-lang/rust/issues/93798>).
         ///
-        /// The can be made the default by using the `cfg` flag
+        /// This can be made the default by using the `cfg` flag
         /// `linktime_used_linker` (`RUSTFLAGS="--cfg linktime_used_linker"`).
         ///
         /// For a crate using this macro to function correctly with and without

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -93,10 +93,11 @@ __declare_features!(
         attr: [(crate_path = $path:pat) => (($path))];
         example: "crate_path = ::path::to::dtor::crate";
     };
-    /// Specify a custom export name prefix for the generated `#[ctor]` that
-    /// registers this destructor (for example the AIX `__sinit` hook).
+    /// Specify a custom export name prefix for the generated constructor
+    /// function.
     ///
-    /// If specified, an export with the given prefix will be generated in the form:
+    /// If specified, an export with the given prefix will be generated in the
+    /// form:
     ///
     /// `<prefix>_<unique_id>`
     ctor_export_name_prefix {

--- a/dtor/src/native.rs
+++ b/dtor/src/native.rs
@@ -34,9 +34,9 @@ pub unsafe fn at_binary_exit(cb: extern "C" fn()) {
 #[inline(always)]
 pub unsafe fn at_module_exit(cb: extern "C" fn()) {
     unsafe {
-        #[cfg(not(windows))]
+        #[cfg(all(not(windows), not(target_family = "wasm")))]
         _run_cxa_atexit(cb);
-        #[cfg(windows)]
+        #[cfg(any(windows, target_family = "wasm"))]
         _run_atexit(cb);
     }
 }
@@ -52,7 +52,7 @@ pub unsafe fn at_library_exit(cb: extern "C" fn()) {
 }
 
 /// Register a function to be called at libc exit time.
-#[cfg(not(miri))]
+#[cfg(all(not(miri), not(target_family = "wasm")))]
 #[inline(always)]
 unsafe fn _run_atexit(cb: unsafe extern "C" fn()) {
     #[allow(missing_unsafe_on_extern)] // MSRV
@@ -64,8 +64,20 @@ unsafe fn _run_atexit(cb: unsafe extern "C" fn()) {
     }
 }
 
+#[cfg(all(not(miri), target_family = "wasm"))]
+#[inline(always)]
+unsafe fn _run_atexit(cb: unsafe extern "C" fn()) {
+    #[allow(missing_unsafe_on_extern)] // MSRV
+    extern "C" {
+        fn atexit(cb: unsafe extern "C" fn()) -> i32;
+    }
+    unsafe {
+        atexit(cb);
+    }
+}
+
 /// Register a function scoped to the current dynamic shared object.
-#[cfg(all(not(miri), not(windows)))]
+#[cfg(all(not(miri), not(windows), not(target_family = "wasm")))]
 #[inline(always)]
 unsafe fn _run_cxa_atexit(cb: extern "C" fn()) {
     #[allow(missing_unsafe_on_extern)] // MSRV

--- a/dtor/tests/macrotest.rs
+++ b/dtor/tests/macrotest.rs
@@ -80,13 +80,15 @@ pub fn trybuild() {
     t.pass("tests/pass/*.rs");
 }
 
-#[cfg(not(linktime_used_linker))] // we don't want to change tests for this
 #[test]
 pub fn target_test() {
     let Some(toolchain) = std::env::var_os("TOOLCHAIN") else {
         return;
     };
     if toolchain != "nightly" {
+        return;
+    }
+    if cfg!(linktime_used_linker) {
         return;
     }
     let cases_dir = Path::new("tests/target-test");

--- a/dtor/tests/macrotest.rs
+++ b/dtor/tests/macrotest.rs
@@ -80,6 +80,7 @@ pub fn trybuild() {
     t.pass("tests/pass/*.rs");
 }
 
+#[cfg(not(linktime_used_linker))] // we don't want to change tests for this
 #[test]
 pub fn target_test() {
     let Some(toolchain) = std::env::var_os("TOOLCHAIN") else {

--- a/dtor/tests/target-test/dtor/wasm32-unknown-unknown.rs
+++ b/dtor/tests/target-test/dtor/wasm32-unknown-unknown.rs
@@ -1,0 +1,22 @@
+use dtor::declarative::dtor;
+
+#[allow(dead_code)]
+fn foo() {
+    fn __dtor_private_inner() {}
+    const _: () =
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            static __CTOR_PRIVATE_REF: unsafe extern "C" fn() =
+                {
+                    unsafe extern "C" fn __ctor_private() {
+                        ::dtor::__support::at_binary_exit(__dtor_private);
+                    }
+                    extern "C" fn __dtor_private() {
+                        { __dtor_private_inner() }
+                    }
+                    __ctor_private
+                };
+        };
+    { __dtor_private_inner() }
+}

--- a/tests/dtor/wasm/Cargo.toml
+++ b/tests/dtor/wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tests-ctor-wasm"
+name = "tests-dtor-wasm"
 version = "0.1.0"
 edition = "2021"
 publish = false
@@ -8,6 +8,6 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-ctor = { path = "../../../ctor" }
+dtor = { path = "../../../dtor" }
 
 [workspace]

--- a/tests/dtor/wasm/src/lib.rs
+++ b/tests/dtor/wasm/src/lib.rs
@@ -1,0 +1,11 @@
+#[dtor::dtor(unsafe)]
+pub fn shutdown() {
+    println!("wasm:dtor");
+}
+
+#[cfg(target_family = "wasm")]
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() -> u32 {
+    println!("wasm:main");
+    42
+}


### PR DESCRIPTION
WASM support in `dtor` stopped working, let's repair it and push a new version.