### PR TITLE
Scattered collection PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,14 @@ fn print_numbers() {
 A crate for defining zero-allocation,linker-managed scattered collections in
 Rust.
 
-- `ScatteredSlice`]: A collection of sized items that collected into a slice in
+- `ScatteredIterable`: A collection of items that are available only via
+- `ScatteredSlice`: A collection of sized items that collected into a slice in
   an arbitrary order.
-- `ScatteredSortedSlice`]: A collection of items that are available via slice,
+- `ScatteredSortedSlice`: A collection of items that are available via slice,
   in sorted order.
-- `ScatteredReferencedSlice`]: A collection of items collected into a slice
+- `ScatteredReferencedSlice`: A collection of items collected into a slice
   (link order).
-- `ScatteredSortedReferencedSlice`]: A collection of sized items that are
+- `ScatteredSortedReferencedSlice`: A collection of sized items that are
   available both via sorted slice and via reference at the declaration site.
 - `ScatteredMap`: A collection of key-value pairs that are available via
   slice, as well as indexed by key.

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -25,6 +25,10 @@ divan = "0.1.21"
 scattered-collect = { path = ".", features = ["__internal"] }
 
 [[example]]
+name = "scattered-collect-iterable"
+path = "examples/iterable.rs"
+
+[[example]]
 name = "scattered-collect-intern-strings"
 path = "examples/intern_strings.rs"
 

--- a/scattered-collect/README.md
+++ b/scattered-collect/README.md
@@ -2,7 +2,8 @@
 
 ![Build Status](https://github.com/mmastrac/linktime/actions/workflows/rust.yml/badge.svg)
 
-The crate is part of the [`linktime`](https://crates.io/crates/linktime) project.
+The crate is part of the [`linktime`](https://crates.io/crates/linktime)
+project.
 
 | crate               |                                                         | docs                                                                                         | version                                                                                                           |
 | ------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
@@ -27,6 +28,8 @@ whatsoever.
 
 ## Collections
 
+- [`ScatteredIterable`]: A collection of items that are available only via
+  iterator.
 - [`ScatteredSlice`]: A collection of sized items that collected into a slice in
   an arbitrary order.
 - [`ScatteredSortedSlice`]: A collection of items that are available via slice,

--- a/scattered-collect/examples/iterable.rs
+++ b/scattered-collect/examples/iterable.rs
@@ -1,0 +1,30 @@
+//! Example for `ScatteredIterable`.
+use scattered_collect::{gather, iterable::ScatteredIterable, scatter};
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct MyId(u32);
+
+/// A scattered iterable of `MyId`.
+#[gather]
+static COLLECTION: ScatteredIterable<MyId>;
+
+#[scatter(COLLECTION)]
+static ITEM_ONE: MyId = MyId(1);
+
+#[scatter(COLLECTION)]
+static ITEM_TWO: MyId = MyId(2);
+
+#[scatter(COLLECTION)]
+static ITEM_THREE: MyId = MyId(3);
+
+fn main() {
+    println!("COLLECTION len: {}", COLLECTION.len());
+    println!("ITEM_ONE: {:?}", *ITEM_ONE);
+    println!("ITEM_TWO: {:?}", *ITEM_TWO);
+    println!("ITEM_THREE: {:?}", *ITEM_THREE);
+
+    println!("Entries (head → tail):");
+    for item in &COLLECTION {
+        println!(" - {:?}", item);
+    }
+}

--- a/scattered-collect/examples/iterable.rs
+++ b/scattered-collect/examples/iterable.rs
@@ -23,7 +23,7 @@ fn main() {
     println!("ITEM_TWO: {:?}", *ITEM_TWO);
     println!("ITEM_THREE: {:?}", *ITEM_THREE);
 
-    println!("Entries (head → tail):");
+    println!("Entries:");
     for item in &COLLECTION {
         println!(" - {:?}", item);
     }

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -4,9 +4,13 @@
 
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
+/// Index stored in [`Ref::index`] before [`submit`] runs.
+const UNSET_INDEX: usize = 0;
+
 /// One node in a [`ScatteredIterable`], with a `static` handle at each scatter site.
 pub struct Ref<T: 'static> {
     next: AtomicPtr<Ref<T>>,
+    index: AtomicUsize,
     value: T,
 }
 
@@ -15,8 +19,23 @@ impl<T> Ref<T> {
     pub const fn new(value: T) -> Self {
         Self {
             next: AtomicPtr::new(core::ptr::null_mut()),
+            index: AtomicUsize::new(UNSET_INDEX),
             value,
         }
+    }
+
+    /// The offset of this node in its collection's submission order.
+    pub fn offset_of(this: &Self) -> usize {
+        this.loaded_index().saturating_sub(1)
+    }
+
+    #[inline]
+    fn loaded_index(&self) -> usize {
+        let index = self.index.load(Ordering::Acquire);
+        if index == UNSET_INDEX {
+            panic!("node index is unset; was this `Ref` submitted to its collection?");
+        }
+        index
     }
 }
 
@@ -69,10 +88,21 @@ pub fn submit<T: 'static>(state: &__ScatteredIterableState<T>, node: &'static Re
             )
             .is_ok()
         {
-            state.len.fetch_add(1, Ordering::Relaxed);
+            let index = state.len.fetch_add(1, Ordering::Relaxed);
+            node.index.store(index + 1, Ordering::Release);
             return;
         }
     }
+}
+
+#[inline]
+fn remaining_from_node<T>(node: *const Ref<T>) -> usize {
+    if node.is_null() {
+        return 0;
+    }
+    // SAFETY: `node` is a live `static` [`Ref`] for the program lifetime.
+    // Stored as submission index + 1; equals [`Ref::offset_of`] + 1.
+    unsafe { (*node).loaded_index() }
 }
 
 /// Iterator over a [`ScatteredIterable`].
@@ -85,17 +115,18 @@ pub struct Iter<'a, T: 'static> {
 impl<'a, T: 'static> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
+    #[allow(unsafe_code)]
     fn next(&mut self) -> Option<Self::Item> {
         if self.current.is_null() {
             return None;
         }
 
         // SAFETY: Nodes are `static` and remain valid for the program lifetime.
-        // Iteration happens after all priority-0 constructors have finished linking.
         let node = unsafe { &*self.current };
+        let _ = node.loaded_index();
         let item = &node.value;
         self.current = node.next.load(Ordering::Acquire);
-        self.remaining = self.remaining.saturating_sub(1);
+        self.remaining = remaining_from_node(self.current);
         Some(item)
     }
 
@@ -104,7 +135,11 @@ impl<'a, T: 'static> Iterator for Iter<'a, T> {
     }
 }
 
-impl<T: 'static> ExactSizeIterator for Iter<'_, T> {}
+impl<T: 'static> ExactSizeIterator for Iter<'_, T> {
+    fn len(&self) -> usize {
+        self.remaining
+    }
+}
 
 /// A collection of items linked at runtime into a singly-linked list.
 ///
@@ -112,11 +147,20 @@ impl<T: 'static> ExactSizeIterator for Iter<'_, T> {}
 /// Iteration order is the reverse of constructor registration order (each item
 /// is prepended to the list).
 ///
+/// ## Thread safety
+///
+/// This collection is thread-safe: access before initialization completes will
+/// yield fewer items, but will not panic or cause undefined behavior. The count
+/// returned by [`len`] may be stale while constructors are still running; the
+/// [`ExactSizeIterator::len`] on [`Iter`] is derived from each node's [`Ref::offset_of`]
+/// index and stays consistent for the suffix being iterated.
+///
 /// For link-time contiguous storage in arbitrary link order, use
 /// [`crate::ScatteredSlice`]. For `static` handles backed by a link section,
 /// use [`crate::ScatteredReferencedSlice`]. For sorted data, use
-/// [`crate::ScatteredSortedSlice`] or [`crate::ScatteredSortedReferencedSlice`].
-/// For key lookup, use [`crate::ScatteredMap`].
+/// [`crate::ScatteredSortedSlice`] or
+/// [`crate::ScatteredSortedReferencedSlice`]. For key lookup, use
+/// [`crate::ScatteredMap`].
 #[doc = concat!("```rust\n", include_str!("../examples/iterable.rs"), "\n```\n")]
 pub struct ScatteredIterable<T: 'static> {
     state: &'static __ScatteredIterableState<T>,
@@ -144,9 +188,10 @@ impl<T: 'static> ::core::iter::IntoIterator for &'static ScatteredIterable<T> {
     type IntoIter = Iter<'static, T>;
 
     fn into_iter(self) -> Self::IntoIter {
+        let current = self.state.head.load(Ordering::Acquire);
         Iter {
-            current: self.state.head.load(Ordering::Acquire),
-            remaining: self.state.len.load(Ordering::Acquire),
+            remaining: remaining_from_node(current),
+            current,
             _marker: ::core::marker::PhantomData,
         }
     }
@@ -202,12 +247,21 @@ macro_rules! __iterable {
 
 #[cfg(all(test, not(miri)))]
 mod tests {
-    use crate::iterable::ScatteredIterable;
+    use crate::iterable::{Ref, ScatteredIterable};
 
     __iterable!(gather pub TEST_ITERABLE: u32);
     __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_A: u32 = 1);
     __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_B: u32 = 3);
     __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_C: u32 = 2);
+
+    fn offset_for_value(value: u32) -> usize {
+        match value {
+            1 => Ref::offset_of(&ITERABLE_ITEM_A),
+            3 => Ref::offset_of(&ITERABLE_ITEM_B),
+            2 => Ref::offset_of(&ITERABLE_ITEM_C),
+            _ => panic!("unexpected value: {value}"),
+        }
+    }
 
     #[test]
     fn test_scattered_iterable() {
@@ -218,8 +272,41 @@ mod tests {
         assert_eq!(*ITERABLE_ITEM_B, 3);
         assert_eq!(*ITERABLE_ITEM_C, 2);
 
+        let mut scatter_offsets = [
+            Ref::offset_of(&ITERABLE_ITEM_A),
+            Ref::offset_of(&ITERABLE_ITEM_B),
+            Ref::offset_of(&ITERABLE_ITEM_C),
+        ];
+        scatter_offsets.sort();
+        assert_eq!(scatter_offsets, [0, 1, 2]);
+
+        let total = TEST_ITERABLE.len();
+        let mut it = (&TEST_ITERABLE).into_iter();
+        assert_eq!(it.len(), total);
+
+        let mut collected_offsets = Vec::new();
+        for step in 0..total {
+            let len_before = it.len();
+            let value = it.next().copied().expect("item");
+            let offset = offset_for_value(value);
+
+            assert_eq!(
+                len_before,
+                offset + 1,
+                "ExactSizeIterator::len before consuming offset {offset}"
+            );
+            assert_eq!(it.len(), total - step - 1);
+            collected_offsets.push(offset);
+        }
+
+        assert_eq!(it.len(), 0);
+        assert_eq!(it.next(), None);
+
+        collected_offsets.sort();
+        assert_eq!(collected_offsets, scatter_offsets);
+
         let items: Vec<u32> = (&TEST_ITERABLE).into_iter().copied().collect();
-        assert_eq!(items.len(), 3);
+        assert_eq!(items.len(), total);
         assert!(items.contains(&1));
         assert!(items.contains(&2));
         assert!(items.contains(&3));

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -96,12 +96,12 @@ pub fn submit<T: 'static>(state: &__ScatteredIterableState<T>, node: &'static Re
 }
 
 #[inline]
+#[allow(unsafe_code)]
 fn remaining_from_node<T>(node: *const Ref<T>) -> usize {
     if node.is_null() {
         return 0;
     }
     // SAFETY: `node` is a live `static` [`Ref`] for the program lifetime.
-    // Stored as submission index + 1; equals [`Ref::offset_of`] + 1.
     unsafe { (*node).loaded_index() }
 }
 

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -1,0 +1,227 @@
+//! A collection of items linked at runtime into a singly-linked list in
+//! constructor order.
+#![doc = concat!("```rust\n", include_str!("../examples/iterable.rs"), "\n```\n")]
+
+use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+
+/// One node in a [`ScatteredIterable`], with a `static` handle at each scatter site.
+pub struct Ref<T: 'static> {
+    next: AtomicPtr<Ref<T>>,
+    value: T,
+}
+
+impl<T> Ref<T> {
+    /// Create a new list node holding `value`.
+    pub const fn new(value: T) -> Self {
+        Self {
+            next: AtomicPtr::new(core::ptr::null_mut()),
+            value,
+        }
+    }
+}
+
+impl<T> ::core::ops::Deref for Ref<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> ::core::fmt::Debug for Ref<T>
+where
+    T: ::core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+/// Gather state for a [`ScatteredIterable`].
+#[doc(hidden)]
+pub struct __ScatteredIterableState<T: 'static> {
+    head: AtomicPtr<Ref<T>>,
+    len: AtomicUsize,
+}
+
+impl<T> __ScatteredIterableState<T> {
+    #[doc(hidden)]
+    pub const fn new() -> Self {
+        Self {
+            head: AtomicPtr::new(core::ptr::null_mut()),
+            len: AtomicUsize::new(0),
+        }
+    }
+}
+
+/// Prepend `node` to `state` and increment the length.
+#[doc(hidden)]
+pub fn submit<T: 'static>(state: &__ScatteredIterableState<T>, node: &'static Ref<T>) {
+    loop {
+        let head = state.head.load(Ordering::Relaxed);
+        node.next.store(head, Ordering::Relaxed);
+        if state
+            .head
+            .compare_exchange_weak(
+                head,
+                core::ptr::from_ref(node).cast_mut(),
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            state.len.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+    }
+}
+
+/// Iterator over a [`ScatteredIterable`].
+pub struct Iter<'a, T: 'static> {
+    current: *const Ref<T>,
+    remaining: usize,
+    _marker: ::core::marker::PhantomData<&'a T>,
+}
+
+impl<'a, T: 'static> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current.is_null() {
+            return None;
+        }
+
+        // SAFETY: Nodes are `static` and remain valid for the program lifetime.
+        // Iteration happens after all priority-0 constructors have finished linking.
+        let node = unsafe { &*self.current };
+        let item = &node.value;
+        self.current = node.next.load(Ordering::Acquire);
+        self.remaining = self.remaining.saturating_sub(1);
+        Some(item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<T: 'static> ExactSizeIterator for Iter<'_, T> {}
+
+/// A collection of items linked at runtime into a singly-linked list.
+///
+/// Scatter sites register `static` [`Ref`] handles in priority-0 constructors.
+/// Iteration order is the reverse of constructor registration order (each item
+/// is prepended to the list).
+///
+/// For link-time contiguous storage in arbitrary link order, use
+/// [`crate::ScatteredSlice`]. For `static` handles backed by a link section,
+/// use [`crate::ScatteredReferencedSlice`]. For sorted data, use
+/// [`crate::ScatteredSortedSlice`] or [`crate::ScatteredSortedReferencedSlice`].
+/// For key lookup, use [`crate::ScatteredMap`].
+#[doc = concat!("```rust\n", include_str!("../examples/iterable.rs"), "\n```\n")]
+pub struct ScatteredIterable<T: 'static> {
+    state: &'static __ScatteredIterableState<T>,
+}
+
+impl<T: 'static> ScatteredIterable<T> {
+    #[doc(hidden)]
+    pub const fn new(state: &'static __ScatteredIterableState<T>) -> Self {
+        Self { state }
+    }
+
+    /// The number of items in the iterable.
+    pub fn len(&self) -> usize {
+        self.state.len.load(Ordering::Acquire)
+    }
+
+    /// True if the iterable is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<T: 'static> ::core::iter::IntoIterator for &'static ScatteredIterable<T> {
+    type Item = &'static T;
+    type IntoIter = Iter<'static, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter {
+            current: self.state.head.load(Ordering::Acquire),
+            remaining: self.state.len.load(Ordering::Acquire),
+            _marker: ::core::marker::PhantomData,
+        }
+    }
+}
+
+/// Declare a scattered iterable.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __iterable_state {
+    ($name:ident) => {
+        $crate::__support::ident_concat!( () (__ $name __state__) () )
+    };
+}
+
+/// Declare a scattered iterable.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __iterable {
+    (gather $vis:vis $name:ident: $ty:ty) => {
+        $crate::__iterable!(@gather $vis static $name: ScatteredIterable<$ty>;);
+    };
+    (@gather $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
+        $crate::__support::ident_concat!((#[doc(hidden)] #[macro_export] macro_rules!) (__ $name __iterable_private_macro__) ({
+            ($passthru:tt) => {
+                $crate::__iterable!(@scatter $passthru);
+            };
+        }));
+
+        $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __iterable_private_macro__) (as $name;));
+
+        $crate::__support::ident_concat!((static ) (__ $name __state__) (: $crate::iterable::__ScatteredIterableState<$ty> = $crate::iterable::__ScatteredIterableState::new();));
+
+        $(#[$meta])*
+        $vis static $name: $collection<$ty> = {
+            $crate::iterable::ScatteredIterable::new(&$crate::__iterable_state!($name))
+        };
+    };
+    (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
+        $collection ! (( $collection => $vis static $name: $ty = $expr; ));
+    };
+    (@scatter ($collection:ident => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
+        $(#[$imeta])*
+        $vis static $name: $crate::iterable::Ref<$ty> = $crate::iterable::Ref::new($expr);
+
+        $crate::__support::ctor::declarative::ctor!(
+            #[ctor(unsafe, anonymous, priority = 0)]
+            fn __iterable_submit() {
+                $crate::iterable::submit(&$crate::__iterable_state!($collection), &$name);
+            }
+        );
+    };
+}
+
+#[cfg(all(test, not(miri)))]
+mod tests {
+    use crate::iterable::ScatteredIterable;
+
+    __iterable!(gather pub TEST_ITERABLE: u32);
+    __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_A: u32 = 1);
+    __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_B: u32 = 3);
+    __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_C: u32 = 2);
+
+    #[test]
+    fn test_scattered_iterable() {
+        assert_eq!(TEST_ITERABLE.len(), 3);
+        assert!(!TEST_ITERABLE.is_empty());
+
+        assert_eq!(*ITERABLE_ITEM_A, 1);
+        assert_eq!(*ITERABLE_ITEM_B, 3);
+        assert_eq!(*ITERABLE_ITEM_C, 2);
+
+        let items: Vec<u32> = (&TEST_ITERABLE).into_iter().copied().collect();
+        assert_eq!(items.len(), 3);
+        assert!(items.contains(&1));
+        assert!(items.contains(&2));
+        assert!(items.contains(&3));
+    }
+}

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -1,12 +1,14 @@
 #![doc = include_str!("../README.md")]
 
 pub mod hash;
+pub mod iterable;
 pub mod map;
 pub mod referenced_slice;
 pub mod slice;
 pub mod sorted_referenced_slice;
 pub mod sorted_slice;
 
+pub use iterable::ScatteredIterable;
 pub use map::ScatteredMap;
 pub use referenced_slice::ScatteredReferencedSlice;
 pub use slice::ScatteredSlice;
@@ -88,6 +90,14 @@ macro_rules! __gather_parse {
             @gather
             $(#[$imeta])*
             $vis static $name: $map < $key, $value >;
+        );
+    };
+
+    (@done ($collection:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredIterable < $ty:ty >; ) => {
+        $crate::__iterable ! (
+            @gather
+            $(#[$imeta])*
+            $vis static $name: $collection < $ty >;
         );
     };
 


### PR DESCRIPTION
This is the PoC for a new crate built on top of ctor and link-section: scattered-collect. This won't land directly -- it will get carved up into smaller PRs and polished.

The idea is:

```rust
#[gather]
pub static COLLECTION: ScatteredSlice<T>;

#[scatter(COLLECTION)]
pub static ITEM: T = { ... };
```

## Why?

Distributed slice is awesome and nearly perfect but it's a static snapshot out of the linker and downstream code occasionally needs more functionality on top of it, ie:

 - Sorting/ordering
 - Lookups by something other than ordinal index

Also, it doesn't support WASM which is a tougher to fix.

Inventory supports pretty much everything, but it's just a `#[ctor]` with a linked list and doesn't offer easy random access.

## TODO

I'll spin some PRs off of this one and slowly land some pieces:

 - [x] PR for placeholder crate (& publish a 0.0.0)
 - [x] Land the top-level scatter/gather macro implementations
 - [x] Implement and land the slice/referenced slice trivial types
 - [x] Implement and land sorted versions of slices
 - [x] Implement and land map
 - [x] Implement and land iterable

## Data types

 - (TODO) Iterable: collected items, only available via iterator (analogous to inventory crate)
 - Slice: collected items, not available at original definition site 
 - Referenced slice: collection items, available at original definition site (analogous to distributed slice crate)
 - Sorted slice: collected and sorted items, not available at original definition site 
 - Sorted referenced slice: collected and sorted items, available at original definition site 
 - Map: similar to hashmap's swisstable implementation, but space is allocated at link time and hashes are precomputed to make construction much cheaper

There are "referenced" and "unreferenced" versions of the slices - the unreferenced versions may be faster as the code is free to re-organize the data more easily.

## Const hashing

 - New trait: ConstHasher (should be able to derive this for custom structs as well)

## Platform challenge notes

 - WASM: link sections are pretty much useless unless we do some sort of post-processing on the binary, which might be an option. We can, however, at least count the number of items using link-section and then place all the data via alloc + ctor copies where needed (the scattered iterator won't need this, and the map needs at least one iteration anyways, so we might be able to have a custom impl there). 
 - All other platforms: generally will work via slices as expected. Similar single-threaded init with a late ctor to ctor's static will allow for guaranteed init before main without ordering issues.
