### PR TITLE
Add const option for link-section

### DIFF
--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -10,6 +10,8 @@ cargo clean
 
 cargo miri test
 
+cargo miri run --example "link-section-const"
+
 miri_crates=(
   tests/ctor/edition-2018
   tests/ctor/priority

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "libc-print",
  "link-section",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "linktime-proc-macro",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.1", default-features = false }
+ctor = { path = "ctor", version = "1.0.2", default-features = false }
 dtor = { path = "dtor", version = "1.0.0", default-features = false }
-link-section = { path = "link-section", version = "0.14.0", default-features = false }
+link-section = { path = "link-section", version = "0.15.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - Unreleased
+
+### Changed
+
+- Use `const` items for collected constructors on macOS.
+
 ## [1.0.1] - 2026-05-04
 
 ### Changed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.1"
+version = "1.0.2"
 authors.workspace = true
 edition = "2021"
 description = "__attribute__((constructor)) for Rust"

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -159,7 +159,7 @@ pub mod collect {
         (priority = $priority:tt, fn = $fn:ident) => {
             $crate::__support::in_section!(
                 #[in_section(unsafe, type = $crate::collect::Constructor, name = _CTOR0_ISIZE_FN)]
-                pub static CTOR: $crate::collect::Constructor = $crate::collect::Constructor {
+                pub const _: $crate::collect::Constructor = $crate::collect::Constructor {
                     priority: $priority,
                     ctor: $fn,
                 };

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -14,15 +14,13 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        pub const _: ::ctor::collect::Constructor = {
-            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+        pub const _: () = {
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-            #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -14,11 +14,15 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-        #[used]
-        pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-            priority: 0,
-            ctor: __ctor_private,
+        pub const _: ::ctor::collect::Constructor = {
+            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                priority: 0,
+                ctor: __ctor_private,
+            };
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -15,9 +15,10 @@ unsafe fn foo() {
             { unsafe { __ctor_private_inner() } }
         }
         pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -16,9 +16,10 @@ const _: () = {
                 { unsafe { __ctor_private_inner() } }
             }
             pub const _: () = {
+                type __InSecStoredTy = ::ctor::collect::Constructor;
                 #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 #[used]
-                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
                     priority: 0,
                     ctor: __ctor_private,
                 };
@@ -44,9 +45,10 @@ const _: () = {
                 { unsafe { __ctor_private_inner() } }
             }
             pub const _: () = {
+                type __InSecStoredTy = ::ctor::collect::Constructor;
                 #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 #[used]
-                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
                     priority: 0,
                     ctor: __ctor_private,
                 };

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -15,15 +15,13 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            pub const _: ::ctor::collect::Constructor = {
-                const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            pub const _: () = {
+                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+                #[used]
+                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
                     priority: 0,
                     ctor: __ctor_private,
                 };
-                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-                #[used]
-                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-                __LINK_SECTION_CONST_ITEM_VALUE
             };
         };
         unsafe { __ctor_private_inner() }
@@ -45,15 +43,13 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            pub const _: ::ctor::collect::Constructor = {
-                const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            pub const _: () = {
+                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+                #[used]
+                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
                     priority: 0,
                     ctor: __ctor_private,
                 };
-                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-                #[used]
-                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-                __LINK_SECTION_CONST_ITEM_VALUE
             };
         };
         unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -15,11 +15,15 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-            #[used]
-            pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-                priority: 0,
-                ctor: __ctor_private,
+            pub const _: ::ctor::collect::Constructor = {
+                const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                    priority: 0,
+                    ctor: __ctor_private,
+                };
+                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+                #[used]
+                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+                __LINK_SECTION_CONST_ITEM_VALUE
             };
         };
         unsafe { __ctor_private_inner() }
@@ -41,11 +45,15 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-            #[used]
-            pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-                priority: 0,
-                ctor: __ctor_private,
+            pub const _: ::ctor::collect::Constructor = {
+                const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                    priority: 0,
+                    ctor: __ctor_private,
+                };
+                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+                #[used]
+                pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+                __LINK_SECTION_CONST_ITEM_VALUE
             };
         };
         unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -17,9 +17,10 @@ unsafe fn foo() {
             { unsafe { __ctor_private_inner() } }
         }
         pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -16,15 +16,13 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        pub const _: ::ctor::collect::Constructor = {
-            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+        pub const _: () = {
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-            #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -16,11 +16,15 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-        #[used]
-        pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-            priority: 0,
-            ctor: __ctor_private,
+        pub const _: ::ctor::collect::Constructor = {
+            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                priority: 0,
+                ctor: __ctor_private,
+            };
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -14,11 +14,15 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-        #[used]
-        pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-            priority: 1,
-            ctor: __ctor_private,
+        pub const _: ::ctor::collect::Constructor = {
+            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                priority: 1,
+                ctor: __ctor_private,
+            };
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -15,9 +15,10 @@ fn foo() {
             { { __ctor_private_inner() } }
         }
         pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
                 priority: 1,
                 ctor: __ctor_private,
             };

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -14,15 +14,13 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        pub const _: ::ctor::collect::Constructor = {
-            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+        pub const _: () = {
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
                 priority: 1,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-            #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -17,10 +17,14 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
-    #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-    #[used]
-    pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-        priority: 0,
-        ctor: __ctor_private,
+    pub const _: ::ctor::collect::Constructor = {
+        const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            priority: 0,
+            ctor: __ctor_private,
+        };
+        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+        #[used]
+        pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+        __LINK_SECTION_CONST_ITEM_VALUE
     };
 };

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -18,9 +18,10 @@ const _: () = {
         { _ = &*STATIC_CTOR }
     }
     pub const _: () = {
+        type __InSecStoredTy = ::ctor::collect::Constructor;
         #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
         #[used]
-        pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+        pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
             priority: 0,
             ctor: __ctor_private,
         };

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -17,14 +17,12 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
-    pub const _: ::ctor::collect::Constructor = {
-        const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+    pub const _: () = {
+        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+        #[used]
+        pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
             priority: 0,
             ctor: __ctor_private,
         };
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-        #[used]
-        pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-        __LINK_SECTION_CONST_ITEM_VALUE
     };
 };

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -14,15 +14,13 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        pub const _: ::ctor::collect::Constructor = {
-            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+        pub const _: () = {
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-            #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -14,11 +14,15 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-        #[used]
-        pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-            priority: 0,
-            ctor: __ctor_private,
+        pub const _: ::ctor::collect::Constructor = {
+            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                priority: 0,
+                ctor: __ctor_private,
+            };
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     unsafe { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -15,9 +15,10 @@ unsafe fn foo() {
             { unsafe { __ctor_private_inner() } }
         }
         pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -14,15 +14,13 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        pub const _: ::ctor::collect::Constructor = {
-            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+        pub const _: () = {
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-            #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
-            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -14,11 +14,15 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
-        #[used]
-        pub static CTOR: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
-            priority: 0,
-            ctor: __ctor_private,
+        pub const _: ::ctor::collect::Constructor = {
+            const __LINK_SECTION_CONST_ITEM_VALUE: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+                priority: 0,
+                ctor: __ctor_private,
+            };
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = __LINK_SECTION_CONST_ITEM_VALUE;
+            __LINK_SECTION_CONST_ITEM_VALUE
         };
     };
     { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -15,9 +15,10 @@ fn foo() {
             { { __ctor_private_inner() } }
         }
         pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
-            pub static __LINK_SECTION_CONST_ITEM: ::ctor::collect::Constructor = ::ctor::collect::Constructor {
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
                 priority: 0,
                 ctor: __ctor_private,
             };

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - Unreleased
+
+### Added
+
+- Support for `const` items in link sections.
+
 ## [0.14.0] - 2026-05-04
 
 ### Changed

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -27,3 +27,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [[example]]
 name = "link-section-example"
 path = "examples/example.rs"
+
+[[example]]
+name = "link-section-const"
+path = "examples/const.rs"

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.14.0"
+version = "0.15.0"
 authors.workspace = true
 edition = "2021"
 description = "Low-level link-section macro support for Rust"
@@ -26,4 +26,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 [[example]]
 name = "link-section-example"
-path = "src/example.rs"
+path = "examples/example.rs"

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -132,6 +132,13 @@ Typed sections provide a section where all items are of a specific, sized type.
 The typed section may be accessed as a slice of the type at zero cost if
 desired.
 
+A typed section can be created from either `static` or `const` items.
+
+For `const` items: a copy of the `const` is materialized at link time, while the
+constant itself remains available for use as a constant in `const` contexts.
+
+For `static` items: the static is stored directly in the link section.
+
 `fn` items are special-cased and stored as function pointers in the typed
 section.
 
@@ -153,7 +160,7 @@ pub fn link_section_function() {
 ```
 
 Create a typed section using the `#[section]` macro that stores items of a
-specific, sized type:
+specific, sized type from `static` or `const` items:
 
 ```rust
 mod my_registry {
@@ -166,16 +173,20 @@ mod my_registry {
     #[section]
     pub static MY_REGISTRY: link_section::TypedSection<MyStruct>;
 
-    mod a {
+    // Registers a `const` item.
+    mod register_a_constant {
         use super::*;
 
+        // A copy of this constant is registered in the link section.
         #[in_section(MY_REGISTRY)]
-        pub static LINKED_MY_STRUCT: MyStruct = MyStruct { name: "my_struct" };
+        pub const LINKED_MY_STRUCT: MyStruct = MyStruct { name: "my_struct" };
     }
 
-    mod b {
+    // Registers a `static` item.
+    mod register_a_static {
         use super::*;
 
+        // This static lives directly in the link section.
         #[in_section(MY_REGISTRY)]
         pub static LINKED_MY_STRUCT: MyStruct = MyStruct { name: "my_struct_2" };
     }

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -121,6 +121,13 @@ Typed sections provide a section where all items are of a specific, sized type.
 The typed section may be accessed as a slice of the type at zero cost if
 desired.
 
+A typed section can be created from either `static` or `const` items.
+
+For `const` items: a copy of the `const` is materialized at link time, while the
+constant itself remains available for use as a constant in `const` contexts.
+
+For `static` items: the static is stored directly in the link section.
+
 `fn` items are special-cased and stored as function pointers in the typed
 section.
 
@@ -142,7 +149,7 @@ pub fn link_section_function() {
 ```
 
 Create a typed section using the `#[section]` macro that stores items of a
-specific, sized type:
+specific, sized type from `static` or `const` items:
 
 ```rust
 mod my_registry {
@@ -155,16 +162,20 @@ mod my_registry {
     #[section]
     pub static MY_REGISTRY: link_section::TypedSection<MyStruct>;
 
-    mod a {
+    // Registers a `const` item.
+    mod register_a_constant {
         use super::*;
 
+        // A copy of this constant is registered in the link section.
         #[in_section(MY_REGISTRY)]
-        pub static LINKED_MY_STRUCT: MyStruct = MyStruct { name: "my_struct" };
+        pub const LINKED_MY_STRUCT: MyStruct = MyStruct { name: "my_struct" };
     }
 
-    mod b {
+    // Registers a `static` item.
+    mod register_a_static {
         use super::*;
 
+        // This static lives directly in the link section.
         #[in_section(MY_REGISTRY)]
         pub static LINKED_MY_STRUCT: MyStruct = MyStruct { name: "my_struct_2" };
     }

--- a/link-section/examples/const.rs
+++ b/link-section/examples/const.rs
@@ -1,0 +1,34 @@
+//! Example usage of the `link-section` crate.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+
+use link_section::{in_section, section};
+
+struct Driver {
+    name: &'static str,
+    f: fn (),
+}
+
+impl Driver {
+    pub const fn new(name: &'static str, f: fn ()) -> Self {
+        Self { name, f }
+    }
+}
+
+#[section]
+static DATA_SECTION: link_section::TypedSection<Driver>;
+
+#[in_section(DATA_SECTION)]
+pub const POSTGRES_DRIVER: Driver = Driver::new("postgres", || println!("postgres"));
+
+#[in_section(DATA_SECTION)]
+pub const MYSQL_DRIVER: Driver = Driver::new("mysql", || println!("mysql"));
+
+#[in_section(DATA_SECTION)]
+pub const SQLITE_DRIVER: Driver = Driver::new("sqlite", || println!("sqlite"));
+
+fn main() {
+    for driver in DATA_SECTION {
+        println!("Connecting to {}...", driver.name);
+        (driver.f)();
+    }
+}

--- a/link-section/examples/const.rs
+++ b/link-section/examples/const.rs
@@ -9,34 +9,43 @@ struct Driver {
 }
 
 impl Driver {
+    /// Create a new driver.
     pub const fn new(name: &'static str, f: fn()) -> Self {
         Self { name, f }
     }
 }
 
+/// Drivers.
 #[section]
 static DATA_SECTION: link_section::TypedSection<Driver>;
 
+/// A driver for PostgreSQL.
 #[in_section(DATA_SECTION)]
 pub const POSTGRES_DRIVER: Driver = Driver::new("postgres", || println!("connected to postgres!"));
 
+/// A driver for MySQL.
 #[in_section(DATA_SECTION)]
 pub const MYSQL_DRIVER: Driver = Driver::new("mysql", || println!("connected to mysql!"));
 
+/// A driver for SQLite.
 #[in_section(DATA_SECTION)]
 pub const SQLITE_DRIVER: Driver = Driver::new("sqlite", || println!("connected to sqlite!"));
 
+/// Databases.
 #[section]
 static DATABASES: link_section::TypedSection<(&'static str, &'static Driver)>;
 
+/// A database for PostgreSQL.
 #[in_section(DATABASES)]
 pub const POSTGRES_DATABASE: (&'static str, &'static Driver) =
     ("postgres://localhost:5432", &POSTGRES_DRIVER);
 
+/// A database for MySQL.
 #[in_section(DATABASES)]
 pub const MYSQL_DATABASE: (&'static str, &'static Driver) =
     ("mysql://localhost:3306", &MYSQL_DRIVER);
 
+/// A database for SQLite.
 #[in_section(DATABASES)]
 pub const SQLITE_DATABASE: (&'static str, &'static Driver) =
     ("sqlite://localhost:1433", &SQLITE_DRIVER);

--- a/link-section/examples/const.rs
+++ b/link-section/examples/const.rs
@@ -10,7 +10,7 @@ struct Driver {
 
 impl Driver {
     /// Create a new driver.
-    pub const fn new(name: &'static str, f: fn()) -> Self {
+    const fn new(name: &'static str, f: fn()) -> Self {
         Self { name, f }
     }
 }

--- a/link-section/examples/const.rs
+++ b/link-section/examples/const.rs
@@ -5,11 +5,11 @@ use link_section::{in_section, section};
 
 struct Driver {
     name: &'static str,
-    f: fn (),
+    f: fn(),
 }
 
 impl Driver {
-    pub const fn new(name: &'static str, f: fn ()) -> Self {
+    pub const fn new(name: &'static str, f: fn()) -> Self {
         Self { name, f }
     }
 }
@@ -18,17 +18,32 @@ impl Driver {
 static DATA_SECTION: link_section::TypedSection<Driver>;
 
 #[in_section(DATA_SECTION)]
-pub const POSTGRES_DRIVER: Driver = Driver::new("postgres", || println!("postgres"));
+pub const POSTGRES_DRIVER: Driver = Driver::new("postgres", || println!("connected to postgres!"));
 
 #[in_section(DATA_SECTION)]
-pub const MYSQL_DRIVER: Driver = Driver::new("mysql", || println!("mysql"));
+pub const MYSQL_DRIVER: Driver = Driver::new("mysql", || println!("connected to mysql!"));
 
 #[in_section(DATA_SECTION)]
-pub const SQLITE_DRIVER: Driver = Driver::new("sqlite", || println!("sqlite"));
+pub const SQLITE_DRIVER: Driver = Driver::new("sqlite", || println!("connected to sqlite!"));
+
+#[section]
+static DATABASES: link_section::TypedSection<(&'static str, &'static Driver)>;
+
+#[in_section(DATABASES)]
+pub const POSTGRES_DATABASE: (&'static str, &'static Driver) =
+    ("postgres://localhost:5432", &POSTGRES_DRIVER);
+
+#[in_section(DATABASES)]
+pub const MYSQL_DATABASE: (&'static str, &'static Driver) =
+    ("mysql://localhost:3306", &MYSQL_DRIVER);
+
+#[in_section(DATABASES)]
+pub const SQLITE_DATABASE: (&'static str, &'static Driver) =
+    ("sqlite://localhost:1433", &SQLITE_DRIVER);
 
 fn main() {
-    for driver in DATA_SECTION {
-        println!("Connecting to {}...", driver.name);
+    for (url, driver) in DATABASES {
+        println!("Connecting to {url} ({})...", driver.name);
         (driver.f)();
     }
 }

--- a/link-section/examples/example.rs
+++ b/link-section/examples/example.rs
@@ -67,9 +67,8 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
-pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) = {
-    &::core::fmt::from_fn(|f| f.write_str("debuggable_function"))
-};
+pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
+    { &::core::fmt::from_fn(|f| f.write_str("debuggable_function")) };
 
 /// Dumps the various sections.
 pub fn main() {

--- a/link-section/examples/example.rs
+++ b/link-section/examples/example.rs
@@ -67,7 +67,7 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
-pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
+pub const DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
     &::core::fmt::from_fn(|f| f.write_str("debuggable_function"));
 
 /// Dumps the various sections.

--- a/link-section/examples/example.rs
+++ b/link-section/examples/example.rs
@@ -67,11 +67,8 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
-pub static DEBUGGABLE_FUNCTION: fn() = {
-    fn debuggable_function() {
-        eprintln!("debuggable_function");
-    }
-    &(debuggable_function as fn())
+pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) = {
+    &::core::fmt::from_fn(|f| f.write_str("debuggable_function"))
 };
 
 /// Dumps the various sections.

--- a/link-section/examples/example.rs
+++ b/link-section/examples/example.rs
@@ -68,7 +68,7 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
 pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
-    { &::core::fmt::from_fn(|f| f.write_str("debuggable_function")) };
+    &::core::fmt::from_fn(|f| f.write_str("debuggable_function"));
 
 /// Dumps the various sections.
 pub fn main() {

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -618,11 +618,12 @@ pub mod __support {
         };
         ($type_source:tt, $ident:ident, $($aux:ident)?, $path:path, ($(#[$meta:meta])* $vis:vis const $name:ident: $ty:ty = $value:expr;)) => {
             $(#[$meta])* $vis const $name: $ty = {
-                const __LINK_SECTION_CONST_ITEM_VALUE: $ty = $value;
+                type __InSecStoredTy = $crate::__in_section_crate!(@type_select $type_source $path, $ty);
+                const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
                 $crate::__add_section_link_attribute!(
                     data section $ident $($aux)?
                     #[link_section = __]
-                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: $ty = __LINK_SECTION_CONST_ITEM_VALUE;
+                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
                 );
                 __LINK_SECTION_CONST_ITEM_VALUE
             };
@@ -630,10 +631,11 @@ pub mod __support {
         // Simplify anonymous constants.
         ($type_source:tt, $ident:ident, $($aux:ident)?, $path:path, ($(#[$meta:meta])* $vis:vis const _: $ty:ty = $value:expr;)) => {
             $(#[$meta])* $vis const _: () = {
+                type __InSecStoredTy = $crate::__in_section_crate!(@type_select $type_source $path, $ty);
                 $crate::__add_section_link_attribute!(
                     data section $ident $($aux)?
                     #[link_section = __]
-                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: $ty = $value;
+                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = $value;
                 );
             };
         };

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -627,15 +627,14 @@ pub mod __support {
                 __LINK_SECTION_CONST_ITEM_VALUE
             };
         };
+        // Simplify anonymous constants.
         ($type_source:tt, $ident:ident, $($aux:ident)?, $path:path, ($(#[$meta:meta])* $vis:vis const _: $ty:ty = $value:expr;)) => {
-            $(#[$meta])* $vis const _: $ty = {
-                const __LINK_SECTION_CONST_ITEM_VALUE: $ty = $value;
+            $(#[$meta])* $vis const _: () = {
                 $crate::__add_section_link_attribute!(
                     data section $ident $($aux)?
                     #[link_section = __]
-                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: $ty = __LINK_SECTION_CONST_ITEM_VALUE;
+                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: $ty = $value;
                 );
-                __LINK_SECTION_CONST_ITEM_VALUE
             };
         };
         (data, $ident:ident, $($aux:ident)?, $path:path, ($(#[$meta:meta])* $item:item)) => {

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -532,7 +532,7 @@ pub mod __support {
         ((v=0 (name=$ident:ident (path=[$path:path] (item=$item:tt $rest:tt)))) () )=> {
             $crate::__support::in_section_crate!(section, $ident,, $path, $item);
         };
-        (v=$v:literal $rest:tt) => {
+        ((v=$v:literal $rest:tt)) => {
             const _: () = {
                 compile_error!(concat!(
                     "link-section: Unsupported version: `",
@@ -556,7 +556,7 @@ pub mod __support {
         ((v=0 (name=$ident:ident (path=[$path:path] (item=$item:tt $rest:tt)))) () )=> {
             $crate::__support::in_section_crate!(data, $ident,, $path, $item);
         };
-        (v=$v:literal $rest:tt) => {
+        ((v=$v:literal $rest:tt)) => {
             const _: () = {
                 compile_error!(concat!(
                     "link-section: Unsupported version: `",
@@ -615,6 +615,28 @@ pub mod __support {
                 #[link_section = __]
                 $(#[$meta])* $vis static $ident_static: $crate::__in_section_crate!(@type_select $type_source $path, $ty) = $value;
             );
+        };
+        ($type_source:tt, $ident:ident, $($aux:ident)?, $path:path, ($(#[$meta:meta])* $vis:vis const $name:ident: $ty:ty = $value:expr;)) => {
+            $(#[$meta])* $vis const $name: $ty = {
+                const __LINK_SECTION_CONST_ITEM_VALUE: $ty = $value;
+                $crate::__add_section_link_attribute!(
+                    data section $ident $($aux)?
+                    #[link_section = __]
+                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: $ty = __LINK_SECTION_CONST_ITEM_VALUE;
+                );
+                __LINK_SECTION_CONST_ITEM_VALUE
+            };
+        };
+        ($type_source:tt, $ident:ident, $($aux:ident)?, $path:path, ($(#[$meta:meta])* $vis:vis const _: $ty:ty = $value:expr;)) => {
+            $(#[$meta])* $vis const _: $ty = {
+                const __LINK_SECTION_CONST_ITEM_VALUE: $ty = $value;
+                $crate::__add_section_link_attribute!(
+                    data section $ident $($aux)?
+                    #[link_section = __]
+                    $(#[$meta])* $vis static __LINK_SECTION_CONST_ITEM: $ty = __LINK_SECTION_CONST_ITEM_VALUE;
+                );
+                __LINK_SECTION_CONST_ITEM_VALUE
+            };
         };
         (data, $ident:ident, $($aux:ident)?, $path:path, ($(#[$meta:meta])* $item:item)) => {
             $crate::__add_section_link_attribute!(

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -893,7 +893,7 @@ impl<T: 'static> TypedSection<T> {
     /// The start address of the section.
     #[inline(always)]
     pub fn start_ptr(&self) -> *const T {
-        self.start as usize as *const T
+        self.start as *const T
     }
 
     /// The end address of the section.

--- a/tests/link_section/basic/src/main.rs
+++ b/tests/link_section/basic/src/main.rs
@@ -66,12 +66,8 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
-pub static DEBUGGABLE_FUNCTION: fn() = {
-    fn debuggable_function() {
-        eprintln!("debuggable_function");
-    }
-    &(debuggable_function as fn())
-};
+pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
+    &::core::fmt::from_fn(|f| f.write_str("debuggable_function"));
 
 #[cfg(miri)]
 pub fn main() {

--- a/tests/link_section/basic/src/main.rs
+++ b/tests/link_section/basic/src/main.rs
@@ -66,7 +66,7 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
-pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
+pub const DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
     &::core::fmt::from_fn(|f| f.write_str("debuggable_function"));
 
 #[cfg(miri)]

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -27,7 +27,10 @@ unordered {
     ! f: %{BASE16NUM}
     ! linked_function_2
 }
-! DEBUGGABLES: [1, 2, %{BASE16NUM}]
+choice {
+    ! DEBUGGABLES: [1, 2, debuggable_function]
+    ! DEBUGGABLES: [debuggable_function, 2, 1]
+}
 "#
 );
 


### PR DESCRIPTION
By using a `const` item, we can potentially allow for better WASM compatibility in the future by keeping the data separate from its definition.
