### PR TITLE
Allow "optional" ctors where the ctors can be generated by a const function

### DIFF
--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - Unreleased
+## [1.0.2] - 2026-05-06
 
 ### Changed
 
-- Use `const` items for collected constructors on macOS.
+- Bump `link-section` dependency to 0.15.0.
+- Use `const` rather than `static` items for collected constructors on macOS.
 - Allow various forms of `&'static` for `#[ctor]` statics which desugar to
   `&'static Static`.
 - Static items delegate `Display` directly as well.

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow various forms of `&'static` for `#[ctor]` statics which desugar to
   `&'static Static`.
 - Static items delegate `Display` directly as well.
+- Support for multiple `#[ctor]` items in a single `#[ctor]` block:
+```rust
+#[ctor]
+static CTOR: &[fn()] = const {
+  // ...
+}
+```
 
 ## [1.0.1] - 2026-05-04
 

--- a/ctor/examples/ctor-dynamic.rs
+++ b/ctor/examples/ctor-dynamic.rs
@@ -1,5 +1,7 @@
 //! Demonstrate dynamic `#[ctor]`s.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![allow(clippy::incompatible_msrv)]
+
 use ctor::ctor;
 use libc_print::*;
 

--- a/ctor/examples/ctor-dynamic.rs
+++ b/ctor/examples/ctor-dynamic.rs
@@ -1,0 +1,26 @@
+//! Demonstrate dynamic `#[ctor]`s.
+use ctor::ctor;
+use libc_print::*;
+
+#[ctor(unsafe)]
+static STATIC_CTORS: &[fn()] = const {
+    fn bind_const<const N: usize>() {
+        libc_eprintln!("bind_const: {}", N);
+    }
+    [bind_const::<1>, bind_const::<2>, bind_const::<3>].as_slice()
+};
+
+#[ctor(unsafe)]
+static OPTIONAL_CTOR: &[fn()] = const {
+    #[allow(unexpected_cfgs)]
+    if cfg!(enable_ctor) {
+        fn ctor() {
+            libc_eprintln!("ctor");
+        }
+        [ctor as fn()].as_slice()
+    } else {
+        &[]
+    }
+};
+
+fn main() {}

--- a/ctor/examples/ctor-dynamic.rs
+++ b/ctor/examples/ctor-dynamic.rs
@@ -1,4 +1,5 @@
 //! Demonstrate dynamic `#[ctor]`s.
+#![allow(clippy::incompatible_msrv)]
 use ctor::ctor;
 use libc_print::*;
 

--- a/ctor/examples/ctor-statics.rs
+++ b/ctor/examples/ctor-statics.rs
@@ -1,4 +1,6 @@
 //! Demonstrate various forms of `#[ctor]` statics.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+
 use std::mem::MaybeUninit;
 
 use ctor::ctor;

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -166,56 +166,35 @@ pub mod collect {
                 };
             );
         };
-        (priority = $priority:tt, fn = (array $fn:ident)) => {
+        (priority = $priority:tt, fn = (array $array:ident)) => {
             $crate::__support::in_section!(
-                #[in_section(unsafe, type = [$crate::collect::Constructor; if $fn().len() == 0 { 1 } else { $fn().len() }], name = _CTOR0_ISIZE_FN)]
-                pub const _: [$crate::collect::Constructor; if $fn().len() == 0 { 1 } else { $fn().len() }] = {
+                #[in_section(unsafe, type = [$crate::collect::Constructor; if $array.len() == 0 { 1 } else { $array.len() }], name = _CTOR0_ISIZE_FN)]
+                pub const _: [$crate::collect::Constructor; if $array.len() == 0 { 1 } else { $array.len() }] = {
                     use core::mem::MaybeUninit;
 
                     // If length zero, register a stub that doesn't get executed
-                    if $fn().len() == 0 {
+                    if $array.len() == 0 {
                         unsafe extern "C" fn empty_ctor() {}
                         [$crate::collect::Constructor {
                             priority: $crate::collect::PROCESSED,
                             ctor: empty_ctor,
-                        }; if $fn().len() == 0 { 1 } else { $fn().len() }]
+                        }; if $array.len() == 0 { 1 } else { $array.len() }]
                     } else {
-                        let mut array: MaybeUninit<[$crate::collect::Constructor; if $fn().len() == 0 { 1 } else { $fn().len() }]> = MaybeUninit::uninit();
-
-                        const fn ctor_fn<const N: usize>() -> $crate::collect::Constructor {
+                        let mut array: MaybeUninit<[$crate::collect::Constructor; if $array.len() == 0 { 1 } else { $array.len() }]> = MaybeUninit::uninit();
+                        let mut array_ptr: *mut $crate::collect::Constructor = array.as_mut_ptr() as _;
+                        const fn ctor_fn(i: usize) -> $crate::collect::Constructor {
                             $crate::collect::Constructor {
                                 priority: $priority,
-                                ctor: bind_array::<N>,
+                                ctor: $array[i],
                             }
                         }
 
-                        extern "C" fn bind_array<const N: usize>() {
-                            $fn()[N]()
+                        let mut i = 0;
+                        while i < $array.len() {
+                            unsafe { array_ptr.add(i).write(ctor_fn(i)) };
+                            i += 1;
                         }
 
-                        unsafe {
-                            let array_ptr = array.as_mut_ptr() as *mut $crate::collect::Constructor;
-                            const LEN: usize = $fn().len();
-                            if LEN > 0 { array_ptr.add(0).write(ctor_fn::<0>()); }
-                            if LEN > 1 { array_ptr.add(1).write(ctor_fn::<1>()); }
-                            if LEN > 2 { array_ptr.add(2).write(ctor_fn::<2>()); }
-                            if LEN > 3 { array_ptr.add(3).write(ctor_fn::<3>()); }
-                            if LEN > 4 { array_ptr.add(4).write(ctor_fn::<4>()); }
-                            if LEN > 5 { array_ptr.add(5).write(ctor_fn::<5>()); }
-                            if LEN > 6 { array_ptr.add(6).write(ctor_fn::<6>()); }
-                            if LEN > 7 { array_ptr.add(7).write(ctor_fn::<7>()); }
-                            if LEN > 8 { array_ptr.add(8).write(ctor_fn::<8>()); }
-                            if LEN > 9 { array_ptr.add(9).write(ctor_fn::<9>()); }
-                            if LEN > 10 { array_ptr.add(10).write(ctor_fn::<10>()); }
-                            if LEN > 11 { array_ptr.add(11).write(ctor_fn::<11>()); }
-                            if LEN > 12 { array_ptr.add(12).write(ctor_fn::<12>()); }
-                            if LEN > 13 { array_ptr.add(13).write(ctor_fn::<13>()); }
-                            if LEN > 14 { array_ptr.add(14).write(ctor_fn::<14>()); }
-                            if LEN > 15 { array_ptr.add(15).write(ctor_fn::<15>()); }
-                            if LEN > 16 {
-                                panic!("Unexpected array length, expected <= 16");
-                            }
-                        }
                         unsafe { array.assume_init() }
                     }
                 };

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -58,7 +58,8 @@ crate::__ctor_parse_internal!(
 pub mod collect {
     use core::sync::atomic::{AtomicU8, Ordering};
 
-    const PROCESSED: isize = isize::MIN;
+    #[doc(hidden)]
+    pub const PROCESSED: isize = isize::MIN;
     #[doc(hidden)]
     pub const LATE: isize = isize::MAX;
 
@@ -162,6 +163,61 @@ pub mod collect {
                 pub const _: $crate::collect::Constructor = $crate::collect::Constructor {
                     priority: $priority,
                     ctor: $fn,
+                };
+            );
+        };
+        (priority = $priority:tt, fn = (array $fn:ident)) => {
+            $crate::__support::in_section!(
+                #[in_section(unsafe, type = [$crate::collect::Constructor; if $fn().len() == 0 { 1 } else { $fn().len() }], name = _CTOR0_ISIZE_FN)]
+                pub const _: [$crate::collect::Constructor; if $fn().len() == 0 { 1 } else { $fn().len() }] = {
+                    use core::mem::MaybeUninit;
+
+                    // If length zero, register a stub that doesn't get executed
+                    if $fn().len() == 0 {
+                        unsafe extern "C" fn empty_ctor() {}
+                        [$crate::collect::Constructor {
+                            priority: $crate::collect::PROCESSED,
+                            ctor: empty_ctor,
+                        }; if $fn().len() == 0 { 1 } else { $fn().len() }]
+                    } else {
+                        let mut array: MaybeUninit<[$crate::collect::Constructor; if $fn().len() == 0 { 1 } else { $fn().len() }]> = MaybeUninit::uninit();
+
+                        const fn ctor_fn<const N: usize>() -> $crate::collect::Constructor {
+                            $crate::collect::Constructor {
+                                priority: $priority,
+                                ctor: bind_array::<N>,
+                            }
+                        }
+
+                        extern "C" fn bind_array<const N: usize>() {
+                            $fn()[N]()
+                        }
+
+                        unsafe {
+                            let array_ptr = array.as_mut_ptr() as *mut $crate::collect::Constructor;
+                            const LEN: usize = $fn().len();
+                            if LEN > 0 { array_ptr.add(0).write(ctor_fn::<0>()); }
+                            if LEN > 1 { array_ptr.add(1).write(ctor_fn::<1>()); }
+                            if LEN > 2 { array_ptr.add(2).write(ctor_fn::<2>()); }
+                            if LEN > 3 { array_ptr.add(3).write(ctor_fn::<3>()); }
+                            if LEN > 4 { array_ptr.add(4).write(ctor_fn::<4>()); }
+                            if LEN > 5 { array_ptr.add(5).write(ctor_fn::<5>()); }
+                            if LEN > 6 { array_ptr.add(6).write(ctor_fn::<6>()); }
+                            if LEN > 7 { array_ptr.add(7).write(ctor_fn::<7>()); }
+                            if LEN > 8 { array_ptr.add(8).write(ctor_fn::<8>()); }
+                            if LEN > 9 { array_ptr.add(9).write(ctor_fn::<9>()); }
+                            if LEN > 10 { array_ptr.add(10).write(ctor_fn::<10>()); }
+                            if LEN > 11 { array_ptr.add(11).write(ctor_fn::<11>()); }
+                            if LEN > 12 { array_ptr.add(12).write(ctor_fn::<12>()); }
+                            if LEN > 13 { array_ptr.add(13).write(ctor_fn::<13>()); }
+                            if LEN > 14 { array_ptr.add(14).write(ctor_fn::<14>()); }
+                            if LEN > 15 { array_ptr.add(15).write(ctor_fn::<15>()); }
+                            if LEN > 16 {
+                                panic!("Unexpected array length, expected <= 16");
+                            }
+                        }
+                        unsafe { array.assume_init() }
+                    }
                 };
             );
         };

--- a/ctor/src/parse.rs
+++ b/ctor/src/parse.rs
@@ -156,6 +156,34 @@ macro_rules! __ctor_parse_impl {
         compile_error!("Trivial const expressions are not supported. Remove the #[ctor] and use a regular `static`.");
     };
 
+    // Allow dynamic #[ctor]s - a const expression determines the actual functions.
+    ( @entry next=$next:path[$next_args:tt], input=(
+        features = (
+            anonymous = $anonymous:tt,
+            linker_options = $linker_options:tt,
+            no_fail_on_missing_unsafe = $no_fail_on_missing_unsafe:tt,
+            priority = $priority:tt,
+        ),
+        self = $self:tt,
+        meta = $meta:tt,
+        unsafe = $unsafe:tt,
+        item = ($vis:vis static $ident:ident : &[fn()] = const $body:block;)
+    ) ) => {
+        $crate::__ctor_parse_impl!(@entry next=$next[$next_args], input=(
+            features = (
+                anonymous = $anonymous,
+                linker_options = $linker_options,
+                link_name = $ident,
+                no_fail_on_missing_unsafe = $no_fail_on_missing_unsafe,
+                priority = $priority,
+            ),
+            self = $self,
+            meta = $meta,
+            unsafe = $unsafe,
+            item = ($vis static $ident : &[fn()] = const $body;)
+        ));
+    };
+
     ( @entry next=$next:path[$next_args:tt], input=(
         features = (
             anonymous = $anonymous:tt,
@@ -168,7 +196,7 @@ macro_rules! __ctor_parse_impl {
         unsafe = $unsafe:tt,
         item = ($vis:vis static $ident:ident : $ty:ty = $(unsafe)? const $body:block;)
     ) ) => {
-        compile_error!("Trivial const expressions are not supported. Remove the #[ctor] and use a regular `static`.");
+        compile_error!("Static const expressions are not supported. Remove the #[ctor] and use a regular `static`.");
     };
 
     ( @entry next=$next:path[$next_args:tt], input=(
@@ -778,6 +806,21 @@ macro_rules! __ctor_parse_impl {
         body_link_meta = ($($body_link_meta:tt)?),
         meta = ($($meta:tt)*),
         unsafe = ($($unsafe:tt)*),
+        item = ($vis:vis static $ident:ident : &[fn()] = const $body:block;)
+    ) ) => {
+        $($meta)*
+        $vis static $ident: &[fn()] = const {
+            $crate::__ctor_parse_impl!(@ctor $link_args fns=$ident);
+
+            $body
+        };
+    };
+
+    ( @entry next=$next:path[$next_args:tt], input=(
+        link_args = $link_args:tt,
+        body_link_meta = ($($body_link_meta:tt)?),
+        meta = ($($meta:tt)*),
+        unsafe = ($($unsafe:tt)*),
         item = ($vis:vis static $ident:ident : & $lt:lifetime $ty:ty = &$($body:tt)*)
     ) ) => {
         $($meta)*
@@ -886,6 +929,34 @@ macro_rules! __ctor_parse_impl {
             }
 
             $crate::__register_ctor!(priority = $priority, fn = __ctor_private);
+        };
+    };
+
+    ( @ctor (
+        body_link_meta = ($($body_link_meta:tt)?),
+        export_name=(),
+        priority=$priority:tt,
+        used=(#$used_linker_meta:tt),
+     ) fns=$ident:ident ) => {
+        // #[allow(unsafe_code)]
+        // #[cfg_attr(clippy, allow(unknown_lints, unsafe_attr_outside_unsafe))]
+        // #[link_section = $($link_section)*]
+        // #$used_linker_meta
+        // static __CTOR_PRIVATE_REF: unsafe extern "C" [fn() = {
+        const _: () = {
+            const fn __ctor_array() -> [fn(); $ident.len()] {
+                use core::mem::MaybeUninit;
+                let mut array: MaybeUninit<[fn(); $ident.len()]> = MaybeUninit::uninit();
+                let mut array_ptr: *mut fn() = array.as_mut_ptr() as _;
+                let mut i = 0;
+                while i < $ident.len() {
+                    unsafe { array_ptr.add(i).write($ident[i]) };
+                    i += 1;
+                }
+                unsafe { array.assume_init() }
+            }
+
+            $crate::__register_ctor!(priority = $priority, fn = (array __ctor_array));
         };
     };
 

--- a/ctor/src/parse.rs
+++ b/ctor/src/parse.rs
@@ -938,11 +938,6 @@ macro_rules! __ctor_parse_impl {
         priority=$priority:tt,
         used=(#$used_linker_meta:tt),
      ) fns=$ident:ident ) => {
-        // #[allow(unsafe_code)]
-        // #[cfg_attr(clippy, allow(unknown_lints, unsafe_attr_outside_unsafe))]
-        // #[link_section = $($link_section)*]
-        // #$used_linker_meta
-        // static __CTOR_PRIVATE_REF: unsafe extern "C" [fn() = {
         const _: () = {
             const fn __ctor_array() -> [fn(); $ident.len()] {
                 use core::mem::MaybeUninit;

--- a/ctor/src/parse.rs
+++ b/ctor/src/parse.rs
@@ -810,7 +810,41 @@ macro_rules! __ctor_parse_impl {
     ) ) => {
         $($meta)*
         $vis static $ident: &[fn()] = const {
-            $crate::__ctor_parse_impl!(@ctor $link_args fns=$ident);
+            const __EXTERN_C_FNS: [extern "C" fn(); $ident.len()] = {
+                use ::core::mem::MaybeUninit;
+                let mut array: MaybeUninit<[extern "C" fn(); $ident.len()]> = MaybeUninit::uninit();
+                let mut array_ptr: *mut extern "C" fn() = array.as_mut_ptr() as _;
+
+                extern "C" fn bind_array<const N: usize>() {
+                    $ident[N]()
+                }
+
+                unsafe {
+                    let array_ptr = array.as_mut_ptr() as *mut extern "C" fn();
+                    const LEN: usize = $ident.len();
+                    if LEN > 0 { array_ptr.add(0).write(bind_array::<0>); }
+                    if LEN > 1 { array_ptr.add(1).write(bind_array::<1>); }
+                    if LEN > 2 { array_ptr.add(2).write(bind_array::<2>); }
+                    if LEN > 3 { array_ptr.add(3).write(bind_array::<3>); }
+                    if LEN > 4 { array_ptr.add(4).write(bind_array::<4>); }
+                    if LEN > 5 { array_ptr.add(5).write(bind_array::<5>); }
+                    if LEN > 6 { array_ptr.add(6).write(bind_array::<6>); }
+                    if LEN > 7 { array_ptr.add(7).write(bind_array::<7>); }
+                    if LEN > 8 { array_ptr.add(8).write(bind_array::<8>); }
+                    if LEN > 9 { array_ptr.add(9).write(bind_array::<9>); }
+                    if LEN > 10 { array_ptr.add(10).write(bind_array::<10>); }
+                    if LEN > 11 { array_ptr.add(11).write(bind_array::<11>); }
+                    if LEN > 12 { array_ptr.add(12).write(bind_array::<12>); }
+                    if LEN > 13 { array_ptr.add(13).write(bind_array::<13>); }
+                    if LEN > 14 { array_ptr.add(14).write(bind_array::<14>); }
+                    if LEN > 15 { array_ptr.add(15).write(bind_array::<15>); }
+                    if LEN > 16 {
+                        panic!("Unexpected array length, expected <= 16");
+                    }
+                }
+                unsafe { array.assume_init() }
+            };
+            $crate::__ctor_parse_impl!(@ctor $link_args fns=__EXTERN_C_FNS);
 
             $body
         };
@@ -878,6 +912,8 @@ macro_rules! __ctor_parse_impl {
     };
 
     // ctor definitions
+
+    // linux-style, one ctor
     ( @ctor (
         body_link_meta = ($($body_link_meta:tt)?),
         export_name=(),
@@ -907,6 +943,37 @@ macro_rules! __ctor_parse_impl {
         };
     };
 
+    // linux-style, multiple ctor
+    ( @ctor (
+        body_link_meta = ($($body_link_meta:tt)?),
+        export_name=(),
+        link_section=($($link_section:tt)*),
+        used=(#$used_linker_meta:tt),
+     ) fns=$ident:ident ) => {
+        #[allow(unsafe_code)]
+        #[cfg_attr(clippy, allow(unknown_lints, unsafe_attr_outside_unsafe))]
+        #[link_section = $($link_section)*]
+        #$used_linker_meta
+        static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
+            #[allow(unused_unsafe)]
+            $(#[allow(unsafe_code)] #$body_link_meta)?
+            extern "C" fn __ctor_private() {
+                #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+                {
+                    static DISARMED: ::core::sync::atomic::AtomicBool = ::core::sync::atomic::AtomicBool::new(false);
+                    if DISARMED.swap(true, ::core::sync::atomic::Ordering::Relaxed) {
+                        return;
+                    }
+                }
+                for f in $ident {
+                    f();
+                }
+            }
+            __ctor_private
+        };
+    };
+
+    // "collect"-style, one ctor
     ( @ctor (
         body_link_meta = ($($body_link_meta:tt)?),
         export_name=(),
@@ -932,6 +999,7 @@ macro_rules! __ctor_parse_impl {
         };
     };
 
+    // "collect"-style, multiple ctors
     ( @ctor (
         body_link_meta = ($($body_link_meta:tt)?),
         export_name=(),
@@ -939,22 +1007,11 @@ macro_rules! __ctor_parse_impl {
         used=(#$used_linker_meta:tt),
      ) fns=$ident:ident ) => {
         const _: () = {
-            const fn __ctor_array() -> [fn(); $ident.len()] {
-                use core::mem::MaybeUninit;
-                let mut array: MaybeUninit<[fn(); $ident.len()]> = MaybeUninit::uninit();
-                let mut array_ptr: *mut fn() = array.as_mut_ptr() as _;
-                let mut i = 0;
-                while i < $ident.len() {
-                    unsafe { array_ptr.add(i).write($ident[i]) };
-                    i += 1;
-                }
-                unsafe { array.assume_init() }
-            }
-
-            $crate::__register_ctor!(priority = $priority, fn = (array __ctor_array));
+            $crate::__register_ctor!(priority = $priority, fn = (array $ident));
         };
     };
 
+    // AIX-style, one ctor
     ( @ctor (
         body_link_meta = ($($body_link_meta:tt)?),
         export_name=($($link_name:tt)*),
@@ -976,6 +1033,34 @@ macro_rules! __ctor_parse_impl {
                     }
                 }
                 $body
+            }
+        };
+    };
+
+    // AIX-style, multiple ctor
+    ( @ctor (
+        body_link_meta = ($($body_link_meta:tt)?),
+        export_name=($($link_name:tt)*),
+        link_section=$link_section:tt,
+        used=(#$used_linker_meta:tt),
+     ) fns=$ident:ident ) => {
+        const _: () = {
+            #[cfg_attr(clippy, allow(unknown_lints, unsafe_attr_outside_unsafe))]
+            #[allow(unused_unsafe, unsafe_code)]
+            #[no_mangle]
+            #[export_name = $($link_name)*]
+            $(#$body_link_meta)?
+            extern "C" fn __ctor_private() {
+                #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+                {
+                    static DISARMED: ::core::sync::atomic::AtomicBool = ::core::sync::atomic::AtomicBool::new(false);
+                    if DISARMED.swap(true, ::core::sync::atomic::Ordering::Relaxed) {
+                        return;
+                    }
+                }
+                for f in $ident {
+                    f();
+                }
             }
         };
     };

--- a/ctor/tests/errors/ctor_bad_static.stderr
+++ b/ctor/tests/errors/ctor_bad_static.stderr
@@ -22,7 +22,7 @@ error: Trivial const expressions are not supported. Remove the #[ctor] and use a
   |
   = note: this error originates in the macro `$crate::__ctor_parse_impl` which comes from the expansion of the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Trivial const expressions are not supported. Remove the #[ctor] and use a regular `static`.
+error: Static const expressions are not supported. Remove the #[ctor] and use a regular `static`.
   --> tests/errors/ctor_bad_static.rs:12:1
    |
 12 | #[ctor]

--- a/ctor/tests/expand-linux/ctor_static.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_static.expanded.rs
@@ -4,10 +4,10 @@ static STATIC_CTOR: ::ctor::statics::Static<HashMap<u32, &'static str>> = {
     #[allow(unsafe_code)]
     #[link_section = ".text.startup"]
     fn init() -> HashMap<u32, &'static str> {
-        unsafe {
+        return unsafe {
             let m = HashMap::new();
             m
-        }
+        };
     }
     unsafe { ::ctor::statics::Static::<HashMap<u32, &'static str>>::new(init) }
 };

--- a/link-section/examples/example.rs
+++ b/link-section/examples/example.rs
@@ -67,8 +67,15 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
-pub const DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
-    &::core::fmt::from_fn(|f| f.write_str("debuggable_function"));
+pub const DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) = {
+    struct Debuggable;
+    impl ::core::fmt::Debug for Debuggable {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+            f.write_str("debuggable_function")
+        }
+    }
+    &Debuggable
+};
 
 /// Dumps the various sections.
 pub fn main() {

--- a/tests/link_section/basic/src/main.rs
+++ b/tests/link_section/basic/src/main.rs
@@ -67,9 +67,15 @@ pub static DEBUGGABLE_2: &'static (dyn ::core::fmt::Debug + Sync) = &2;
 
 /// A function pointer in the `DEBUGGABLES` section.
 #[in_section(DEBUGGABLES)]
-#[ctor::ctor(unsafe)]
-pub static DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) =
-    &{ ::core::fmt::from_fn(|f| f.write_str("debuggable_function")) };
+pub const DEBUGGABLE_FUNCTION: &'static (dyn ::core::fmt::Debug + Sync) = {
+    struct Debuggable;
+    impl ::core::fmt::Debug for Debuggable {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+            f.write_str("debuggable_function")
+        }
+    }
+    &Debuggable
+};
 
 #[cfg(miri)]
 pub fn main() {


### PR DESCRIPTION
Fixes #434

There are some cases where it might be useful to generate zero to N `ctors` via `const`. While this is technically possible to do via a nested `const fn`, this can be a useful desugaring for ctor re-exports.

In the future we may also be able to fully elide zero-sized slices, but this currently has some issues with the linker emitting single bytes for those and this needs further work. 

```rust
#[ctor]
static CTORS: &[fn()] = const {
  if cfg!(feature="my_feature") {
    [ctor_fn_one, ctor_fn_two].as_slice()
  } else {
    &[]
  }
};

fn ctor_fn_one() {
  // ...
}

fn ctor_fn_two() {
  // ...
}

```
