### PR TITLE
Fix unsafe C library access with default priority value

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -247,7 +247,7 @@ jobs:
             /usr/sbin/pkg_add rust
           fi
           cargo build --examples -p ctor -p dtor -p link-section
-          for example in ctor-basic ctor-example ctor-advanced; do
+          for example in ctor-basic ctor-example ctor-advanced ctor-priority; do
             cargo run -p ctor --example "$example"
           done
           cargo run -p dtor --example dtor-example
@@ -271,7 +271,7 @@ jobs:
           set -xe
           pkg install -y rust
           cargo build --examples -p ctor -p dtor -p link-section
-          for example in ctor-basic ctor-example ctor-advanced; do
+          for example in ctor-basic ctor-example ctor-advanced ctor-priority; do
             cargo run -p ctor --example "$example"
           done
           cargo run -p dtor --example dtor-example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "libc-print",
  "link-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.2", default-features = false }
+ctor = { path = "ctor", version = "1.0.3", default-features = false }
 dtor = { path = "dtor", version = "1.0.1", default-features = false }
 link-section = { path = "link-section", version = "0.15.0", default-features = false }
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-05-07
+
+### Fixed
+
+- A `default` priority value is now supported and is the default. This is
+  equivalent to a priority of 500 on most platforms. The previous `priority`
+  default of 0 was unsafe for C library access on some platforms.
+- The `early` priority value is now equivalent to a priority of 101 on most platforms.
+
 ## [1.0.2] - 2026-05-06
 
 ### Changed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.2"
+version = "1.0.3"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -297,24 +297,31 @@ The idea for `ctor` was originally inspired by the Neon project.
  run last. `N` must be between 0 and 999 inclusive for ordering
  guarantees (`N` >= 1000 ordering is platform-defined).
 
- Priority is specified as an isize, string literal, or the identifiers
- `early` or `late`. The integer value will be clamped to a
- platform-defined range (typically 0-65535), while string priorities are
- passed through unprocessed.
+ Priority is specified as numeric value, string literal, or the
+ identifiers `early`, `default`, or `late`. The integer value will be
+ clamped to a platform-defined range (typically 0-65535), while string
+ priorities are passed through unprocessed.
+
+ Most platforms reserve the numeric values range of 0..100 for their own
+ internal use and it may not be safe to access platform services (`libc`
+ or other) in constructors with those priorities.
 
  Priority is applied as follows:
 
-  - `early` is the default, and is run first (constructors annotated with
-    `early` and those with no priority attribute are run in the same
-    phase).
-  - `N` is run in increasing order, from 0 <= N <= 999.
+  - `N` is run in increasing order, from `0 <= N <= 999`.
+  - `early` is run at a priority level where it is safe to access the C
+    runtime. This is equivalent to a priority of 101 on most platforms.
+  - `default` is the default, and is run after `early`. This is
+    equivalent to a priority of 500.
   - `late` is run last, and will be positioned to run after most
-    constructors, even outside the range 0 <= N <= 999.
+    constructors, even outside the range `0 <= N <= 999`. The equivalent
+    priority is platform-defined.
   - `main` is run, for binary targets.
 
- Ordering outside of `0 <= N <= 999` is platform-defined with respect to
- the list above, however platforms will order constructors within a given
- length range in ascending order (ie: 10000 will run before 20000).
+ Ordering with explicit priority values outside of `0 <= N <= 999` is
+ platform-defined with respect to the list above, however platforms will
+ order constructors within a given priority range in ascending order
+ (i.e.: 10000 will run before 20000).
 
 
 </td></tr>
@@ -421,7 +428,7 @@ link_section = (compile_error! ("Unsupported target for #[ctor]"))
 
  ```rust
 #[cfg(feature = "priority")]
-priority = early
+priority = default
 
  // default
 priority = ()

--- a/ctor/docs/GENERATED.md
+++ b/ctor/docs/GENERATED.md
@@ -82,24 +82,31 @@
  run last. `N` must be between 0 and 999 inclusive for ordering
  guarantees (`N` >= 1000 ordering is platform-defined).
 
- Priority is specified as an isize, string literal, or the identifiers
- `early` or `late`. The integer value will be clamped to a
- platform-defined range (typically 0-65535), while string priorities are
- passed through unprocessed.
+ Priority is specified as numeric value, string literal, or the
+ identifiers `early`, `default`, or `late`. The integer value will be
+ clamped to a platform-defined range (typically 0-65535), while string
+ priorities are passed through unprocessed.
+
+ Most platforms reserve the numeric values range of 0..100 for their own
+ internal use and it may not be safe to access platform services (`libc`
+ or other) in constructors with those priorities.
 
  Priority is applied as follows:
 
-  - `early` is the default, and is run first (constructors annotated with
-    `early` and those with no priority attribute are run in the same
-    phase).
-  - `N` is run in increasing order, from 0 <= N <= 999.
+  - `N` is run in increasing order, from `0 <= N <= 999`.
+  - `early` is run at a priority level where it is safe to access the C
+    runtime. This is equivalent to a priority of 101 on most platforms.
+  - `default` is the default, and is run after `early`. This is
+    equivalent to a priority of 500.
   - `late` is run last, and will be positioned to run after most
-    constructors, even outside the range 0 <= N <= 999.
+    constructors, even outside the range `0 <= N <= 999`. The equivalent
+    priority is platform-defined.
   - `main` is run, for binary targets.
 
- Ordering outside of `0 <= N <= 999` is platform-defined with respect to
- the list above, however platforms will order constructors within a given
- length range in ascending order (ie: 10000 will run before 20000).
+ Ordering with explicit priority values outside of `0 <= N <= 999` is
+ platform-defined with respect to the list above, however platforms will
+ order constructors within a given priority range in ascending order
+ (i.e.: 10000 will run before 20000).
 
 
 </td></tr>
@@ -242,7 +249,7 @@ link_section = (compile_error! ("Unsupported target for #[ctor]"))
  # #[cfg(false)] {
 #[cfg(feature = "priority")]
  # const _: () = { let
-priority = early
+priority = default
  # ; };
 
  // default

--- a/ctor/examples/ctor-priority.rs
+++ b/ctor/examples/ctor-priority.rs
@@ -1,0 +1,105 @@
+#![allow(unexpected_cfgs)]
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+//! Edition 2024 test.
+
+use ctor::ctor;
+use libc_print::*;
+
+#[ctor(unsafe, priority = 1)]
+unsafe fn priority_1() {
+    libc_println!("1");
+}
+
+#[ctor(unsafe, priority = 2)]
+unsafe fn priority_b() {
+    libc_println!("2");
+}
+
+#[ctor(unsafe, priority = 3)]
+unsafe fn priority_three() {
+    libc_println!("3");
+}
+
+#[ctor(unsafe, priority = 7)]
+unsafe fn z_priority_7() {
+    libc_println!("7");
+}
+
+#[ctor(unsafe, priority = 4)]
+unsafe fn priority_four() {
+    libc_println!("4");
+}
+
+#[ctor(unsafe, priority = late, anonymous)]
+unsafe fn priority_late() {
+    libc_println!("late");
+}
+
+#[ctor(unsafe, priority = 10)]
+unsafe fn priority_10() {
+    libc_println!("10");
+}
+
+#[ctor(unsafe, priority = 5)]
+unsafe fn priority_five() {
+    libc_println!("5");
+}
+
+#[ctor(unsafe, priority = early, anonymous)]
+unsafe fn priority_early() {
+    libc_println!("early");
+}
+
+#[ctor(unsafe, priority = 0)]
+unsafe fn priority_zero() {
+    libc_println!("0");
+}
+
+#[ctor(unsafe, priority = late, anonymous)]
+unsafe fn priority_late() {
+    libc_println!("late");
+}
+
+#[ctor(unsafe, priority = 6)]
+unsafe fn a_priority_6() {
+    libc_println!("6");
+}
+
+#[ctor(unsafe, anonymous)]
+unsafe fn priority_none() {
+    libc_println!("no priority");
+}
+
+#[ctor(unsafe, priority = default, anonymous)]
+unsafe fn priority_default() {
+    libc_println!("default");
+}
+
+#[ctor(unsafe, priority = 8)]
+unsafe fn priority_eight() {
+    libc_println!("8");
+}
+
+#[ctor(unsafe, priority = 9)]
+unsafe fn priority_nine() {
+    libc_println!("9");
+}
+
+#[ctor(unsafe, anonymous)]
+unsafe fn priority_none() {
+    libc_println!("no priority");
+}
+
+#[ctor(unsafe, priority = default, anonymous)]
+unsafe fn priority_default() {
+    libc_println!("default");
+}
+
+#[ctor(unsafe, priority = early, anonymous)]
+unsafe fn priority_early() {
+    libc_println!("early");
+}
+
+fn main() {
+    libc_println!("main");
+}

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -513,30 +513,37 @@ __declare_features!(
     /// run last. `N` must be between 0 and 999 inclusive for ordering
     /// guarantees (`N` >= 1000 ordering is platform-defined).
     ///
-    /// Priority is specified as an isize, string literal, or the identifiers
-    /// `early` or `late`. The integer value will be clamped to a
-    /// platform-defined range (typically 0-65535), while string priorities are
-    /// passed through unprocessed.
+    /// Priority is specified as numeric value, string literal, or the
+    /// identifiers `early`, `default`, or `late`. The integer value will be
+    /// clamped to a platform-defined range (typically 0-65535), while string
+    /// priorities are passed through unprocessed.
+    ///
+    /// Most platforms reserve the numeric values range of 0..100 for their own
+    /// internal use and it may not be safe to access platform services (`libc`
+    /// or other) in constructors with those priorities.
     ///
     /// Priority is applied as follows:
     ///
-    ///  - `early` is the default, and is run first (constructors annotated with
-    ///    `early` and those with no priority attribute are run in the same
-    ///    phase).
-    ///  - `N` is run in increasing order, from 0 <= N <= 999.
+    ///  - `N` is run in increasing order, from `0 <= N <= 999`.
+    ///  - `early` is run at a priority level where it is safe to access the C
+    ///    runtime. This is equivalent to a priority of 101 on most platforms.
+    ///  - `default` is the default, and is run after `early`. This is
+    ///    equivalent to a priority of 500.
     ///  - `late` is run last, and will be positioned to run after most
-    ///    constructors, even outside the range 0 <= N <= 999.
+    ///    constructors, even outside the range `0 <= N <= 999`. The equivalent
+    ///    priority is platform-defined.
     ///  - `main` is run, for binary targets.
     ///
-    /// Ordering outside of `0 <= N <= 999` is platform-defined with respect to
-    /// the list above, however platforms will order constructors within a given
-    /// length range in ascending order (ie: 10000 will run before 20000).
+    /// Ordering with explicit priority values outside of `0 <= N <= 999` is
+    /// platform-defined with respect to the list above, however platforms will
+    /// order constructors within a given priority range in ascending order
+    /// (i.e.: 10000 will run before 20000).
     priority {
         attr: [(priority = $priority_value:tt) => ($priority_value)];
         example: "priority = N | early | late";
-        validate: [($priority:literal), (early), (late)];
+        validate: [($priority:literal), (early), (late), (default)];
         default {
-            (feature = "priority") => early,
+            (feature = "priority") => default,
             _ => ()
         }
     };

--- a/ctor/src/parse.rs
+++ b/ctor/src/parse.rs
@@ -1098,7 +1098,7 @@ macro_rules! __map_priority {
         $next!($next_args, naked);
     };
 
-    // Priority unspecified, link options not, priority enabled => early (0)
+    // Priority unspecified, link options not, priority enabled => default (500)
     ( @entry next=$next:path[$next_args:tt], input=(
         export_name_prefix = ($enp:tt: default),
         link_section = ($ls:tt: default),
@@ -1106,7 +1106,7 @@ macro_rules! __map_priority {
         priority = ($priority:tt: default),
         priority_enabled = (priority_enabled: $pe_spec:ident),
     ) ) => {
-        $next!($next_args, 0);
+        $next!($next_args, 500);
     };
 
     // Priority specified (or default) = early, link options not, priority enabled
@@ -1117,7 +1117,18 @@ macro_rules! __map_priority {
         priority = (early: $p_spec:ident),
         priority_enabled = $pe:tt,
     ) ) => {
-        $next!($next_args, 0);
+        $next!($next_args, 101);
+    };
+
+    // Priority specified (or default) = default, link options not, priority enabled
+    ( @entry next=$next:path[$next_args:tt], input=(
+        export_name_prefix = ($enp:tt: default),
+        link_section = ($ls:tt: default),
+        naked = ($naked:tt: default),
+        priority = (default: $p_spec:ident),
+        priority_enabled = $pe:tt,
+    ) ) => {
+        $next!($next_args, 500);
     };
 
     // Priority specified = late, link options not, priority enabled

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -19,7 +19,7 @@ unsafe fn foo() {
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
             pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-                priority: 0,
+                priority: 500,
                 ctor: __ctor_private,
             };
         };

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -20,7 +20,7 @@ const _: () = {
                 #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 #[used]
                 pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-                    priority: 0,
+                    priority: 500,
                     ctor: __ctor_private,
                 };
             };
@@ -49,7 +49,7 @@ const _: () = {
                 #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 #[used]
                 pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-                    priority: 0,
+                    priority: 500,
                     ctor: __ctor_private,
                 };
             };

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -21,7 +21,7 @@ unsafe fn foo() {
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
             pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-                priority: 0,
+                priority: 500,
                 ctor: __ctor_private,
             };
         };

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -1,13 +1,32 @@
 use ctor::ctor;
 #[allow(dead_code)]
-fn foo() {
+fn early() {
     #[allow(unsafe_code)]
     #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
-    fn __ctor_private_inner() {
-        {
-            ::std::io::_print(format_args!("foo\n"));
+    fn __ctor_private_inner() {}
+    const _: () = {
+        #[allow(unsafe_code, unused_unsafe)]
+        #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+        extern "C" fn __ctor_private() {
+            { { __ctor_private_inner() } }
+        }
+        pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
+                priority: 101,
+                ctor: __ctor_private,
+            };
         };
-    }
+    };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
+fn priority1() {
+    #[allow(unsafe_code)]
+    #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+    fn __ctor_private_inner() {}
     const _: () = {
         #[allow(unsafe_code, unused_unsafe)]
         #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
@@ -22,6 +41,119 @@ fn foo() {
                 priority: 1,
                 ctor: __ctor_private,
             };
+        };
+    };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
+fn priority900() {
+    #[allow(unsafe_code)]
+    #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+    fn __ctor_private_inner() {}
+    const _: () = {
+        #[allow(unsafe_code, unused_unsafe)]
+        #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+        extern "C" fn __ctor_private() {
+            { { __ctor_private_inner() } }
+        }
+        pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
+                priority: 900,
+                ctor: __ctor_private,
+            };
+        };
+    };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
+fn late() {
+    #[allow(unsafe_code)]
+    #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+    fn __ctor_private_inner() {}
+    const _: () = {
+        #[allow(unsafe_code, unused_unsafe)]
+        #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+        extern "C" fn __ctor_private() {
+            { { __ctor_private_inner() } }
+        }
+        pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
+                priority: (::ctor::collect::LATE),
+                ctor: __ctor_private,
+            };
+        };
+    };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
+fn priority_default() {
+    #[allow(unsafe_code)]
+    #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+    fn __ctor_private_inner() {}
+    const _: () = {
+        #[allow(unsafe_code, unused_unsafe)]
+        #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+        extern "C" fn __ctor_private() {
+            { { __ctor_private_inner() } }
+        }
+        pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
+                priority: 500,
+                ctor: __ctor_private,
+            };
+        };
+    };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
+fn priority_unspecified() {
+    #[allow(unsafe_code)]
+    #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+    fn __ctor_private_inner() {}
+    const _: () = {
+        #[allow(unsafe_code, unused_unsafe)]
+        #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+        extern "C" fn __ctor_private() {
+            { { __ctor_private_inner() } }
+        }
+        pub const _: () = {
+            type __InSecStoredTy = ::ctor::collect::Constructor;
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
+            #[used]
+            pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
+                priority: 500,
+                ctor: __ctor_private,
+            };
+        };
+    };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
+fn naked() {
+    #[allow(unsafe_code)]
+    #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+    fn __ctor_private_inner() {}
+    const _: () = {
+        #[allow(unsafe_code)]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        #[used]
+        static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
+            #[allow(unused_unsafe)]
+            #[allow(unsafe_code)]
+            #[link_section = "__TEXT,__text_startup,regular,pure_instructions"]
+            extern "C" fn __ctor_private() {
+                { { __ctor_private_inner() } }
+            }
+            __ctor_private
         };
     };
     { __ctor_private_inner() }

--- a/ctor/tests/expand-darwin/ctor_priority.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.rs
@@ -1,6 +1,22 @@
 use ctor::ctor;
 
+#[ctor(unsafe, priority = early)]
+fn early() {}
+
 #[ctor(unsafe, priority = 1)]
-fn foo() {
-    println!("foo");
-}
+fn priority1() {}
+
+#[ctor(unsafe, priority = 900)]
+fn priority900() {}
+
+#[ctor(unsafe, priority = late)]
+fn late() {}
+
+#[ctor(unsafe, priority = default)]
+fn priority_default() {}
+
+#[ctor(unsafe)]
+fn priority_unspecified() {}
+
+#[ctor(unsafe, naked)]
+fn naked() {}

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -22,7 +22,7 @@ const _: () = {
         #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
         #[used]
         pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-            priority: 0,
+            priority: 500,
             ctor: __ctor_private,
         };
     };

--- a/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
@@ -22,7 +22,7 @@ const _: () = {
         #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
         #[used]
         pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-            priority: 0,
+            priority: 500,
             ctor: __ctor_private,
         };
     };

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -19,7 +19,7 @@ unsafe fn foo() {
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
             pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-                priority: 0,
+                priority: 500,
                 ctor: __ctor_private,
             };
         };

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -19,7 +19,7 @@ fn foo() {
             #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
             pub static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = ::ctor::collect::Constructor {
-                priority: 0,
+                priority: 500,
                 ctor: __ctor_private,
             };
         };

--- a/ctor/tests/expand-linux/ctor.expanded.rs
+++ b/ctor/tests/expand-linux/ctor.expanded.rs
@@ -1,9 +1,9 @@
 use ctor::ctor;
 #[allow(dead_code)]
-unsafe fn foo() {
+fn foo() {
     #[allow(unsafe_code)]
     #[link_section = ".text.startup"]
-    unsafe fn __ctor_private_inner() {
+    fn __ctor_private_inner() {
         {
             ::std::io::_print(format_args!("foo\n"));
         };
@@ -17,10 +17,10 @@ unsafe fn foo() {
             #[allow(unsafe_code)]
             #[link_section = ".text.startup"]
             extern "C" fn __ctor_private() {
-                { unsafe { __ctor_private_inner() } }
+                { { __ctor_private_inner() } }
             }
             __ctor_private
         };
     };
-    unsafe { __ctor_private_inner() }
+    { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor.expanded.rs
+++ b/ctor/tests/expand-linux/ctor.expanded.rs
@@ -1,6 +1,26 @@
 use ctor::ctor;
+#[allow(dead_code)]
 unsafe fn foo() {
-    {
-        ::std::io::_print(format_args!("foo\n"));
+    #[allow(unsafe_code)]
+    #[link_section = ".text.startup"]
+    unsafe fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
+    const _: () = {
+        #[allow(unsafe_code)]
+        #[link_section = ".init_array.500"]
+        #[used]
+        static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
+            #[allow(unused_unsafe)]
+            #[allow(unsafe_code)]
+            #[link_section = ".text.startup"]
+            extern "C" fn __ctor_private() {
+                { unsafe { __ctor_private_inner() } }
+            }
+            __ctor_private
+        };
     };
+    unsafe { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor.rs
+++ b/ctor/tests/expand-linux/ctor.rs
@@ -1,5 +1,6 @@
 use ctor::ctor;
 
-unsafe fn foo() {
+#[ctor(unsafe)]
+fn foo() {
     println!("foo");
 }

--- a/ctor/tests/expand-linux/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_anon.expanded.rs
@@ -11,7 +11,7 @@ const _: () = {
         }
         const _: () = {
             #[allow(unsafe_code)]
-            #[link_section = ".init_array.000"]
+            #[link_section = ".init_array.500"]
             #[used]
             static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
                 #[allow(unused_unsafe)]
@@ -38,7 +38,7 @@ const _: () = {
         }
         const _: () = {
             #[allow(unsafe_code)]
-            #[link_section = ".init_array.000"]
+            #[link_section = ".init_array.500"]
             #[used]
             static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
                 #[allow(unused_unsafe)]

--- a/ctor/tests/expand-linux/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_doc.expanded.rs
@@ -12,7 +12,7 @@ unsafe fn foo() {
     }
     const _: () = {
         #[allow(unsafe_code)]
-        #[link_section = ".init_array.000"]
+        #[link_section = ".init_array.500"]
         #[used]
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]

--- a/ctor/tests/expand-linux/ctor_static.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_static.expanded.rs
@@ -13,7 +13,7 @@ static STATIC_CTOR: ::ctor::statics::Static<HashMap<u32, &'static str>> = {
 };
 const _: () = {
     #[allow(unsafe_code)]
-    #[link_section = ".init_array.000"]
+    #[link_section = ".init_array.500"]
     #[used]
     static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
         #[allow(unused_unsafe)]

--- a/ctor/tests/expand-linux/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_unsafe.expanded.rs
@@ -1,6 +1,26 @@
 use ctor::ctor;
+#[allow(dead_code)]
 unsafe fn foo() {
-    {
-        ::std::io::_print(format_args!("foo\n"));
+    #[allow(unsafe_code)]
+    #[link_section = ".text.startup"]
+    unsafe fn __ctor_private_inner() {
+        {
+            ::std::io::_print(format_args!("foo\n"));
+        };
+    }
+    const _: () = {
+        #[allow(unsafe_code)]
+        #[link_section = ".init_array.500"]
+        #[used]
+        static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
+            #[allow(unused_unsafe)]
+            #[allow(unsafe_code)]
+            #[link_section = ".text.startup"]
+            extern "C" fn __ctor_private() {
+                { unsafe { __ctor_private_inner() } }
+            }
+            __ctor_private
+        };
     };
+    unsafe { __ctor_private_inner() }
 }

--- a/ctor/tests/expand-linux/ctor_unsafe.rs
+++ b/ctor/tests/expand-linux/ctor_unsafe.rs
@@ -1,5 +1,6 @@
 use ctor::ctor;
 
+#[ctor]
 unsafe fn foo() {
     println!("foo");
 }

--- a/ctor/tests/expand-linux/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-linux/ctor_used_linker_attr.expanded.rs
@@ -10,7 +10,7 @@ fn foo() {
     }
     const _: () = {
         #[allow(unsafe_code)]
-        #[link_section = ".init_array.000"]
+        #[link_section = ".init_array.500"]
         #[used(linker)]
         static __CTOR_PRIVATE_REF: unsafe extern "C" fn() = {
             #[allow(unused_unsafe)]

--- a/ctor/tests/target-test/ctor_priority.rs
+++ b/ctor/tests/target-test/ctor_priority.rs
@@ -21,6 +21,16 @@ ctor!(
 );
 
 ctor!(
+    #[ctor(unsafe, priority = default)]
+    fn priority_default() {}
+);
+
+ctor!(
+    #[ctor(unsafe)]
+    fn priority_unspecified() {}
+);
+
+ctor!(
     #[ctor(unsafe, naked)]
     fn naked() {}
 );

--- a/ctor/tests/target-test/ctor_priority/powerpc64-ibm-aix.rs
+++ b/ctor/tests/target-test/ctor_priority/powerpc64-ibm-aix.rs
@@ -4,6 +4,8 @@ use ctor::declarative::ctor;
 
 
 
+
+
 #[allow(dead_code)]
 fn early() {
     fn __ctor_private_inner() {}
@@ -57,6 +59,32 @@ fn late() {
     { __ctor_private_inner() }
 }
 #[allow(dead_code)]
+fn priority_default() {
+    fn __ctor_private_inner() {}
+    const _: () =
+        {
+            #[allow(unused_unsafe, unsafe_code)]
+            #[no_mangle]
+            #[export_name =
+            "__sinit80000500_expand_probe_expand_probe_priority_default_L25C1"]
+            extern "C" fn __ctor_private() { { { __ctor_private_inner() } } }
+        };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
+fn priority_unspecified() {
+    fn __ctor_private_inner() {}
+    const _: () =
+        {
+            #[allow(unused_unsafe, unsafe_code)]
+            #[no_mangle]
+            #[export_name =
+            "__sinit80000000_expand_probe_expand_probe_priority_unspecified_L30C1"]
+            extern "C" fn __ctor_private() { { { __ctor_private_inner() } } }
+        };
+    { __ctor_private_inner() }
+}
+#[allow(dead_code)]
 fn naked() {
     fn __ctor_private_inner() {}
     const _: () =
@@ -64,7 +92,7 @@ fn naked() {
             #[allow(unused_unsafe, unsafe_code)]
             #[no_mangle]
             #[export_name =
-            "__sinit80000000_expand_probe_expand_probe_naked_L25C1"]
+            "__sinit80000000_expand_probe_expand_probe_naked_L35C1"]
             extern "C" fn __ctor_private() { { { __ctor_private_inner() } } }
         };
     { __ctor_private_inner() }

--- a/ctor/tests/target-test/ctor_priority/powerpc64-ibm-aix.rs
+++ b/ctor/tests/target-test/ctor_priority/powerpc64-ibm-aix.rs
@@ -12,7 +12,7 @@ fn early() {
             #[allow(unused_unsafe, unsafe_code)]
             #[no_mangle]
             #[export_name =
-            "__sinit80000000_expand_probe_expand_probe_early_L5C1"]
+            "__sinit80000101_expand_probe_expand_probe_early_L5C1"]
             extern "C" fn __ctor_private() { { { __ctor_private_inner() } } }
         };
     { __ctor_private_inner() }

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - Unreleased
+## [1.0.1] - 2026-05-07
 
 ### Changed
 

--- a/tests/ctor/mod.rs
+++ b/tests/ctor/mod.rs
@@ -120,13 +120,7 @@ defer {
 $ cargo build --quiet
 *
 $ cargo run --quiet
-unordered {
-    ! no priority
-    ! no priority
-    ! early
-    ! early
-    ! 0
-}
+! 0
 ! 1
 ! 2
 ! 3
@@ -137,6 +131,16 @@ unordered {
 ! 8
 ! 9
 ! 10
+unordered {
+    ! early
+    ! early
+}
+unordered {
+    ! no priority
+    ! no priority
+    ! default
+    ! default
+}
 ! late
 ! late
 ! main

--- a/tests/ctor/priority/src/main.rs
+++ b/tests/ctor/priority/src/main.rs
@@ -70,6 +70,11 @@ unsafe fn priority_none() {
     libc_println!("no priority");
 }
 
+#[ctor(unsafe, priority = default, anonymous)]
+unsafe fn priority_default() {
+    libc_println!("default");
+}
+
 #[ctor(unsafe, priority = 8)]
 unsafe fn priority_eight() {
     libc_println!("8");
@@ -83,6 +88,11 @@ unsafe fn priority_nine() {
 #[ctor(unsafe, anonymous)]
 unsafe fn priority_none() {
     libc_println!("no priority");
+}
+
+#[ctor(unsafe, priority = default, anonymous)]
+unsafe fn priority_default() {
+    libc_println!("default");
 }
 
 #[ctor(unsafe, priority = early, anonymous)]


### PR DESCRIPTION
Most C library implementations reserve priority 0 <= N <= 100 for their own internal purposes and it is generally recommended for priorities to start at 101 for safe C library access.

There is a new `default` priority value for `ctor` that is set to `500` which is safe for C library access. The `early` priority value is now the earliest safe C library access priority, which is 101. The `late` priority is unchanged.

Priority values of 0 <= N <= 100 are still legal to specify, but it is not recommended to perform any operations that may touch the platform C runtime before `early` runs (pure, in-memory setup is considered safe, it is unspecified whether it is safe to use the allocator in these pre-early priorities, but no platform appears to break when doing so).
