### PR TITLE
Add uefi support (`.init_array`)

### DIFF
--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for win7, uwp and other windows targets
+- Support for UEFI targets (`.init_array` matching gnu-efi)
+
+### Changed
+
+- `target_vendor = "pc"` is now `target_os = "windows"`. This should be a
+strictly increasing set of support for windows targets.
 
 ## [1.0.3] - 2026-05-07
 

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -43,14 +43,14 @@ Contributions to support other platforms or improve testing are welcome.
 
 | OS           | Supported | CI Tested |
 | ------------ | --------- | --------- |
-| Linux        | ✅        | ✅        |
-| macOS        | ✅        | ✅        |
-| Windows      | ✅        | ✅        |
-| WASM         | ✅        | ✅        |
+| Linux        | ✅        | 🏅        |
+| macOS        | ✅        | 🏅        |
+| Windows      | ✅        | 🏅        |
+| WASM 🕸️      | ✅        | 🏅        |
 | FreeBSD      | ✅        | 💨        |
-| NetBSD       | ✅        | 💨         |
-| OpenBSD      | ✅        | 💨         |
-| DragonFlyBSD | ✅        | 💨         |
+| NetBSD       | ✅        | 💨        |
+| OpenBSD      | ✅        | 💨        |
+| DragonFlyBSD | ✅        | 💨        |
 | Illumos      | ✅        | -         |
 | Android      | ✅        | -         |
 | iOS          | ✅        | -         |
@@ -59,11 +59,12 @@ Contributions to support other platforms or improve testing are welcome.
 | VxWorks      | ✅        | -         |
 | Xtensa       | ✅        | -         |
 | NTO          | ✅        | -         |
+| UEFI         | ⚠️        | -         |
 
- - ✅ Full CI (miri, address sanitizer, etc.)
- - 💨 Smoke tests (varying levels)
-
-🕸️ = WASM `wasm-unknown-unknown`, `wasm-wasip1`, `wasm-wasip2` are supported.
+- 🏅 Full CI (miri, address sanitizer, etc.)
+- 💨 Smoke tests (varying levels)
+- ⚠️ Needs more feedback
+- 🕸️ WASM `wasm-unknown-unknown`, `wasm-wasip1`, `wasm-wasip2` are supported.
 
 - `wasm-unknown-unknown` requires host environment support for `atexit` if used
   with `dtor`.
@@ -416,6 +417,9 @@ link_section = ".CRT$XCU"
 
 #[cfg(all(target_os = "windows", not(any(target_env = "gnu", target_env = "msvc"))))]
 link_section = ".ctors"
+
+#[cfg(target_os = "uefi")]
+link_section = ".init_array"
 
 #[cfg(all(target_os = "aix"))]
 link_section = ()

--- a/ctor/docs/GENERATED.md
+++ b/ctor/docs/GENERATED.md
@@ -233,6 +233,11 @@ link_section = ".CRT$XCU"
 link_section = ".ctors"
  # ; };
 
+#[cfg(target_os = "uefi")]
+ # const _: () = { let
+link_section = ".init_array"
+ # ; };
+
 #[cfg(all(target_os = "aix"))]
  # const _: () = { let
 link_section = ()

--- a/ctor/docs/PREAMBLE.md
+++ b/ctor/docs/PREAMBLE.md
@@ -32,14 +32,14 @@ Contributions to support other platforms or improve testing are welcome.
 
 | OS           | Supported | CI Tested |
 | ------------ | --------- | --------- |
-| Linux        | ✅        | ✅        |
-| macOS        | ✅        | ✅        |
-| Windows      | ✅        | ✅        |
-| WASM         | ✅        | ✅        |
+| Linux        | ✅        | 🏅        |
+| macOS        | ✅        | 🏅        |
+| Windows      | ✅        | 🏅        |
+| WASM 🕸️      | ✅        | 🏅        |
 | FreeBSD      | ✅        | 💨        |
-| NetBSD       | ✅        | 💨         |
-| OpenBSD      | ✅        | 💨         |
-| DragonFlyBSD | ✅        | 💨         |
+| NetBSD       | ✅        | 💨        |
+| OpenBSD      | ✅        | 💨        |
+| DragonFlyBSD | ✅        | 💨        |
 | Illumos      | ✅        | -         |
 | Android      | ✅        | -         |
 | iOS          | ✅        | -         |
@@ -48,11 +48,12 @@ Contributions to support other platforms or improve testing are welcome.
 | VxWorks      | ✅        | -         |
 | Xtensa       | ✅        | -         |
 | NTO          | ✅        | -         |
+| UEFI         | ⚠️        | -         |
 
- - ✅ Full CI (miri, address sanitizer, etc.)
- - 💨 Smoke tests (varying levels)
-
-🕸️ = WASM `wasm-unknown-unknown`, `wasm-wasip1`, `wasm-wasip2` are supported.
+- 🏅 Full CI (miri, address sanitizer, etc.)
+- 💨 Smoke tests (varying levels)
+- ⚠️ Needs more feedback
+- 🕸️ WASM `wasm-unknown-unknown`, `wasm-wasip1`, `wasm-wasip2` are supported.
 
 - `wasm-unknown-unknown` requires host environment support for `atexit` if used
   with `dtor`.

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -465,6 +465,9 @@ __declare_features!(
     link_section {
         attr: [(link_section = $section:literal) => ($section)];
         example: "link_section = \".ctors\"";
+        // Historical note: GCC 4.7 stopped providing .ctors/.dtors compatible
+        // crt files. Modern compilers, with the exception of Apple, MSVC, and
+        // AIX, will use `.init_array`.
         default {
             (target_vendor = "apple") => "__DATA,__mod_init_func,mod_init_funcs",
             // Most LLVM/GCC targets can use .init_array
@@ -487,8 +490,12 @@ __declare_features!(
             (target_arch = "xtensa") => ".ctors",
             // Windows targets: .CRT$XCU
             (all(target_os = "windows", any(target_env = "gnu", target_env = "msvc"))) => ".CRT$XCU",
-            // ... except GNU
+            // ... except mingw32 (https://llvm.googlesource.com/clang/+/1a209b667f83588866326a0384fa943ea2287b6c)
             (all(target_os = "windows", not(any(target_env = "gnu", target_env = "msvc")))) => ".ctors",
+            // Research suggests that MSVC will use .CRT$XCU for UEFI targets, but won't actually
+            // run them. The gnu-efi project _does_ at least document .init_array support:
+            // https://github.com/vathpela/gnu-efi/blob/master/gnuefi/elf_x86_64_efi.lds
+            (target_os = "uefi") => ".init_array",
             (all(target_os = "aix")) => (), // AIX uses export_name_prefix
             _ => (compile_error!("Unsupported target for #[ctor]"))
         }


### PR DESCRIPTION
Based on the gnu-efi linker script, this is likely the right answer. Regardless, this will probably require users to manually run ctors themselves.