### PR TITLE
Fall back to .init_array on unsupported platforms

### DIFF
--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for win7, uwp and other windows targets
 - Support for UEFI targets (`.init_array` matching gnu-efi)
+- Fallback to `.init_array` for unsupported targets
 
 ### Changed
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for win7, uwp and other windows targets
 - Support for UEFI targets (`.init_array` matching gnu-efi)
-- Fallback to `.init_array` for unsupported targets
+- Fallback to `.init_array` for unsupported targets (with a warning)
 
 ### Changed
 

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -421,11 +421,11 @@ link_section = ".ctors"
 #[cfg(target_os = "uefi")]
 link_section = ".init_array"
 
-#[cfg(all(target_os = "aix"))]
+#[cfg(target_os = "aix")]
 link_section = ()
 
  // default
-link_section = (compile_error! ("Unsupported target for #[ctor]"))
+link_section = ".init_array"
  ```
 
 ## `priority`

--- a/ctor/docs/GENERATED.md
+++ b/ctor/docs/GENERATED.md
@@ -238,13 +238,13 @@ link_section = ".ctors"
 link_section = ".init_array"
  # ; };
 
-#[cfg(all(target_os = "aix"))]
+#[cfg(target_os = "aix")]
  # const _: () = { let
 link_section = ()
  # ; };
 
  // default
-link_section = (compile_error! ("Unsupported target for #[ctor]"))
+link_section = ".init_array"
  # }
  ```
 

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -499,6 +499,9 @@ __declare_features!(
             (target_os = "aix") => (), // AIX uses export_name_prefix
             // Fall back to .init_array which is effectively the gold standard
             // for LLVM/GCC targets moving forward
+            #[warn("Falling back to .init_array for unsupported target. If this \
+            works for you, please file an issue to add support for your target \
+            at https://github.com/mmastrac/linktime/issues")]
             _ => ".init_array",
         }
     };

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -496,8 +496,10 @@ __declare_features!(
             // run them. The gnu-efi project _does_ at least document .init_array support:
             // https://github.com/vathpela/gnu-efi/blob/master/gnuefi/elf_x86_64_efi.lds
             (target_os = "uefi") => ".init_array",
-            (all(target_os = "aix")) => (), // AIX uses export_name_prefix
-            _ => (compile_error!("Unsupported target for #[ctor]"))
+            (target_os = "aix") => (), // AIX uses export_name_prefix
+            // Fall back to .init_array which is effectively the gold standard
+            // for LLVM/GCC targets moving forward
+            _ => ".init_array",
         }
     };
     /// Use the least-possibly mangled version of the linker invocation for this

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - Unreleased
+
+### Added
+
+- Support for UEFI targets (`.fini_array` matching gnu-efi)
+- Fallback to `.fini_array` for unsupported targets
+
+### Changed
+
+- `target_vendor = "pc"` is now `target_os = "windows"`. This should be a
+  strictly increasing set of support for windows targets.
+
 ## [1.0.1] - 2026-05-07
 
 ### Changed

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for UEFI targets (`.fini_array` matching gnu-efi)
-- Fallback to `.fini_array` for unsupported targets
+- Fallback to `.fini_array` for unsupported targets (with a warning)
 
 ### Changed
 

--- a/dtor/README.md
+++ b/dtor/README.md
@@ -284,11 +284,14 @@ ctor_link_section = ".CRT$XCU"
 #[cfg(all(target_os = "windows", not(any(target_env = "gnu", target_env = "msvc"))))]
 ctor_link_section = ".ctors"
 
-#[cfg(all(target_os = "aix"))]
+#[cfg(target_os = "uefi")]
+ctor_link_section = ".init_array"
+
+#[cfg(target_os = "aix")]
 ctor_link_section = ()
 
  // default
-ctor_link_section = (compile_error! ("Unsupported target for #[ctor]"))
+ctor_link_section = ".init_array"
  ```
 
 ## `default_term_method`
@@ -345,11 +348,14 @@ link_section = ".CRT$XPU"
 #[cfg(all(target_os = "windows", not(any(target_env = "gnu", target_env = "msvc"))))]
 link_section = ".dtors"
 
-#[cfg(all(target_os = "aix"))]
+#[cfg(target_os = "uefi")]
+link_section = ".fini_array"
+
+#[cfg(target_os = "aix")]
 link_section = ()
 
  // default
-link_section = (compile_error! ("Unsupported target for #[dtor]"))
+link_section = ".fini_array"
  ```
 
 ## `method`

--- a/dtor/docs/GENERATED.md
+++ b/dtor/docs/GENERATED.md
@@ -168,13 +168,18 @@ ctor_link_section = ".CRT$XCU"
 ctor_link_section = ".ctors"
  # ; };
 
-#[cfg(all(target_os = "aix"))]
+#[cfg(target_os = "uefi")]
+ # const _: () = { let
+ctor_link_section = ".init_array"
+ # ; };
+
+#[cfg(target_os = "aix")]
  # const _: () = { let
 ctor_link_section = ()
  # ; };
 
  // default
-ctor_link_section = (compile_error! ("Unsupported target for #[ctor]"))
+ctor_link_section = ".init_array"
  # }
  ```
 
@@ -257,13 +262,18 @@ link_section = ".CRT$XPU"
 link_section = ".dtors"
  # ; };
 
-#[cfg(all(target_os = "aix"))]
+#[cfg(target_os = "uefi")]
+ # const _: () = { let
+link_section = ".fini_array"
+ # ; };
+
+#[cfg(target_os = "aix")]
  # const _: () = { let
 link_section = ()
  # ; };
 
  // default
-link_section = (compile_error! ("Unsupported target for #[dtor]"))
+link_section = ".fini_array"
  # }
  ```
 

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -113,10 +113,12 @@ __declare_features!(
     ctor_link_section {
         attr: [(ctor(link_section = $ctor_link_section_name:literal)) => ($ctor_link_section_name)];
         example: "ctor(link_section = \".ctors\")";
+        // Historical note: GCC 4.7 stopped providing .ctors/.dtors compatible
+        // crt files. Modern compilers, with the exception of Apple, MSVC, and
+        // AIX, will use `.init_array`.
         default {
-            // This is no longer supported by Apple
             (target_vendor = "apple") => "__DATA,__mod_init_func,mod_init_funcs",
-            // Most LLVM/GCC targets can use .fini_array
+            // Most LLVM/GCC targets can use .init_array
             (any(
                 target_os = "linux",
                 target_os = "android",
@@ -132,14 +134,20 @@ __declare_features!(
             )) => ".init_array",
             // No OS
             (target_os = "none") => ".init_array",
-            // xtensa targets: .dtors
+            // xtensa targets: .ctors
             (target_arch = "xtensa") => ".ctors",
             // Windows targets: .CRT$XCU
             (all(target_os = "windows", any(target_env = "gnu", target_env = "msvc"))) => ".CRT$XCU",
-            // ... except GNU
+            // ... except mingw32 (https://llvm.googlesource.com/clang/+/1a209b667f83588866326a0384fa943ea2287b6c)
             (all(target_os = "windows", not(any(target_env = "gnu", target_env = "msvc")))) => ".ctors",
-            (all(target_os = "aix")) => (), // AIX uses export_name_prefix
-            _ => (compile_error!("Unsupported target for #[ctor]"))
+            // Research suggests that MSVC will use .CRT$XCU for UEFI targets, but won't actually
+            // run them. The gnu-efi project _does_ at least document .init_array support:
+            // https://github.com/vathpela/gnu-efi/blob/master/gnuefi/elf_x86_64_efi.lds
+            (target_os = "uefi") => ".init_array",
+            (target_os = "aix") => (), // AIX uses export_name_prefix
+            // Fall back to .init_array which is effectively the gold standard
+            // for LLVM/GCC targets moving forward
+            _ => ".init_array",
         }
     };
     /// The default method used for running a `dtor` on termination. This is
@@ -208,8 +216,13 @@ __declare_features!(
             (all(target_os = "windows", any(target_env = "gnu", target_env = "msvc"))) => ".CRT$XPU",
             // ... except GNU
             (all(target_os = "windows", not(any(target_env = "gnu", target_env = "msvc")))) => ".dtors",
-            (all(target_os = "aix")) => (), // AIX uses export_name_prefix
-            _ => (compile_error!("Unsupported target for #[dtor]"))
+            // The gnu-efi project documents .fini_array support:
+            // https://github.com/vathpela/gnu-efi/blob/master/gnuefi/elf_x86_64_efi.lds
+            (target_os = "uefi") => ".fini_array",
+            (target_os = "aix") => (), // AIX uses export_name_prefix
+            // Fall back to .fini_array which is effectively the gold standard
+            // for LLVM/GCC targets moving forward
+            _ => ".fini_array",
         }
     };
     /// Specify the dtor method.

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -147,6 +147,9 @@ __declare_features!(
             (target_os = "aix") => (), // AIX uses export_name_prefix
             // Fall back to .init_array which is effectively the gold standard
             // for LLVM/GCC targets moving forward
+            #[warn("Falling back to .init_array for unsupported target. If this \
+            works for you, please file an issue to add support for your target \
+            at https://github.com/mmastrac/linktime/issues")]
             _ => ".init_array",
         }
     };
@@ -222,6 +225,9 @@ __declare_features!(
             (target_os = "aix") => (), // AIX uses export_name_prefix
             // Fall back to .fini_array which is effectively the gold standard
             // for LLVM/GCC targets moving forward
+            #[warn("Falling back to .fini_array for unsupported target. If this \
+            works for you, please file an issue to add support for your target \
+            at https://github.com/mmastrac/linktime/issues")]
             _ => ".fini_array",
         }
     };

--- a/macro-magic/src/macros/features.rs
+++ b/macro-magic/src/macros/features.rs
@@ -256,6 +256,7 @@ macro_rules! __parse_feature_input {
                 )?
                 $( default {
                     $( ($default_expr:meta) => $default_value:tt, )*
+                    $( #[warn($default_warn:literal)] )?
                     _ => $default_fallback:tt $(,)?
                 } )?
             };
@@ -287,6 +288,7 @@ macro_rules! __parse_feature_input {
                             [$dollar $feature:tt]
                         );
                         default = [
+                            $( $( #[warn($default_warn)] )? )?
                             $(
                                 ((feature = $feature_name) => $feature)
                             )?
@@ -442,13 +444,16 @@ macro_rules! __process_defaults {
                 example = $example:tt;
             )?
             validate = $validate:tt;
-            default = [$($default:tt)*]
+            default = [$( #[warn($default_warn:literal)] )? $(($($default:tt)*))*]
         )
     ) ) => {
         $crate::__process_defaults!( @process accum=(), negative=(), defaults=
             [
-                $($default)*
+                $(
+                    ($($default)*)
+                )*
             ],
+            warn=($($default_warn)?),
             next=[$next[$next_args]],
             rest=(
                 feature = $feature;
@@ -464,13 +469,24 @@ macro_rules! __process_defaults {
                     example = $example;
                 )?
                 validate = $validate;
-                original_defaults = {$($default)*};
+                original_defaults = {$(($($default)*))*};
             )
         );
     };
 
     // Stop when we hit the final default.
-    (@process accum=($($accum:tt)*), negative=$negative:tt, defaults=[(_ => $default_value:tt) $($ignored:tt)*], next=[$next:path[$next_args:tt]], rest=($($rest:tt)*)) => {
+    (@process accum=($($accum:tt)*), negative=$negative:tt, defaults=[(_ => $default_value:tt) $($ignored:tt)*], warn=($($default_warn:literal)?), next=[$next:path[$next_args:tt]], rest=($($rest:tt)*)) => {
+
+        $(
+            #[cfg(not(any $negative))]
+            const _: () = {
+                #[deprecated(note = $default_warn)]
+                const fn warn_unsupported_target() {}
+
+                warn_unsupported_target()
+            };
+        )?
+
         $next ! ( $next_args, (($($rest)* default = [
             $($accum)*
             ((not(any $negative)) => $default_value)

--- a/macro-magic/tests/test_macro.rs
+++ b/macro-magic/tests/test_macro.rs
@@ -60,9 +60,7 @@ __test!(__process_defaults:
             attr_docs = [];
             example = ();
             validate = [];
-            original_defaults =
-            {((a = "apple") => 1) ((b = "pc") => (compile_error!("2")))
-                ((c = "linux") => 3) (_ => (compile_error!("4")))};
+            original_defaults = {((a = "apple") => 1)((b = "pc") => (compile_error!("2")))((c = "linux") => 3)(_ => (compile_error!("4")))};
             default = [
                 ((all(a = "apple", not(any()))) => 1)
                 ((all(b = "pc", not(any(a = "apple",)))) => (compile_error!("2")))


### PR DESCRIPTION
The ctor and dtor crates can use a reasonable fallback for other platforms. We can generate a warning inside the ctor/dtor crate though it is unlikely to be seen.