### PR TITLE
AIX support in link-section

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,10 @@
 [alias]
 # Generate docs/GENERATED.md and README.md for crates.
 generate-docs = "run --package macro-magic --bin generate-docs --"
+
+[target.powerpc64-ibm-aix]
+rustflags = [
+    "-C", "link-arg=-bdbg:namedsects:ss",   # required
+#    "-C", "link-arg=-bmap:linker.out",     # for debugging
+#    "-C", "link-arg=-bnoquiet",            # for debugging
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "linktime-proc-macro",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ repository = "https://github.com/mmastrac/linktime"
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.3", default-features = false }
 dtor = { path = "dtor", version = "1.0.1", default-features = false }
-link-section = { path = "link-section", version = "0.15.0", default-features = false }
+link-section = { path = "link-section", version = "0.16.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - Unreleased
+
+### Added
+
+- Support for AIX targets. Requires `-C link-arg=-bdbg:namedsects:ss` (or a
+recent Rust version that sets this automatically).
+
 ## [0.15.0] - 2026-05-06
 
 ### Added

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.15.0"
+version = "0.16.0"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -17,24 +17,28 @@ are placed into the associated section.
 
 ## Platform Support
 
-| Platform                 | Support                                                                                       |
-| ------------------------ | --------------------------------------------------------------------------------------------- |
-| Linux                    | ✅ Supported, uses orphan section handling (§1)                                               |
-| \*BSD                    | ✅ Supported, uses orphan section handling (§1)                                               |
-| macOS                    | ✅ Fully supported                                                                            |
-| Windows                  | ✅ Fully supported                                                                            |
-| WASM                     | ✅ Fully supported (§2) (§3) |
-| Other LLVM/GCC platforms | ✅ Supported, uses orphan section handling (§1)                                               |
+| Platform                 | Support                                         |
+| ------------------------ | ----------------------------------------------- |
+| Linux                    | ✅ Supported, uses orphan section handling (§1) |
+| \*BSD                    | ✅ Supported, uses orphan section handling (§1) |
+| macOS                    | ✅ Fully supported                              |
+| Windows                  | ✅ Fully supported                              |
+| WASM                     | ✅ Fully supported (§2) (§3)                    |
+| AIX                      | ✅ Supported (§4)                               |
+| Other LLVM/GCC platforms | ✅ Supported, uses orphan section handling (§1) |
 
 (§1) Orphan section handling is a feature of the linker that allows sections to
 be defined without a pre-defined name.
 
 (§2) WASM requires `const` items, and uses `ctor`-like initialization to copy
-data to a contiguous section. To access link-section slices in WASM in
-`#[ctor]` functions, make sure to use at least `#[ctor(priority = 1)]`.
+data to a contiguous section. To access link-section slices in WASM in `#[ctor]`
+functions, make sure to use at least `#[ctor(priority = 1)]`.
 
 (§3) Host environment support (by calling the exported `register_link_section`
 function) is required to register each section with the runtime.
+
+(§4) AIX requires `-C link-arg=-bdbg:namedsects:ss` which enables functionality
+similar to LLVM/GCC's orphan section handling.
 
 ## Platform Details
 
@@ -42,8 +46,8 @@ Each platform has a slightly different implementation of section control.
 
 ### Linux and other LLVM/GCC platforms
 
- - Has start/end symbols: ✅ (C-compatible names only)
- - Supports linker sorting: ❌
+- Has start/end symbols: ✅ (C-compatible names only)
+- Supports linker sorting: ❌
 
 On Linux and other LLVM/GCC platforms, the linker supports orphan sections,
 which allow sections to be defined without a pre-defined name. These sections
@@ -55,8 +59,8 @@ Orphan sections are not sorted via numeric suffix (e.g.: `SECTION.1`,
 
 ### macOS
 
- - Has start/end symbols: ✅
- - Supports linker sorting: ❌
+- Has start/end symbols: ✅
+- Supports linker sorting: ❌
 
 On macOS, sections are configured via `__DATA` or `__TEXT` prefix and option
 suffixes (`regular`, `no_dead_strip`, etc.). The linker emits start and stop
@@ -65,23 +69,23 @@ the section name. macOS does not support ordering in the linker.
 
 ### Windows
 
- - Has start/end symbols: ❌
- - Supports linker sorting: ✅
- 
+- Has start/end symbols: ❌
+- Supports linker sorting: ✅
+
 On Windows, the linker does not emit start/end symbols, but all sections with a
 common prefix are automatically sorted by suffix, allowing us to use suffixes to
 control placement of start/stop symbols that we emit.
 
-See [this blog
-post](https://devblogs.microsoft.com/oldnewthing/20181107-00/?p=100155) and
-[this blog
-post](https://devblogs.microsoft.com/oldnewthing/20181108-00/?p=100165) for more
-details about the alphabetical sorting rule.
+See
+[this blog post](https://devblogs.microsoft.com/oldnewthing/20181107-00/?p=100155)
+and
+[this blog post](https://devblogs.microsoft.com/oldnewthing/20181108-00/?p=100165)
+for more details about the alphabetical sorting rule.
 
 ### WASM
 
- - Has start/end symbols: ❌
- - Supports linker sorting: ❌
+- Has start/end symbols: ❌
+- Supports linker sorting: ❌
 
 On WASM platforms, Rust emits data into custom sections which do not support
 ordering, and are stored out-of-band. The host environment is responsible for
@@ -130,6 +134,48 @@ export function readCustomSection(
     new Uint8Array(memory.buffer, targetPtr, need).set(new Uint8Array(section));
     return need;
 }
+```
+
+### AIX
+
+- Has start/end symbols: ✅
+- Supports linker sorting: ❌
+
+AIX maps Rust's `#[link_section]` to `csect`s, which act like subsections of the larger `.text` and `.data` sections.
+
+By default, AIX does not have section start/stop symbols, but the most recent
+versions of the linker added a new `-bdbg:namedsects:ss` flag which enables
+section start/stop symbols
+<sup>[↳](https://reviews.llvm.org/D124857?id=427067)</sup>.
+
+This flag can be set with `-C link-arg=-bdbg:namedsects:ss` (or by upgrading to
+a recent Rust version that sets this automatically
+<sup>[↳](https://rust.googlesource.com/rust/+/ad582a586550bf2c72e963939f61a71df1af7c0c%5E%21/#F0)</sup>
+to support link sections.
+
+The linker will report an error like this if the start/stop symbols are not
+found:
+
+```text
+  = note: ld: 0711-317 ERROR: Undefined symbol: __start__data_link_section_DATABASES
+          ld: 0711-317 ERROR: Undefined symbol: __stop__data_link_section_DATABASES
+          ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
+```
+
+For debugging AIX link-section issues, `-C link-arg=-bmap:[path]/linker.out`
+and `-C link-arg=-bnoquiet` may also be useful. 
+
+AIX supports a special mode to strip (`strip -r`) that preserves structural
+symbols like `csect`s and exports. A future version of `link-section` may add
+support for loading `csect` bounds from the binary's symbol table.
+
+```toml
+[target.powerpc64-ibm-aix]
+rustflags = [
+    "-C", "link-arg=-bdbg:namedsects:ss",   # required
+    "-C", "link-arg=-bmap:linker.out",      # for debugging
+    "-C", "link-arg=-bnoquiet",             # for debugging
+]
 ```
 
 ## Typed Sections

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -141,7 +141,10 @@ export function readCustomSection(
 - Has start/end symbols: ✅
 - Supports linker sorting: ❌
 
-AIX maps Rust's `#[link_section]` to `csect`s, which act like subsections of the larger `.text` and `.data` sections.
+AIX maps Rust's `#[link_section]` to `csect`s (Control Sections), which act like
+subsections of the larger `.text` and `.data` sections
+<sup>[↳](https://www.ibm.com/docs/kk/aix/7.2.0?topic=program-understanding-programming-toc)</sup>.
+A `csect` is the smallest, indivisible unit of code or data.
 
 By default, AIX does not have section start/stop symbols, but the most recent
 versions of the linker added a new `-bdbg:namedsects:ss` flag which enables

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -6,24 +6,28 @@ are placed into the associated section.
 
 ## Platform Support
 
-| Platform                 | Support                                                                                       |
-| ------------------------ | --------------------------------------------------------------------------------------------- |
-| Linux                    | ✅ Supported, uses orphan section handling (§1)                                               |
-| \*BSD                    | ✅ Supported, uses orphan section handling (§1)                                               |
-| macOS                    | ✅ Fully supported                                                                            |
-| Windows                  | ✅ Fully supported                                                                            |
-| WASM                     | ✅ Fully supported (§2) (§3) |
-| Other LLVM/GCC platforms | ✅ Supported, uses orphan section handling (§1)                                               |
+| Platform                 | Support                                         |
+| ------------------------ | ----------------------------------------------- |
+| Linux                    | ✅ Supported, uses orphan section handling (§1) |
+| \*BSD                    | ✅ Supported, uses orphan section handling (§1) |
+| macOS                    | ✅ Fully supported                              |
+| Windows                  | ✅ Fully supported                              |
+| WASM                     | ✅ Fully supported (§2) (§3)                    |
+| AIX                      | ✅ Supported (§4)                               |
+| Other LLVM/GCC platforms | ✅ Supported, uses orphan section handling (§1) |
 
 (§1) Orphan section handling is a feature of the linker that allows sections to
 be defined without a pre-defined name.
 
 (§2) WASM requires `const` items, and uses `ctor`-like initialization to copy
-data to a contiguous section. To access link-section slices in WASM in
-`#[ctor]` functions, make sure to use at least `#[ctor(priority = 1)]`.
+data to a contiguous section. To access link-section slices in WASM in `#[ctor]`
+functions, make sure to use at least `#[ctor(priority = 1)]`.
 
 (§3) Host environment support (by calling the exported `register_link_section`
 function) is required to register each section with the runtime.
+
+(§4) AIX requires `-C link-arg=-bdbg:namedsects:ss` which enables functionality
+similar to LLVM/GCC's orphan section handling.
 
 ## Platform Details
 
@@ -31,8 +35,8 @@ Each platform has a slightly different implementation of section control.
 
 ### Linux and other LLVM/GCC platforms
 
- - Has start/end symbols: ✅ (C-compatible names only)
- - Supports linker sorting: ❌
+- Has start/end symbols: ✅ (C-compatible names only)
+- Supports linker sorting: ❌
 
 On Linux and other LLVM/GCC platforms, the linker supports orphan sections,
 which allow sections to be defined without a pre-defined name. These sections
@@ -44,8 +48,8 @@ Orphan sections are not sorted via numeric suffix (e.g.: `SECTION.1`,
 
 ### macOS
 
- - Has start/end symbols: ✅
- - Supports linker sorting: ❌
+- Has start/end symbols: ✅
+- Supports linker sorting: ❌
 
 On macOS, sections are configured via `__DATA` or `__TEXT` prefix and option
 suffixes (`regular`, `no_dead_strip`, etc.). The linker emits start and stop
@@ -54,23 +58,23 @@ the section name. macOS does not support ordering in the linker.
 
 ### Windows
 
- - Has start/end symbols: ❌
- - Supports linker sorting: ✅
- 
+- Has start/end symbols: ❌
+- Supports linker sorting: ✅
+
 On Windows, the linker does not emit start/end symbols, but all sections with a
 common prefix are automatically sorted by suffix, allowing us to use suffixes to
 control placement of start/stop symbols that we emit.
 
-See [this blog
-post](https://devblogs.microsoft.com/oldnewthing/20181107-00/?p=100155) and
-[this blog
-post](https://devblogs.microsoft.com/oldnewthing/20181108-00/?p=100165) for more
-details about the alphabetical sorting rule.
+See
+[this blog post](https://devblogs.microsoft.com/oldnewthing/20181107-00/?p=100155)
+and
+[this blog post](https://devblogs.microsoft.com/oldnewthing/20181108-00/?p=100165)
+for more details about the alphabetical sorting rule.
 
 ### WASM
 
- - Has start/end symbols: ❌
- - Supports linker sorting: ❌
+- Has start/end symbols: ❌
+- Supports linker sorting: ❌
 
 On WASM platforms, Rust emits data into custom sections which do not support
 ordering, and are stored out-of-band. The host environment is responsible for
@@ -119,6 +123,48 @@ export function readCustomSection(
     new Uint8Array(memory.buffer, targetPtr, need).set(new Uint8Array(section));
     return need;
 }
+```
+
+### AIX
+
+- Has start/end symbols: ✅
+- Supports linker sorting: ❌
+
+AIX maps Rust's `#[link_section]` to `csect`s, which act like subsections of the larger `.text` and `.data` sections.
+
+By default, AIX does not have section start/stop symbols, but the most recent
+versions of the linker added a new `-bdbg:namedsects:ss` flag which enables
+section start/stop symbols
+<sup>[↳](https://reviews.llvm.org/D124857?id=427067)</sup>.
+
+This flag can be set with `-C link-arg=-bdbg:namedsects:ss` (or by upgrading to
+a recent Rust version that sets this automatically
+<sup>[↳](https://rust.googlesource.com/rust/+/ad582a586550bf2c72e963939f61a71df1af7c0c%5E%21/#F0)</sup>
+to support link sections.
+
+The linker will report an error like this if the start/stop symbols are not
+found:
+
+```text
+  = note: ld: 0711-317 ERROR: Undefined symbol: __start__data_link_section_DATABASES
+          ld: 0711-317 ERROR: Undefined symbol: __stop__data_link_section_DATABASES
+          ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
+```
+
+For debugging AIX link-section issues, `-C link-arg=-bmap:[path]/linker.out`
+and `-C link-arg=-bnoquiet` may also be useful. 
+
+AIX supports a special mode to strip (`strip -r`) that preserves structural
+symbols like `csect`s and exports. A future version of `link-section` may add
+support for loading `csect` bounds from the binary's symbol table.
+
+```toml
+[target.powerpc64-ibm-aix]
+rustflags = [
+    "-C", "link-arg=-bdbg:namedsects:ss",   # required
+    "-C", "link-arg=-bmap:linker.out",      # for debugging
+    "-C", "link-arg=-bnoquiet",             # for debugging
+]
 ```
 
 ## Typed Sections

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -130,7 +130,10 @@ export function readCustomSection(
 - Has start/end symbols: ✅
 - Supports linker sorting: ❌
 
-AIX maps Rust's `#[link_section]` to `csect`s, which act like subsections of the larger `.text` and `.data` sections.
+AIX maps Rust's `#[link_section]` to `csect`s (Control Sections), which act like
+subsections of the larger `.text` and `.data` sections
+<sup>[↳](https://www.ibm.com/docs/kk/aix/7.2.0?topic=program-understanding-programming-toc)</sup>.
+A `csect` is the smallest, indivisible unit of code or data.
 
 By default, AIX does not have section start/stop symbols, but the most recent
 versions of the linker added a new `-bdbg:namedsects:ss` flag which enables

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -103,13 +103,17 @@ pub mod __support {
         (
             $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             $(#[$meta:meta])*
-            $vis:vis static $($static:tt)*
+            $vis:vis static $ident:ident : $($static:tt)*
         ) => {
             $crate::__add_section_link_attribute_impl!(
                 $section $type $name $($aux)? #[$attr = __]
                 $(#[$meta])*
                 #[used]
-                $vis static $($static)*
+                #[cfg_attr(target_os = "aix", export_name = concat!("_", env!("CARGO_PKG_NAME"), "_",
+                    ::core::module_path!(), "_",
+                    stringify!($ident),
+                    "_L", line!(), "C", column!()))]
+                $vis static $ident : $($static)*
             );
         };
     }
@@ -121,13 +125,17 @@ pub mod __support {
         (
             $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             $(#[$meta:meta])*
-            $vis:vis static $($static:tt)*
+            $vis:vis static $ident:ident : $($static:tt)*
         ) => {
             $crate::__add_section_link_attribute_impl!(
                 $section $type $name $($aux)? #[$attr = __]
                 $(#[$meta])*
                 #[used(linker)]
-                $vis static $($static)*
+                #[cfg_attr(target_os = "aix", export_name = concat!("_", env!("CARGO_PKG_NAME"), "_",
+                    ::core::module_path!(), "_",
+                    stringify!($ident),
+                    "_L", line!(), "C", column!()))]
+                $vis static $ident : $($static)*
             );
         };
     }
@@ -417,10 +425,10 @@ pub mod __support {
                         data bounds $ident $($aux)?
                         #[export_name = __]
                         #[used]
-                        static mut __LINK_SECTION_INFO: $crate::__support::LinkSectionRawInfo = $crate::__support::LinkSectionRawInfo::new::<$generic_ty>(__LINK_SECTION_NAME);
+                        static __LINK_SECTION_INFO: $crate::__support::LinkSectionRawInfo = $crate::__support::LinkSectionRawInfo::new::<$generic_ty>(__LINK_SECTION_NAME);
                     );
 
-                    unsafe { $crate::__support::Bounds::new(&raw mut __LINK_SECTION_INFO) }
+                    unsafe { $crate::__support::Bounds::new(&raw const __LINK_SECTION_INFO) }
                 }
             }
         }
@@ -667,19 +675,19 @@ pub mod __support {
                         data bounds $ident $($aux)?
                         #[link_name = __]
                         extern "C" {
-                            static mut __LINK_SECTION_INFO: $crate::__support::LinkSectionRawInfo;
+                            static __LINK_SECTION_INFO: $crate::__support::LinkSectionRawInfo;
                         }
                     );
 
                     #[link_section = ".init_array.0"]
-                    static mut __LINK_SECTION_ITEM_FN_REF: extern "C" fn() = {
+                    static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() = {
                         extern "C" fn __LINK_SECTION_ITEM_FN() {
                             static DISARMED: ::core::sync::atomic::AtomicBool = ::core::sync::atomic::AtomicBool::new(false);
                             if DISARMED.swap(true, ::core::sync::atomic::Ordering::Relaxed) {
                                 return;
                             }
                             unsafe {
-                                let ptr = $crate::__support::register_wasm_link_section_item(&raw mut __LINK_SECTION_INFO);
+                                let ptr = $crate::__support::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
                                 ::core::ptr::write(ptr as *mut __InSecStoredTy, __LINK_SECTION_CONST_ITEM_VALUE);
                             }
                         }

--- a/link-section/src/wasm.rs
+++ b/link-section/src/wasm.rs
@@ -1,6 +1,7 @@
 //! WASM-specific implementation of the link section.
 use alloc::alloc::alloc;
 use core::alloc::Layout;
+use core::cell::UnsafeCell;
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicU8, Ordering};
 
@@ -78,7 +79,10 @@ impl LinkSection {
 
     #[inline(always)]
     unsafe fn as_mut(&self) -> &mut LinkSectionInfo {
-        unsafe { ptr::addr_of_mut!((*self.0.as_ptr()).info).as_mut_unchecked() }
+        unsafe {
+            let unsafe_cell = ptr::addr_of!((*self.0.as_ptr()).info);
+            UnsafeCell::raw_get(unsafe_cell).as_mut_unchecked()
+        }
     }
 }
 
@@ -105,8 +109,14 @@ impl<'a> Drop for LinkSectionLockGuard<'a> {
 #[repr(C)]
 pub struct LinkSectionRawInfo {
     lock: AtomicU8,
-    info: LinkSectionInfo,
+    info: UnsafeCell<LinkSectionInfo>,
 }
+
+// SAFETY:
+
+// Mutation of `LinkSectionInfo` is guarded by `LinkSection::lock`, which
+// synchronize via `AtomicU8`.
+unsafe impl Sync for LinkSectionRawInfo {}
 
 #[repr(C)]
 pub struct LinkSectionInfo {
@@ -124,7 +134,7 @@ impl LinkSectionRawInfo {
     pub const fn new<T>(name: &'static str) -> Self {
         Self {
             lock: AtomicU8::new(LockState::Uninitialized as _),
-            info: LinkSectionInfo {
+            info: UnsafeCell::new(LinkSectionInfo {
                 state: LinkSectionState::Uninitialized as _,
                 name_length: name.len() as _,
                 name: name.as_ptr(),
@@ -133,7 +143,7 @@ impl LinkSectionRawInfo {
                 current: ptr::null_mut(),
                 size_of: ::core::mem::size_of::<T>(),
                 align_of: ::core::mem::align_of::<T>(),
-            },
+            }),
         }
     }
 }
@@ -179,8 +189,8 @@ impl LinkSectionInfo {
     }
 }
 
-pub unsafe fn register_wasm_link_section_item<T>(info_ptr: *mut LinkSectionRawInfo) -> *mut T {
-    let link_section = LinkSection::new(NonNull::new_unchecked(info_ptr));
+pub unsafe fn register_wasm_link_section_item<T>(info_ptr: *const LinkSectionRawInfo) -> *mut T {
+    let link_section = LinkSection::new(NonNull::new_unchecked(info_ptr as _));
     let mut info = link_section.lock();
 
     unsafe {
@@ -208,9 +218,9 @@ pub unsafe fn register_wasm_link_section_item<T>(info_ptr: *mut LinkSectionRawIn
 pub struct Bounds(LinkSection);
 
 impl Bounds {
-    pub const unsafe fn new(info_ptr: *mut LinkSectionRawInfo) -> Self {
+    pub const unsafe fn new(info_ptr: *const LinkSectionRawInfo) -> Self {
         Self(LinkSection::new(unsafe {
-            NonNull::new_unchecked(info_ptr)
+            NonNull::new_unchecked(info_ptr as _)
         }))
     }
 


### PR DESCRIPTION
AIX support was surprisingly close - we just needed two things:

1) Each link-section item needs an export to keep it alive.
2) `-C link-arg=-bdbg:namedsects:ss` is required. More recent versions of Rust will be making this the default.

Also simplifies the mutable static that was used in the WASM support to one with an `UnsafeCell` so we can ensure all statics generated are immutable at the top level.

Fixes #402 