### PR TITLE
Bump to latest setup-rust-toolchain and pin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,7 +87,7 @@ jobs:
         tool: ${{ matrix.needs }}
   
     - name: Install Rust toolchain (${{ matrix.rust-toolchain }})
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: ${{ matrix.rust-components }}


### PR DESCRIPTION
Adopt the latest setup-rust-toolchain with the fix for https://github.com/actions-rust-lang/setup-rust-toolchain/issues/91

Thanks @jonasbb! 