### PR TITLE
Preparing ctor/dtor/link-section publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "libc-print",
  "link-section",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "libc-print",
  "linktime-proc-macro",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "linktime"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "ctor",
  "dtor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.3", default-features = false }
-dtor = { path = "dtor", version = "1.0.1", default-features = false }
+ctor = { path = "ctor", version = "1.0.4", default-features = false }
+dtor = { path = "dtor", version = "1.0.2", default-features = false }
 link-section = { path = "link-section", version = "0.16.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.4] - Unreleased
+## [1.0.4] - 2026-05-08
 
 ### Added
 

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.3"
+version = "1.0.4"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - Unreleased
+## [1.0.2] - 2026-05-08
 
 ### Added
 

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtor"
-version = "1.0.1"
+version = "1.0.2"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible destructors for all platforms that run after main (like C/C++ __attribute__((destructor)))"

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.0] - Unreleased
+## [0.16.0] - 2026-05-08
 
 ### Added
 

--- a/linktime/CHANGELOG.md
+++ b/linktime/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-05-08
+
+- Bumped `ctor`, `dtor` and `link-section` dependencies.
+
 ## [0.14.1] - 2026-05-03
 
 - Stabilized the `dtor` crate at 1.0.0 (optional dependency updated accordingly).

--- a/linktime/Cargo.toml
+++ b/linktime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linktime"
-version = "0.14.1"
+version = "0.15.0"
 authors.workspace = true
 edition = "2021"
 description = "Link-time registration patterns for Rust (ctors, dtors, link-time slices and sections)"


### PR DESCRIPTION
Big changes:

 - AIX in link-section
 - UEFI
 - Win7/UWP and other windows platforms
 - Fallback support for other OSes in ctor/dtor (use init_array/fini_array by default)
