### PR TITLE
Ensure WASM meets MSRV of 1.85

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ jobs:
                 "this.job == 'test-used-linker'": nightly
                 "this.job == 'build'": [stable, beta, nightly]
                 "this.job == 'build-minimal'": ["1.65"]
+                "this.job == 'wasm'": ["1.85"]
                 "true": "stable"
             rust-extra-target:
               $match:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "libc-print",
  "link-section",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "linktime-proc-macro",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.4", default-features = false }
+ctor = { path = "ctor", version = "1.0.5", default-features = false }
 dtor = { path = "dtor", version = "1.0.2", default-features = false }
-link-section = { path = "link-section", version = "0.16.0", default-features = false }
+link-section = { path = "link-section", version = "0.16.1", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-05-11
+
+### Changed
+
+- Repair MSRV breakage for WASM targets.
+
 ## [1.0.4] - 2026-05-08
 
 ### Added

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.4"
+version = "1.0.5"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-05-11
+
+### Changed
+
+- Repair MSRV breakage for WASM targets.
+
 ## [0.16.0] - 2026-05-08
 
 ### Added

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/link-section/src/wasm.rs
+++ b/link-section/src/wasm.rs
@@ -75,7 +75,11 @@ impl LinkSection {
     #[inline(always)]
     unsafe fn lock_ref(&self) -> &AtomicU8 {
         // as_ref_unchecked when we bump MSRV
-        unsafe { ptr::addr_of!((*self.0.as_ptr()).lock).as_ref().unwrap_unchecked() }
+        unsafe {
+            ptr::addr_of!((*self.0.as_ptr()).lock)
+                .as_ref()
+                .unwrap_unchecked()
+        }
     }
 
     #[inline(always)]

--- a/link-section/src/wasm.rs
+++ b/link-section/src/wasm.rs
@@ -74,14 +74,16 @@ impl LinkSection {
 
     #[inline(always)]
     unsafe fn lock_ref(&self) -> &AtomicU8 {
-        unsafe { ptr::addr_of!((*self.0.as_ptr()).lock).as_ref_unchecked() }
+        // as_ref_unchecked when we bump MSRV
+        unsafe { ptr::addr_of!((*self.0.as_ptr()).lock).as_ref().unwrap_unchecked() }
     }
 
     #[inline(always)]
     unsafe fn as_mut(&self) -> &mut LinkSectionInfo {
         unsafe {
             let unsafe_cell = ptr::addr_of!((*self.0.as_ptr()).info);
-            UnsafeCell::raw_get(unsafe_cell).as_mut_unchecked()
+            // as_mut_unchecked when we bump MSRV
+            UnsafeCell::raw_get(unsafe_cell).as_mut().unwrap_unchecked()
         }
     }
 }


### PR DESCRIPTION
As reported in #454, https://github.com/rust-lang/rust/issues/122034 didn't land until much later than the WASM MSRV we state in the README.

