### PR TITLE
Improve feature parser macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,7 @@ jobs:
         toolchain: ${{ matrix.rust-toolchain }}
         components: ${{ matrix.rust-components }}
         target: ${{ matrix.rust-extra-target }}
+        cache: false
 
     - name: Install Zig
       if: ${{ matrix.job == 'zigbuild' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,10 @@ name = "link-section"
 version = "0.16.1"
 dependencies = [
  "linktime-proc-macro",
+ "macrotest",
+ "tempfile",
+ "trybuild",
+ "walkdir",
 ]
 
 [[package]]

--- a/dtor/tests/errors/dtor_bad_nesting.stderr
+++ b/dtor/tests/errors/dtor_bad_nesting.stderr
@@ -1,10 +1,15 @@
 error: Unexpected meta attribute: 'ctor (link_section = ".ctors", used(linker))'
        ...expected one of:
-       anonymous; crate_path = $path : pat;
-       ctor(export_name_prefix = $ctor_export_name_prefix_str : literal);
-       ctor(link_section = $ctor_link_section_name : literal); export_name_prefix =
-       $export_name_prefix_str : literal; link_section = $section : literal; method =
-       $method_id : ident; unsafe; used(linker);
+         anonymous
+         crate_path = ::path::to::dtor::crate
+         ctor(export_name_prefix = "ctor_")
+         ctor(link_section = ".ctors")
+         export_name_prefix = "ctor_"
+         link_section = ".dtors"
+         method = term|unload|at_module_exit|at_binary_exit|linker
+         unsafe
+         used(linker)
+
  --> tests/errors/dtor_bad_nesting.rs:3:1
   |
 3 | #[dtor(unsafe, link_section = ".dtors", ctor(link_section = ".ctors", used(linker)))]

--- a/dtor/tests/errors/dtor_unknown.stderr
+++ b/dtor/tests/errors/dtor_unknown.stderr
@@ -1,10 +1,15 @@
 error: Unexpected meta attribute: 'unknown'
        ...expected one of:
-       anonymous; crate_path = $path : pat;
-       ctor(export_name_prefix = $ctor_export_name_prefix_str : literal);
-       ctor(link_section = $ctor_link_section_name : literal); export_name_prefix =
-       $export_name_prefix_str : literal; link_section = $section : literal; method =
-       $method_id : ident; unsafe; used(linker);
+         anonymous
+         crate_path = ::path::to::dtor::crate
+         ctor(export_name_prefix = "ctor_")
+         ctor(link_section = ".ctors")
+         export_name_prefix = "ctor_"
+         link_section = ".dtors"
+         method = term|unload|at_module_exit|at_binary_exit|linker
+         unsafe
+         used(linker)
+
  --> tests/errors/dtor_unknown.rs:3:1
   |
 3 | #[dtor(unknown)]
@@ -14,11 +19,16 @@ error: Unexpected meta attribute: 'unknown'
 
 error: Unexpected meta attribute: 'unknown'
        ...expected one of:
-       anonymous; crate_path = $path : pat;
-       ctor(export_name_prefix = $ctor_export_name_prefix_str : literal);
-       ctor(link_section = $ctor_link_section_name : literal); export_name_prefix =
-       $export_name_prefix_str : literal; link_section = $section : literal; method =
-       $method_id : ident; unsafe; used(linker);
+         anonymous
+         crate_path = ::path::to::dtor::crate
+         ctor(export_name_prefix = "ctor_")
+         ctor(link_section = ".ctors")
+         export_name_prefix = "ctor_"
+         link_section = ".dtors"
+         method = term|unload|at_module_exit|at_binary_exit|linker
+         unsafe
+         used(linker)
+
  --> tests/errors/dtor_unknown.rs:7:1
   |
 7 | #[dtor(unsafe, unknown, unknown2)]

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -18,6 +18,10 @@ std = []
 linktime-proc-macro = { workspace = true, optional = true, features = ["link_section"] }
 
 [dev-dependencies]
+macrotest = "1"
+trybuild = "1"
+walkdir = "2"
+tempfile = "3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -1,0 +1,71 @@
+use link_section::{section, in_section, TypedSection};
+#[doc(hidden)]
+pub use __FOO__link_section_private_macro__ as FOO;
+#[allow(non_camel_case_types)]
+struct FOO;
+impl ::link_section::__support::SectionItemType for FOO {
+    type Item = fn();
+}
+impl ::core::fmt::Debug for FOO {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        ::core::ops::Deref::deref(self).fmt(f)
+    }
+}
+impl ::core::ops::Deref for FOO {
+    type Target = TypedSection<fn()>;
+    fn deref(&self) -> &Self::Target {
+        self.const_deref()
+    }
+}
+impl FOO {
+    /// Get a `const` reference to the underlying section. In
+    /// non-const contexts, `deref` is sufficient.
+    pub const fn const_deref(&self) -> &TypedSection<fn()> {
+        static SECTION: TypedSection<fn()> = {
+            let section = {
+                extern "C" {
+                    #[link_name = "\u{1}section$start$__DATA$FOO"]
+                    #[allow(unsafe_code)]
+                    #[allow(unsafe_code)]
+                    static __START: u8;
+                }
+                extern "C" {
+                    #[link_name = "\u{1}section$end$__DATA$FOO"]
+                    #[allow(unsafe_code)]
+                    #[allow(unsafe_code)]
+                    static __END: u8;
+                }
+                ::link_section::__support::PtrBounds::new(
+                    unsafe { &raw const __START as *const () },
+                    unsafe { &raw const __END as *const () },
+                )
+            };
+            let name = "__DATA,FOO";
+            unsafe { <TypedSection<fn()>>::new(name, section) }
+        };
+        &SECTION
+    }
+}
+impl ::core::iter::IntoIterator for FOO {
+    type Item = &'static fn();
+    type IntoIter = ::core::slice::Iter<'static, fn()>;
+    fn into_iter(self) -> Self::IntoIter {
+        FOO.as_slice().iter()
+    }
+}
+const _: () = {
+    type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
+    #[link_section = "__DATA,FOO,regular,no_dead_strip"]
+    #[allow(unsafe_code)]
+    #[used]
+    static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = foo;
+};
+#[link_section = "__TEXT,FOO,regular,pure_instructions"]
+#[allow(unsafe_code)]
+#[allow(unsafe_code)]
+fn foo() {
+    {
+        ::std::io::_print(format_args!("foo\n"));
+    };
+}
+fn main() {}

--- a/link-section/tests/expand-darwin/link_section.rs
+++ b/link-section/tests/expand-darwin/link_section.rs
@@ -1,0 +1,12 @@
+use link_section::{section, in_section, TypedSection};
+
+#[section]
+static FOO: TypedSection<fn()>;
+
+#[in_section(FOO)]
+fn foo() {
+    println!("foo");
+}
+
+fn main() {
+}

--- a/link-section/tests/macrotest.rs
+++ b/link-section/tests/macrotest.rs
@@ -139,7 +139,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ctor = {{ path = "{repo_root}/ctor", default-features = false }}
+link-section = {{ path = "{repo_root}/link-section", default-features = false }}
 "#,
                 repo_root = repo_root.display()
             )

--- a/link-section/tests/macrotest.rs
+++ b/link-section/tests/macrotest.rs
@@ -172,6 +172,7 @@ link-section = {{ path = "{repo_root}/link-section", default-features = false }}
                 .current_dir(dir.path())
                 .env("CARGO_TERM_COLOR", "never")
                 .env("CARGO_TARGET_DIR", target_dir.join(&target))
+                .env_remove("RUSTFLAGS")
                 .args([
                     "+nightly",
                     "rustc",

--- a/link-section/tests/macrotest.rs
+++ b/link-section/tests/macrotest.rs
@@ -1,0 +1,248 @@
+#![cfg(not(miri))]
+
+/*
+
+To overwrite the Linux expansion tests on macOS, run:
+
+docker run --rm -v "$(pwd):/src" -w /src rust:1.88 \
+  bash -lc 'export CARGO_TARGET_DIR=/src/target/target-docker && export PATH="/usr/local/cargo/bin:$PATH" && cargo install cargo-expand && MACROTEST=overwrite cargo test -p ctor --test macrotest'
+*/
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use tempfile::tempdir;
+
+/// Macrotest sometimes leaves files empty when things fail to compile.
+fn ensure_no_empty_files(path: impl AsRef<Path>) {
+    if ensure_no_empty_files_recurse(path) {
+        panic!("Empty files found");
+    }
+}
+
+fn ensure_no_empty_files_recurse(path: impl AsRef<Path>) -> bool {
+    if !std::fs::exists(path.as_ref()).unwrap() {
+        return false;
+    }
+    let mut empty_files = false;
+    let files = std::fs::read_dir(path).unwrap();
+    for file in files.flatten() {
+        if file.file_type().unwrap().is_dir() {
+            ensure_no_empty_files_recurse(file.path());
+        } else {
+            let content = std::fs::read_to_string(file.path()).unwrap();
+            if content.trim().is_empty() {
+                eprintln!("Empty file found: {}", file.path().display());
+                empty_files = true;
+            }
+            if content.contains("/*ERROR*/") {
+                panic!("Error found in file: {}", file.path().display());
+            }
+        }
+    }
+    empty_files
+}
+
+#[test]
+#[cfg(not(linktime_used_linker))]
+pub fn pass() {
+    macrotest::expand("tests/expand/*.rs");
+    ensure_no_empty_files("tests/expand");
+}
+
+#[cfg(target_vendor = "apple")]
+#[cfg(not(linktime_used_linker))]
+#[test]
+pub fn pass_darwin() {
+    macrotest::expand("tests/expand-darwin/*.rs");
+    ensure_no_empty_files("tests/expand-darwin");
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(not(linktime_used_linker))]
+#[test]
+pub fn pass_linux() {
+    macrotest::expand("tests/expand-linux/*.rs");
+    ensure_no_empty_files("tests/expand-linux");
+}
+
+#[test]
+pub fn trybuild() {
+    let t = trybuild::TestCases::new();
+    // TODO: whitespace issue (tabs?) in error tests
+    #[cfg(not(target_os = "openbsd"))]
+    t.compile_fail("tests/errors/*.rs");
+    t.pass("tests/pass/*.rs");
+}
+
+#[test]
+pub fn target_test() {
+    let Some(toolchain) = std::env::var_os("TOOLCHAIN") else {
+        return;
+    };
+    if toolchain != "nightly" {
+        return;
+    }
+    let cases_dir = Path::new("tests/target-test");
+    let overwrite = std::env::var_os("MACROTEST")
+        .map(|v| v == "overwrite")
+        .unwrap_or(false);
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .canonicalize()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+
+    let mut count = 0;
+    let mut success = 0;
+
+    let target_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("target")
+        .join("target-test");
+
+    // Each testcase is:
+    // - input:  tests/target-test/<case>.rs
+    // - outputs: tests/target-test/<case>/<target-triple>.rs
+    for entry in fs::read_dir(cases_dir).unwrap().flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+
+        let case_name = path.file_stem().unwrap().to_string_lossy().to_string();
+        let outputs_dir = cases_dir.join(&case_name);
+        if !outputs_dir.is_dir() {
+            panic!(
+                "expected output directory {} for testcase {}",
+                outputs_dir.display(),
+                case_name
+            );
+        }
+
+        // Allow a testcase-specific Cargo.toml at tests/target-test/<case>/Cargo.toml
+        // (useful for additional deps or feature flags).
+        let case_cargo_toml_path = outputs_dir.join("Cargo.toml");
+        let base_cargo_toml = if case_cargo_toml_path.exists() {
+            fs::read_to_string(&case_cargo_toml_path).unwrap()
+        } else {
+            format!(
+                r#"[package]
+name = "expand_probe"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+ctor = {{ path = "{repo_root}/ctor", default-features = false }}
+"#,
+                repo_root = repo_root.display()
+            )
+        };
+
+        for out_file in fs::read_dir(&outputs_dir).unwrap().flatten() {
+            let out_path = out_file.path();
+            if out_path.extension().and_then(|s| s.to_str()) != Some("rs") {
+                continue;
+            }
+
+            count += 1;
+
+            let target = out_path.file_stem().unwrap().to_string_lossy().to_string();
+            eprintln!("testing testcase={case_name}, target={target}");
+
+            let dir = tempdir().unwrap();
+            fs::create_dir_all(dir.path().join("src")).unwrap();
+
+            fs::write(dir.path().join("Cargo.toml"), &base_cargo_toml).unwrap();
+            // Ensure the probe crate doesn't require `std` for exotic targets.
+            let input_src = fs::read_to_string(&path).unwrap();
+            fs::write(
+                dir.path().join("src/lib.rs"),
+                format!("#![no_std]\n// ***START MARKER***\n{input_src}"),
+            )
+            .unwrap();
+
+            let out = Command::new("cargo")
+                .current_dir(dir.path())
+                .env("CARGO_TERM_COLOR", "never")
+                .env("CARGO_TARGET_DIR", target_dir.join(&target))
+                .args([
+                    "+nightly",
+                    "rustc",
+                    // Build core from source so we can target triples without prebuilt std.
+                    "-Zbuild-std=core",
+                    "-Zbuild-std-features=compiler-builtins-mem",
+                    "--target",
+                    &target,
+                    "--lib",
+                    "--quiet",
+                    "--",
+                    "-Zunpretty=expanded",
+                ])
+                .output()
+                .unwrap();
+
+            // Even when compilation fails later, -Zunpretty=expanded often emits output.
+            // For debugging, include stderr on mismatch.
+            let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+            eprintln!("{stderr}");
+
+            if stderr.contains("error") {
+                panic!("compilation failed for testcase={case_name}, target={target}\n\n--- stderr ---\n{stderr}\n");
+            }
+
+            if stdout.trim().is_empty() {
+                panic!(
+                    "no expansion output for testcase={case_name}, target={target}\n\n--- stderr ---\n{stderr}\n"
+                );
+            }
+
+            if !stdout.contains("// ***START MARKER***") {
+                panic!(
+                    "no start marker in expansion output for testcase={case_name}, target={target}\n\n--- stdout ---\n{stdout}\n"
+                );
+            }
+
+            let stdout = stdout
+                .split("// ***START MARKER***\n")
+                .nth(1)
+                .unwrap()
+                .to_string();
+
+            if overwrite {
+                fs::write(&out_path, &stdout).unwrap();
+                success += 1;
+            } else {
+                let expected = fs::read_to_string(&out_path).unwrap();
+                if expected != stdout {
+                    eprintln!(
+                        "target-test mismatch for testcase={case_name}, target={target}\n\
+                         (set MACROTEST=overwrite to update)\n\n\
+                         --- expected file ---\n{expected}\n\n\
+                         --- actual stdout ---\n{stdout}\n\n\
+                         --- stderr ---\n{stderr}\n"
+                    );
+                } else {
+                    success += 1;
+                }
+            }
+        }
+    }
+
+    if count == 0 {
+        panic!("no testcases found");
+    } else if count == success {
+        println!("all {} testcases passed", count);
+    } else {
+        panic!("{} of {} testcases passed", success, count);
+    }
+
+    ensure_no_empty_files("tests/target-test");
+}

--- a/link-section/tests/macrotest.rs
+++ b/link-section/tests/macrotest.rs
@@ -5,7 +5,7 @@
 To overwrite the Linux expansion tests on macOS, run:
 
 docker run --rm -v "$(pwd):/src" -w /src rust:1.88 \
-  bash -lc 'export CARGO_TARGET_DIR=/src/target/target-docker && export PATH="/usr/local/cargo/bin:$PATH" && cargo install cargo-expand && MACROTEST=overwrite cargo test -p ctor --test macrotest'
+  bash -lc 'export CARGO_TARGET_DIR=/src/target/target-docker && export PATH="/usr/local/cargo/bin:$PATH" && cargo install cargo-expand && MACROTEST=overwrite cargo test -p link-section --test macrotest'
 */
 
 use std::{

--- a/link-section/tests/pass/link_section.rs
+++ b/link-section/tests/pass/link_section.rs
@@ -1,0 +1,12 @@
+use link_section::{section, in_section, TypedSection};
+
+#[section]
+static FOO: TypedSection<fn()>;
+
+#[in_section(FOO)]
+fn foo() {
+    println!("foo");
+}
+
+fn main() {
+}

--- a/link-section/tests/target-test/link-section.rs
+++ b/link-section/tests/target-test/link-section.rs
@@ -1,0 +1,17 @@
+use link_section::declarative::{section, in_section};
+use link_section::TypedSection;
+
+section! {
+    #[section]
+    static FOO: TypedSection<fn()>;
+}
+
+in_section! {
+    #[in_section(FOO)]
+    fn foo() {
+        
+    }
+}
+
+fn main() {
+}

--- a/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
@@ -1,0 +1,71 @@
+use link_section::declarative::{section, in_section};
+use link_section::TypedSection;
+
+
+
+
+/// Internal macro for parsing the section. This is exported with
+/// the same name as the type below.
+#[doc(hidden)]
+use ::link_section::__in_section_helper_macro_generic as FOO;
+#[allow(non_camel_case_types)]
+struct FOO;
+impl ::link_section::__support::SectionItemType for FOO {
+    type Item = fn();
+}
+impl ::core::fmt::Debug for FOO {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        ::core::ops::Deref::deref(self).fmt(f)
+    }
+}
+impl ::core::ops::Deref for FOO {
+    type Target = TypedSection<fn()>;
+    fn deref(&self) -> &Self::Target { self.const_deref() }
+}
+impl FOO {
+    /// Get a `const` reference to the underlying section. In
+    /// non-const contexts, `deref` is sufficient.
+    pub const fn const_deref(&self) -> &TypedSection<fn()> {
+        static SECTION: TypedSection<fn()> =
+            {
+                let section =
+                    {
+                        extern "C" {
+                            #[link_name = "__start__data_link_section_FOO"]
+                            #[allow(unsafe_code)]
+                            static __START: u8;
+                        }
+                        extern "C" {
+                            #[link_name = "__stop__data_link_section_FOO"]
+                            #[allow(unsafe_code)]
+                            static __END: u8;
+                        }
+                        ::link_section::__support::PtrBounds::new(unsafe {
+                                &raw const __START as *const ()
+                            }, unsafe { &raw const __END as *const () })
+                    };
+                let name = "_data_link_section_FOO";
+                unsafe { <TypedSection<fn()>>::new(name, section) }
+            };
+        &SECTION
+    }
+}
+impl ::core::iter::IntoIterator for FOO {
+    type Item = &'static fn();
+    type IntoIter = ::core::slice::Iter<'static, fn()>;
+    fn into_iter(self) -> Self::IntoIter { FOO.as_slice().iter() }
+}
+const _: () =
+    {
+        type __InSecStoredTy =
+            <FOO as ::link_section::__support::SectionItemType>::Item;
+        #[link_section = "_data_link_section_FOO"]
+        #[used]
+        #[export_name =
+        "_expand_probe_expand_probe___LINK_SECTION_CONST_ITEM_L11C1"]
+        static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = foo;
+    };
+#[link_section = "_text_link_section_FOO"]
+#[allow(unsafe_code)]
+fn foo() {}
+fn main() {}

--- a/macro-magic/src/macros/features.rs
+++ b/macro-magic/src/macros/features.rs
@@ -1,6 +1,31 @@
-//! A set of macros to declare features for another macro.
-
-/// A macro that generates the appropriate feature extraction macros.
+/// Declarative **feature** tables for `__declare_features!`.
+///
+/// Note: pattern matches inside this macro must be unique.
+///
+/// ## Shape
+///
+/// ```text
+/// __declare_features!(
+///     MACRO_NAME: parse_macro_ident;
+///     /// Docs for this feature…
+///     feature_ident {
+///         /// crate Optional docs for the crate feature.
+///         // Ties the Rust symbol to a **Cargo feature** name.
+///         feature: "…";
+///
+///         /// attr Optional docs for the attribute fragment.
+///         // Attribute pattern. $feature_ident can be used in VALUE to take the first token.
+///         attr: [(PATTERN) => (VALUE)];
+///         // Literal string used in generated **attribute** docs as a sample.
+///         example: "…";
+///         // Comma-separated patterns this value must match.
+///         validate: [(…), …];
+///         // Target- or cfg-specific defaults (`cfg` meta on each arm), optional
+///         // `#[warn("…")]` on the `_` arm, always end with `_ => …`.
+///         default { (cfg meta) => tokens, … _ => fallback };
+///     };
+/// );
+/// ```
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __declare_features {
@@ -230,7 +255,65 @@ macro_rules! __extract_unsafe {
     };
 }
 
-/// Parses a "pretty" feature specification into something easier to work with.
+/// Parse a type, optionally followed with a semicolon.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __parse_type {
+    (@entry next=$next:path[$next_args:tt], input=($final:ident $(< $($generic:ty),* >)? $(;)?)) => {
+        $next!($next_args, (
+            type = ($final$(<$($generic),*>)?)
+            prefix = ()
+            final = $final
+            generics = ($($($generic),*)?)
+        ));
+    };
+    (@entry next=$next:path[$next_args:tt], input=(:: $final:ident $(< $($generic:ty),* >)? $(;)?)) => {
+        $next!($next_args, (
+            type = (:: $final$(<$($generic),*>)?)
+            prefix = (::)
+            final = $final
+            generics = ($($($generic),*)?)
+        ));
+    };
+    (@entry next=$next:path[$next_args:tt], input=($prefix:ident :: $final:ident $(< $($generic:ty),* >)? $(;)?)) => {
+        $next!($next_args, (
+            type = ($prefix:: $final$(<$($generic),*>)?)
+            prefix = ($prefix::)
+            final = $final
+            generics = ($($($generic),*)?)
+        ));
+    };
+    (@entry next=$next:path[$next_args:tt], input=(:: $prefix:ident :: $final:ident $(< $($generic:ty),* >)? $(;)?)) => {
+        $next!($next_args, (
+            type = (:: $prefix:: $final$(<$($generic),*>)?)
+            prefix = (::$prefix::)
+            final = $final
+            generics = ($($($generic),*)?)
+        ));
+    };
+
+    // Longer, needs a munch
+    (@entry next=$next:path[$next_args:tt], input=($prefix:tt :: $($rest:tt)*)) => {
+        $crate::__parse_type!(@accum prefix=( $prefix ), rest=( :: $( $rest )* ), next=[$next[$next_args]], input=($prefix::$($rest)*));
+    };
+    (@entry next=$next:path[$next_args:tt], input=(:: $prefix:tt :: $($rest:tt)*)) => {
+        $crate::__parse_type!(@accum prefix=( :: $prefix ), rest=( :: $( $rest )* ), next=[$next[$next_args]], input=(::$prefix::$($rest)*));
+    };
+
+    (@accum prefix=($( $prefix:tt )*), rest=(:: $more_prefix:ident :: $( $rest:tt )*), next=$next:tt, input=$input:tt) => {
+        $crate::__parse_type!(@accum prefix=( $( $prefix )* :: $more_prefix ), rest=( :: $( $rest )* ), next=$next, input=$input);
+    };
+    (@accum prefix=($($prefix:tt)*), rest=(:: $final:ident $(< $($generic:ty),* >)? $(;)?), next=[$next:path[$next_args:tt]], input=$input:tt) => {
+        $next!($next_args, (
+            type = ( $( $prefix )* :: $final$(<$($generic),*>)?)
+            prefix = ( $( $prefix )* :: )
+            final = $final
+            generics = ($($($generic),*)?)
+        ));
+    };
+}
+
+/// Normalizes `__declare_features!` input into tuples for later passes (grammar: module `//!`).
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __parse_feature_input {
@@ -622,9 +705,9 @@ macro_rules! __extract_meta {
     ), args=[$macro_path:path]) => {
         // This will return to us after the generated macro has finished processing.
         $macro_path!(@meta macro=$macro_path, next=$crate::__extract_meta[[@finish $macro_path, next=$next[$next_args]]] $(
-            // Pass each of the attributes down, but we separate with a `, , ;`
+            // Pass each of the attributes down, but we separate with a `, $name ;`
             // sequence to help the downstream macro split things up.
-            $name $( ($( $args )*) )? $( = $value $( $value_ident )? $( :: $value_path )* )? , , ;
+            $name $( ($( $args )*) )? $( = $value $( $value_ident )? $( :: $value_path )* )? , $name ;
         )*);
     };
     // If we couldn't parse one of those forms above, this path gets hit.
@@ -651,7 +734,7 @@ macro_rules! __extract_meta {
     // us with @error.
     ( [@finish $macro_path:path, next=$next:path[$next_args:tt]],
         ($(
-            ( $name:ident = $value:tt $value_what:ident $( , $def_value:tt $def_value_what:ident )? )
+            ( $name:ident = $value:tt $value_what:ident $ignored:tt $( , $def_value:tt $def_value_what:ident $ignored2:tt )? )
         )*)
     ) => {
         // Pass the calculated feature back to @validate, which will continue on if all
@@ -663,7 +746,7 @@ macro_rules! __extract_meta {
     // Catch duplicate items.
     ( [@finish $macro_path:path, next=$next:path[$next_args:tt]],
         (
-            $(( $name:ident = $value:tt $value_what:ident $( , $def_value:tt $def_value_what:ident $( $comma:tt $($rest:tt)* )? )? ))*
+            $(( $name:ident = $value:tt $value_what:ident $ignore:tt $( , $def_value:tt $def_value_what:ident $ignore2:tt $( $comma:tt $($rest:tt)* )? )? ))*
         )
     ) => {
         // TODO: This should show the underlying attribute rather than the internal name.
@@ -673,13 +756,13 @@ macro_rules! __extract_meta {
     };
     // Unknown items (valid form, unrecognized pattern).
     ( @error rest=(
-        $name:ident $( ($( $args:tt)*) )? $( = $value:tt )? , , ; $($rest:tt)*
-    ) attrs=($($attr:tt)*)) => {
+        $name:ident $( ($( $args:tt)*) )? $( = $value:tt )? , $ignore:tt ; $($rest:tt)*
+    ) attrs=( $( ( $($example:tt)* ) )* )) => {
         const _: () = { compile_error!(concat!("Unexpected meta attribute: '", stringify!(
             $name $( ($( $args )*) )? $( = $value )?
         ),
-        "'\n...expected one of:\n",
-        stringify!($($attr)*))); };
+        "'\n...expected one of:\n  ",
+        $($($example)*, "\n  ",)*)); };
     };
     ( $($input:tt)* ) => {
         const _: () = { compile_error!(concat!("Unexpected input in __extract_meta: ", stringify!($($input)*))); };
@@ -778,15 +861,15 @@ macro_rules! __make_macros {
                         $dollar(
                             $($attr)*
                             ,
-                            $dollar $feature:tt // comma
+                            $dollar $feature:tt // first token
                         )?
                     )?)*
                     ;
                 )*
             ) => {
                 $next_macro ! ( $next_macro_args, ( $(($feature = $(
-                    $dollar ( $dollar( $($attr_output)* value $dollar $feature )? )*
-                )? $default_value default))* ) );
+                    $dollar ( $dollar( $($attr_output)* value $dollar $feature, )? )*
+                )? $default_value default _))* ) );
             };
 
             // Unrecognized, munch until end of recognized input.
@@ -801,7 +884,7 @@ macro_rules! __make_macros {
                     $dollar(
                         $($attr)*
                         ,
-                        $dollar $feature:tt // comma
+                        $dollar $feature:tt // first token
                     )?
                 )?)*
                 ;
@@ -812,7 +895,7 @@ macro_rules! __make_macros {
             // Found the error!
             (@metaerror macro=$macro_path:path, next=$next_macro:path[$next_macro_args:tt]
                 $dollar ($dollar rest:tt)*) => {
-                $crate::__extract_meta!(@error rest=($dollar($dollar rest)*) attrs=($($($($attr)* ;)?)*));
+                $crate::__extract_meta!(@error rest=($dollar($dollar rest)*) attrs=($($($example)?)*));
             };
 
             // @validate ensures that all features match the validate expressions. If this doesn't

--- a/macro-magic/src/macros/features.rs
+++ b/macro-magic/src/macros/features.rs
@@ -1,5 +1,5 @@
-/// Declarative **feature** tables for `__declare_features!`.
-///
+//! Declarative feature macros.
+
 /// Note: pattern matches inside this macro must be unique.
 ///
 /// ## Shape

--- a/macro-magic/tests/test_item.rs
+++ b/macro-magic/tests/test_item.rs
@@ -76,3 +76,106 @@ __test!(__parse_item[my_macro_parse]:
     meta = (#[other] #[doc]),
     item = (fn foo() { /* ... */ })
 ));
+
+__declare_features!(
+    section: section_type_parse;
+    other {
+        attr: [(other = $value:tt) => ($value)];
+        example: "other = N";
+        validate: [($numeric:literal)];
+    };
+    /// One of `untyped`, `typed`, `reference`, or `moveable` (same choices as `#[section(...)]`).
+    section_type {
+        attr: [
+            ($(untyped)? $(typed)? $(reference)? $(moveable)?) => ($section_type)
+        ];
+        example: "untyped | typed | reference | moveable";
+        validate: [(untyped), (typed), (reference), (moveable)];
+    };
+);
+
+__test!(__parse_item[section_type_parse]:
+(
+    #[section(typed)]
+    fn foo() { /* ... */ }
+) =>
+(
+    features = (other = (): default, section_type = typed : value,),
+    self = (typed),
+    meta = (),
+    item = (fn foo() { /* ... */ })
+));
+
+__test!(__parse_item[section_type_parse]:
+(
+    #[section(typed, other = 1)]
+    fn foo() { /* ... */ }
+) =>
+(
+    features = (other = 1: value, section_type = typed : value,),
+    self = (typed, other = 1),
+    meta = (),
+    item = (fn foo() { /* ... */ })
+));
+
+__test!(__parse_type: (SomeType) =>
+(
+    type = (SomeType)
+    prefix = ()
+    final = SomeType
+    generics = ()
+));
+__test!(__parse_type: (::SomeType) =>
+(
+    type = (:: SomeType)
+    prefix = (::)
+    final = SomeType
+    generics = ()
+));
+__test!(__parse_type: (::root::SomeType) =>
+(
+    type = (:: root :: SomeType)
+    prefix = (:: root ::)
+    final = SomeType
+    generics = ()
+));
+
+__test!(__parse_type: (root::SomeType) =>
+(
+    type = (root :: SomeType)
+    prefix = (root ::)
+    final = SomeType
+    generics = ()
+));
+
+__test!(__parse_type: (::root::more::SomeType) =>
+(
+    type = (:: root:: more :: SomeType)
+    prefix = (:: root:: more ::)
+    final = SomeType
+    generics = ()
+));
+
+__test!(__parse_type: (root::more::SomeType) =>
+(
+    type = (root:: more :: SomeType)
+    prefix = (root:: more ::)
+    final = SomeType
+    generics = ()
+));
+
+__test!(__parse_type: (SomeType<T, U>) =>
+(
+    type = (SomeType < T, U >)
+    prefix = ()
+    final = SomeType
+    generics = (T, U)
+));
+
+__test!(__parse_type: (::crazy::long::path_to_type::with::generics::SomeType<T, U>) =>
+(
+    type = (:: crazy:: long :: path_to_type :: with :: generics :: SomeType < T, U >)
+    prefix = (:: crazy:: long :: path_to_type :: with :: generics ::)
+    final = SomeType
+    generics = (T, U)
+));


### PR DESCRIPTION
Allows the feature macro to parse single-ident params to an attribute (not used here - later PR) and improves failure messages.

Adds some macrotests for link-section too.