### PR TITLE
"movable" typed sections and sorted/referenced slice

### DIFF
--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -6,6 +6,9 @@ sanitize_runs=(
   "ctor:ctor-example"
   "ctor:ctor-advanced"
   "link-section:link-section-example"
+  "link-section:link-section-ref"
+  "link-section:link-section-mut"
+  "link-section:link-section-movable"
 )
 
 for spec in "${sanitize_runs[@]}"; do

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `reference` sections support access both as a slice and as a reference at the
   submission site on all platforms (including WASM).
+- `movable` sections support reordering and back-reference updates during
+  startup initialization (allowing a "reference" to an item that may move during
+  initialization at the submission site).
 - `typed` and `mutable` sections have been split: `typed` allows for `const` and
   `static` items, while `mutable` allows for `const` items and `as_mut_slice`
   access.
@@ -19,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Significant rewrite to link-section's internal implementation.
 - Sections require a type: `#[section(typed)]`, `#[section(untyped)]`,
-  `#[section(mutable)]`, or `#[section(reference)]`.
+  `#[section(mutable)]`, `#[section(movable)]`, or `#[section(reference)]`.
 - When submitting a fn() with a body to a typed link section, the function's
 body is not placed in any specific section. To restore the previous behavior,
 manually split function pointers and bodies:

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -41,6 +41,10 @@ name = "link-section-example"
 path = "examples/example.rs"
 
 [[example]]
+name = "link-section-movable"
+path = "examples/movable.rs"
+
+[[example]]
 name = "link-section-mut"
 path = "examples/mut.rs"
 

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -268,6 +268,19 @@ For `static` items: the static is stored directly in the link section.
 `fn` items are special-cased and stored as function pointers in the typed
 section.
 
+## Exclusive Access
+
+Mutable sections (ie: [`TypedMutableSection`] and [`TypedMovableSection`])
+require exclusive access to the section's memory while calling
+[`TypedMutableSection::as_mut_slice`] or [`TypedMovableSection::as_mut_slice`].
+
+This is normally satisfied only during pre-`main` initialization (for example
+inside a `#[ctor]`). After `main`, the caller must guarantee no concurrent reads
+or writes from other threads and no active Rust references into the section.
+
+It is highly recommended not to access the mutable references after `main` has
+started.
+
 ## Usage
 
 Create an untyped section using the `#[section]` macro that keeps related items

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -24,7 +24,7 @@ linker section and accessed through a single section handle.
 
 ## Section Kinds
 
-There are four section kinds:
+There are five section kinds:
 
 - `untyped`: Collects related code or data in one linker section without
   exposing a typed slice. This is useful for co-location, phase-specific code,
@@ -34,6 +34,10 @@ There are four section kinds:
 - `reference`: Stores values of one type, exposes them as an immutable slice,
   and also lets each submitted item be used as a reference at its submission
   site.
+- `movable`: Stores values of one type and exposes them as a mutable slice, and
+  also lets each submitted item be used as a reference at its submission site.
+  The entire section is available as a mutable slice, and items may be reordered
+  during startup initialization (see [`TypedMovableSection`] for more details).
 
 | Section Kind | Immutable Slice | Mutable Slice | `const` Items | `static` / Reference Items |
 | ------------ | --------------- | ------------- | ------------- | -------------------------- |
@@ -41,6 +45,7 @@ There are four section kinds:
 | `typed`      | ✅              | ❌            | ✅            | ⚠️                         |
 | `mutable`    | ✅              | ✅            | ✅            | ❌                         |
 | `reference`  | ✅              | ❌            | ✅            | ✅                         |
+| `movable`    | ✅              | ✅            | ❌            | ✅                         |
 
 ⚠️ Native targets support `static` submissions for `typed` sections; WASM uses
 `const` submissions only.

--- a/link-section/docs/GENERATED.md
+++ b/link-section/docs/GENERATED.md
@@ -35,7 +35,7 @@
 
 
 </td></tr>
-<tr><td><code>untyped | typed | mutable | reference</code></td><td>
+<tr><td><code>untyped | typed | mutable | movable | reference</code></td><td>
 
  The type of the section.
 

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -264,6 +264,19 @@ For `static` items: the static is stored directly in the link section.
 `fn` items are special-cased and stored as function pointers in the typed
 section.
 
+## Exclusive Access
+
+Mutable sections (ie: [`TypedMutableSection`] and [`TypedMovableSection`])
+require exclusive access to the section's memory while calling
+[`TypedMutableSection::as_mut_slice`] or [`TypedMovableSection::as_mut_slice`].
+
+This is normally satisfied only during pre-`main` initialization (for example
+inside a `#[ctor]`). After `main`, the caller must guarantee no concurrent reads
+or writes from other threads and no active Rust references into the section.
+
+It is highly recommended not to access the mutable references after `main` has
+started.
+
 ## Usage
 
 Create an untyped section using the `#[section]` macro that keeps related items

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -13,7 +13,7 @@ linker section and accessed through a single section handle.
 
 ## Section Kinds
 
-There are four section kinds:
+There are five section kinds:
 
 - `untyped`: Collects related code or data in one linker section without
   exposing a typed slice. This is useful for co-location, phase-specific code,
@@ -23,6 +23,10 @@ There are four section kinds:
 - `reference`: Stores values of one type, exposes them as an immutable slice,
   and also lets each submitted item be used as a reference at its submission
   site.
+- `movable`: Stores values of one type and exposes them as a mutable slice, and
+  also lets each submitted item be used as a reference at its submission site.
+  The entire section is available as a mutable slice, and items may be reordered
+  during startup initialization (see [`TypedMovableSection`] for more details).
 
 | Section Kind | Immutable Slice | Mutable Slice | `const` Items | `static` / Reference Items |
 | ------------ | --------------- | ------------- | ------------- | -------------------------- |
@@ -30,6 +34,7 @@ There are four section kinds:
 | `typed`      | ✅              | ❌            | ✅            | ⚠️                         |
 | `mutable`    | ✅              | ✅            | ✅            | ❌                         |
 | `reference`  | ✅              | ❌            | ✅            | ✅                         |
+| `movable`    | ✅              | ✅            | ❌            | ✅                         |
 
 ⚠️ Native targets support `static` submissions for `typed` sections; WASM uses
 `const` submissions only.

--- a/link-section/examples/movable.rs
+++ b/link-section/examples/movable.rs
@@ -11,57 +11,43 @@ static OPERATIONS: link_section::TypedMovableSection<Operation>;
 #[derive(Debug, PartialEq, Eq, Ord, PartialOrd)]
 struct Operation(u32);
 
-mod operations {
+pub(crate) mod operations {
     use super::Operation;
     use link_section::in_section;
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_1: Operation = Operation(1);
+    pub static OPERATION_A: Operation = Operation(1);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_3: Operation = Operation(3);
+    pub static OPERATION_B: Operation = Operation(3);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_6: Operation = Operation(6);
+    pub static OPERATION_C: Operation = Operation(6);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_7: Operation = Operation(7);
+    pub static OPERATION_D: Operation = Operation(10);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_8: Operation = Operation(8);
+    pub static OPERATION_E: Operation = Operation(8);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_2: Operation = Operation(2);
+    pub static OPERATION_F: Operation = Operation(2);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_4: Operation = Operation(4);
+    pub static OPERATION_G: Operation = Operation(4);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_5: Operation = Operation(5);
+    pub static OPERATION_H: Operation = Operation(5);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_9: Operation = Operation(9);
+    pub static OPERATION_I: Operation = Operation(9);
 
     #[in_section(super::OPERATIONS)]
-    static OPERATION_10: Operation = Operation(10);
+    pub static OPERATION_J: Operation = Operation(7);
 }
 
 fn sort_operations() {
-    let section = unsafe { OPERATIONS.as_mut_slice() };
-    section.sort_unstable();
-
-    let movable_section = unsafe { OPERATIONS.as_mut_slice() };
-    let movable_backrefs = unsafe { OPERATIONS.as_mut_backrefs() };
-    assert_eq!(movable_section.len(), movable_backrefs.len());
-
-    for i in 0..movable_section.len() {
-        for j in i + 1..movable_section.len() {
-            if movable_section[i] > movable_section[j] {
-                movable_section.swap(i, j);
-                movable_backrefs.swap(i, j);
-            }
-        }
-    }
+    unsafe { OPERATIONS.sort_unstable() };
 }
 
 #[allow(unsafe_code)]
@@ -73,4 +59,15 @@ fn main() {
     for op in OPERATIONS {
         println!("Operation: {op:?}");
     }
+
+    println!("OPERATION_A: {:?}", *operations::OPERATION_A);
+    println!("OPERATION_B: {:?}", *operations::OPERATION_B);
+    println!("OPERATION_C: {:?}", *operations::OPERATION_C);
+    println!("OPERATION_D: {:?}", *operations::OPERATION_D);
+    println!("OPERATION_E: {:?}", *operations::OPERATION_E);
+    println!("OPERATION_F: {:?}", *operations::OPERATION_F);
+    println!("OPERATION_G: {:?}", *operations::OPERATION_G);
+    println!("OPERATION_H: {:?}", *operations::OPERATION_H);
+    println!("OPERATION_I: {:?}", *operations::OPERATION_I);
+    println!("OPERATION_J: {:?}", *operations::OPERATION_J);
 }

--- a/link-section/examples/movable.rs
+++ b/link-section/examples/movable.rs
@@ -1,0 +1,76 @@
+//! Reference-section example for `link-section`.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+#![warn(missing_docs)]
+
+use link_section::section;
+
+/// Operations.
+#[section(movable)]
+static OPERATIONS: link_section::TypedMovableSection<Operation>;
+
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd)]
+struct Operation(u32);
+
+mod operations {
+    use super::Operation;
+    use link_section::in_section;
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_1: Operation = Operation(1);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_3: Operation = Operation(3);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_6: Operation = Operation(6);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_7: Operation = Operation(7);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_8: Operation = Operation(8);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_2: Operation = Operation(2);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_4: Operation = Operation(4);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_5: Operation = Operation(5);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_9: Operation = Operation(9);
+
+    #[in_section(super::OPERATIONS)]
+    static OPERATION_10: Operation = Operation(10);
+}
+
+fn sort_operations() {
+    let section = unsafe { OPERATIONS.as_mut_slice() };
+    section.sort_unstable();
+
+    let movable_section = unsafe { OPERATIONS.as_mut_slice() };
+    let movable_backrefs = unsafe { OPERATIONS.as_mut_backrefs() };
+    assert_eq!(movable_section.len(), movable_backrefs.len());
+
+    for i in 0..movable_section.len() {
+        for j in i + 1..movable_section.len() {
+            if movable_section[i] > movable_section[j] {
+                movable_section.swap(i, j);
+                movable_backrefs.swap(i, j);
+            }
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+fn main() {
+    // This should normally be done in a `ctor`, but for this example we know
+    // there are no other live threads and we do it here.
+    sort_operations();
+
+    for op in OPERATIONS {
+        println!("Operation: {op:?}");
+    }
+}

--- a/link-section/examples/movable.rs
+++ b/link-section/examples/movable.rs
@@ -46,11 +46,11 @@ pub(crate) mod operations {
     pub static OPERATION_J: Operation = Operation(7);
 }
 
+#[allow(unsafe_code)]
 fn sort_operations() {
     unsafe { OPERATIONS.sort_unstable() };
 }
 
-#[allow(unsafe_code)]
 fn main() {
     // This should normally be done in a `ctor`, but for this example we know
     // there are no other live threads and we do it here.

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -429,10 +429,13 @@ pub mod __support {
                     $crate::__add_section_link_attribute!(
                         backref data section $section $($aux)?
                         #[link_section = __]
-                        static __LINK_SECTION_MOVABLE_BACKREF: $crate::MovableBackref<__InSecStoredTy> =
+                        static __LINK_SECTION_MOVABLE_BACKREF: $crate::__support::SyncUnsafeCell<
+                            $crate::MovableBackref<__InSecStoredTy>
+                        > = $crate::__support::SyncUnsafeCell::new(
                             $crate::MovableBackref::new(
                                 $crate::MovableRef::slot_ptr(&raw const $ident),
-                            );
+                            )
+                        );
                     );
 
                     $crate::MovableRef::new(

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -394,7 +394,7 @@ pub mod __support {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
 
-                $crate::__register_wasm_item!(value=__LINK_SECTION_CONST_ITEM_VALUE, section=$section $($aux)?);
+                $crate::__register_wasm_item!(mutable, value=__LINK_SECTION_CONST_ITEM_VALUE, section=$section $($aux)?);
 
                 #[cfg(not(target_family = "wasm"))]
                 $crate::__add_section_link_attribute!(
@@ -415,38 +415,43 @@ pub mod __support {
         (@typed[movable] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis static $ident:ident: $ty:ty = $value:expr;)) => {
             $($meta)*
             $vis static $ident: $crate::MovableRef<$crate::__in_section_crate!(@type_select $path)> = const {
-                type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
-
-                $crate::__register_wasm_movable_item!(
-                    value=__LINK_SECTION_CONST_ITEM_VALUE,
-                    type=__InSecStoredTy,
-                    section=$section $($aux)?
-                );
-
+                type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 #[cfg(not(target_family = "wasm"))]
-                $crate::__add_section_link_attribute!(
-                    item data section $section $($aux)?
-                    #[link_section = __]
-                    static __LINK_SECTION_CONST_ITEM: $crate::__support::SyncUnsafeCell<__InSecStoredTy> = $crate::__support::SyncUnsafeCell::new(__LINK_SECTION_CONST_ITEM_VALUE);
-                );
+                {
+                    $crate::__add_section_link_attribute!(
+                        item data section $section $($aux)?
+                        #[link_section = __]
+                        static __LINK_SECTION_CONST_ITEM: $crate::__support::SyncUnsafeCell<__InSecStoredTy> =
+                            $crate::__support::SyncUnsafeCell::new(__LINK_SECTION_CONST_ITEM_VALUE);
+                    );
 
-                #[cfg(not(target_family = "wasm"))]
-                static __LINK_SECTION_MOVABLE_PTR: $crate::__support::SyncUnsafeCell<*const __InSecStoredTy> =
-                    $crate::__support::SyncUnsafeCell::new((&raw const __LINK_SECTION_CONST_ITEM).cast::<__InSecStoredTy>());
+                    $crate::__add_section_link_attribute!(
+                        backref data section $section $($aux)?
+                        #[link_section = __]
+                        static __LINK_SECTION_MOVABLE_BACKREF: $crate::MovableBackref<__InSecStoredTy> =
+                            $crate::MovableBackref::new(
+                                $crate::MovableRef::slot_ptr(&raw const $ident),
+                            );
+                    );
 
-                #[cfg(not(target_family = "wasm"))]
-                $crate::__add_section_link_attribute!(
-                    backref data section $section $($aux)?
-                    #[link_section = __]
-                    static __LINK_SECTION_MOVABLE_BACKREF: $crate::MovableBackref<__InSecStoredTy> =
-                        $crate::MovableBackref::new(
-                            (&raw const __LINK_SECTION_CONST_ITEM).cast::<__InSecStoredTy>(),
-                            &raw const __LINK_SECTION_MOVABLE_PTR,
-                        );
-                );
+                    $crate::MovableRef::new(
+                        (&raw const __LINK_SECTION_CONST_ITEM)
+                            .cast::<__InSecStoredTy>(),
+                    )
+                }
 
-                $crate::MovableRef::new(&__LINK_SECTION_MOVABLE_PTR)
+                #[cfg(target_family = "wasm")]
+                {
+                    $crate::__register_wasm_item!(
+                        movable,
+                        value=__LINK_SECTION_CONST_ITEM_VALUE,
+                        slot=$crate::MovableRef::slot_ptr(&raw const $ident),
+                        section=$section $($aux)?
+                    );
+
+                    $crate::MovableRef::new(::core::ptr::null())
+                }
             };
         };
 
@@ -461,7 +466,7 @@ pub mod __support {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
 
-                $crate::__register_wasm_item!(value=__LINK_SECTION_CONST_ITEM_VALUE, section=$section $($aux)?);
+                $crate::__register_wasm_item!($section_type, value=__LINK_SECTION_CONST_ITEM_VALUE, section=$section $($aux)?);
 
                 #[cfg(not(target_family = "wasm"))]
                 $crate::__add_section_link_attribute!(
@@ -480,7 +485,7 @@ pub mod __support {
             $vis static $ident: $crate::reference::Ref<$crate::__in_section_crate!(@type_select $path)> = const {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
-                $crate::__register_wasm_item!(value=__LINK_SECTION_CONST_ITEM_VALUE, ref=$ident, section=$section $($aux)?);
+                $crate::__register_wasm_item!(reference, value=__LINK_SECTION_CONST_ITEM_VALUE, ref=$ident, section=$section $($aux)?);
                 $crate::reference::Ref::new()
             };
 

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -14,7 +14,10 @@ mod platform;
 mod section_parse;
 mod sections;
 
-pub use sections::{Section, TypedMutableSection, TypedReferenceSection, TypedSection};
+pub use sections::{
+    MovableBackref, MovableRef, Section, TypedMovableSection, TypedMutableSection,
+    TypedReferenceSection, TypedSection,
+};
 
 /// Types for [`TypedReferenceSection`].
 pub mod reference {
@@ -58,8 +61,8 @@ __declare_features!(
         attr: [
             (type = $section_type:ident) => ($section_type)
         ];
-        example: "untyped | typed | mutable | reference";
-        validate: [(untyped), (typed), (mutable), (reference)];
+        example: "untyped | typed | mutable | movable | reference";
+        validate: [(untyped), (typed), (mutable), (movable), (reference)];
     };
 );
 
@@ -86,8 +89,8 @@ __declare_features!(
     };
     section_type {
         attr: [(type = $section_type_name:ident) => ($section_type_name)];
-        example: "type = untyped | typed | mutable | reference";
-        validate: [(untyped), (typed), (mutable), (reference)];
+        example: "type = untyped | typed | mutable | movable | reference";
+        validate: [(untyped), (typed), (mutable), (movable), (reference)];
     };
     unsafe {
         attr: [(unsafe) => (unsafe)];
@@ -128,12 +131,12 @@ pub mod __support {
     #[macro_export]
     macro_rules! __add_used {
         (
-            $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
+            $ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             $(#[$meta:meta])*
             $vis:vis static $ident:ident : $($static:tt)*
         ) => {
             $crate::__add_section_link_attribute_impl!(
-                $section $type $name $($aux)? #[$attr = __]
+                $ref_or_item $section $type $name $($aux)? #[$attr = __]
                 $(#[$meta])*
                 #[used]
                 #[cfg_attr(target_os = "aix", export_name = concat!("_", env!("CARGO_PKG_NAME"), "_",
@@ -150,12 +153,12 @@ pub mod __support {
     #[macro_export]
     macro_rules! __add_used {
         (
-            $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
+            $ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             $(#[$meta:meta])*
             $vis:vis static $ident:ident : $($static:tt)*
         ) => {
             $crate::__add_section_link_attribute_impl!(
-                $section $type $name $($aux)? #[$attr = __]
+                $ref_or_item $section $type $name $($aux)? #[$attr = __]
                 $(#[$meta])*
                 #[used(linker)]
                 #[cfg_attr(target_os = "aix", export_name = concat!("_", env!("CARGO_PKG_NAME"), "_",
@@ -171,7 +174,7 @@ pub mod __support {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __address_of_symbol {
-        ($section:ident $type:ident $name:ident $($aux:ident)?) => {
+        ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)?) => {
             // Miri does not support any of these linker-defined extern statics
             // see: https://github.com/rust-lang/miri/blob/master/src/shims/extern_static.rs#L15
             ::core::ptr::null() as *const ()
@@ -182,12 +185,12 @@ pub mod __support {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __address_of_symbol {
-        ($section:ident $type:ident $name:ident $($aux:ident)?) => {
+        ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)?) => {
             {
                 // These are not valid items, but they are valid pointers.
                 // We cannot safely use them - only take pointers to them.
                 $crate::__support::add_section_link_attribute!(
-                    $section $type $name $($aux)?
+                    $ref_or_item $section $type $name $($aux)?
                     #[link_name = __]
                     extern "C" {
                         static __SYMBOL: u8;
@@ -202,17 +205,17 @@ pub mod __support {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __add_section_link_attribute(
-        ($section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
+        ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             $(#[$meta:meta])*
             $vis:vis static $($static:tt)*
         ) => {
             $crate::__add_used!(
-                $section $type $name $($aux)? #[$attr = __]
+                $ref_or_item $section $type $name $($aux)? #[$attr = __]
                 $(#[$meta])*
                 $vis static $($static)*
             );
         };
-        ($section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
+        ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             extern "C" {
                 $(#[$meta:meta])*
                 $vis:vis static $($static:tt)*
@@ -220,17 +223,17 @@ pub mod __support {
         ) => {
             extern "C" {
                 $crate::__add_section_link_attribute_impl!(
-                    $section $type $name $($aux)? #[$attr = __]
+                    $ref_or_item $section $type $name $($aux)? #[$attr = __]
                     $(#[$meta])*
                     #[allow(unsafe_code)]
                     $vis static $($static)*
                 );
             }
         };
-        ($section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
+        ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             $($item:tt)*) => {
             $crate::__add_section_link_attribute_impl!(
-                $section $type $name $($aux)? #[$attr = __]
+                $ref_or_item $section $type $name $($aux)? #[$attr = __]
                 #[allow(unsafe_code)]
                 $($item)*
             );
@@ -241,10 +244,10 @@ pub mod __support {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __add_section_link_attribute_impl(
-        ($section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __] $($item:tt)*) => {
+        ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __] $($item:tt)*) => {
             $crate::__support::section_name!(
                 (#[$attr = __] #[allow(unsafe_code)] $($item)*)
-                $section $type $name $($aux)?
+                $ref_or_item $section $type $name $($aux)?
             );
         }
     );
@@ -253,9 +256,9 @@ pub mod __support {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __add_section_link_attribute_impl(
-        ($section:ident $type:ident $name:ident #[$attr:ident = __] $($item:tt)*) => {
+        ($ref_or_item:ident $section:ident $type:ident $name:ident #[$attr:ident = __] $($item:tt)*) => {
             #[$attr = $crate::__support::section_name!(
-                raw $section $type $name
+                raw $ref_or_item $section $type $name
             )] $($item)*
         }
     );
@@ -286,6 +289,12 @@ pub mod __support {
 
     #[macro_export]
     #[doc(hidden)]
+    macro_rules! __in_section_helper_macro_generic_movable {
+        (($($args:tt)*)) => { $crate::__support::in_section_crate!((@v=0 ; (source=section) ; (type=movable) ; $($args)*)); }
+    }
+
+    #[macro_export]
+    #[doc(hidden)]
     macro_rules! __in_section_helper_macro_generic_reference {
         (($($args:tt)*)) => { $crate::__support::in_section_crate!((@v=0 ; (source=section) ; (type=reference) ; $($args)*)); }
     }
@@ -310,7 +319,7 @@ pub mod __support {
         // Untyped items are placed in the data or code section as-is.
         (@untyped $section:tt, $($aux:ident)?, $($path:path)?, ($($meta:tt)*) ($vis:vis fn $($rest:tt)*)) => {
             $crate::__add_section_link_attribute!(
-                code section $section $($aux)?
+                item code section $section $($aux)?
                 #[link_section = __]
                 $($meta)*
                 $vis fn $($rest)*
@@ -323,7 +332,7 @@ pub mod __support {
         };
         (@untyped $section:tt, $($aux:ident)?, $($path:path)?, ($($meta:tt)*) ($($rest:tt)*)) => {
             $crate::__add_section_link_attribute!(
-                data section $section $($aux)?
+                item data section $section $($aux)?
                 #[link_section = __]
                 $($meta)*
                 $($rest)*
@@ -362,7 +371,7 @@ pub mod __support {
         (@typed[typed] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis static $ident:ident : $ty:ty = $value:expr;)) => {
             #[cfg(not(target_family = "wasm"))]
             $crate::__add_section_link_attribute!(
-                data section $section $($aux)?
+                item data section $section $($aux)?
                 #[link_section = __]
                 $($meta)*
                 $vis static $ident: $crate::__in_section_crate!(@type_select $path) = const{
@@ -389,7 +398,7 @@ pub mod __support {
 
                 #[cfg(not(target_family = "wasm"))]
                 $crate::__add_section_link_attribute!(
-                    data section $section $($aux)?
+                    item data section $section $($aux)?
                     #[link_section = __]
                     static __LINK_SECTION_CONST_ITEM: $crate::__support::SyncUnsafeCell<__InSecStoredTy> = $crate::__support::SyncUnsafeCell::new(__LINK_SECTION_CONST_ITEM_VALUE);
                 );
@@ -400,6 +409,49 @@ pub mod __support {
 
         (@typed[mutable] $($rest:tt)*) => {
             compile_error!("Only const items are supported in mutable sections");
+        };
+
+        // movable static items expose a MovableRef and submit hidden value/backref records.
+        (@typed[movable] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis static $ident:ident: $ty:ty = $value:expr;)) => {
+            $($meta)*
+            $vis static $ident: $crate::MovableRef<$crate::__in_section_crate!(@type_select $path)> = const {
+                type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
+                const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
+
+                $crate::__register_wasm_movable_item!(
+                    value=__LINK_SECTION_CONST_ITEM_VALUE,
+                    type=__InSecStoredTy,
+                    section=$section $($aux)?
+                );
+
+                #[cfg(not(target_family = "wasm"))]
+                $crate::__add_section_link_attribute!(
+                    item data section $section $($aux)?
+                    #[link_section = __]
+                    static __LINK_SECTION_CONST_ITEM: $crate::__support::SyncUnsafeCell<__InSecStoredTy> = $crate::__support::SyncUnsafeCell::new(__LINK_SECTION_CONST_ITEM_VALUE);
+                );
+
+                #[cfg(not(target_family = "wasm"))]
+                static __LINK_SECTION_MOVABLE_PTR: $crate::__support::SyncUnsafeCell<*const __InSecStoredTy> =
+                    $crate::__support::SyncUnsafeCell::new((&raw const __LINK_SECTION_CONST_ITEM).cast::<__InSecStoredTy>());
+
+                #[cfg(not(target_family = "wasm"))]
+                $crate::__add_section_link_attribute!(
+                    backref data section $section $($aux)?
+                    #[link_section = __]
+                    static __LINK_SECTION_MOVABLE_BACKREF: $crate::MovableBackref<__InSecStoredTy> =
+                        $crate::MovableBackref::new(
+                            (&raw const __LINK_SECTION_CONST_ITEM).cast::<__InSecStoredTy>(),
+                            &raw const __LINK_SECTION_MOVABLE_PTR,
+                        );
+                );
+
+                $crate::MovableRef::new(&__LINK_SECTION_MOVABLE_PTR)
+            };
+        };
+
+        (@typed[movable] $($rest:tt)*) => {
+            compile_error!("Only static items are supported in movable sections");
         };
 
         // const items are the same across all other types
@@ -413,7 +465,7 @@ pub mod __support {
 
                 #[cfg(not(target_family = "wasm"))]
                 $crate::__add_section_link_attribute!(
-                    data section $section $($aux)?
+                    item data section $section $($aux)?
                     #[link_section = __]
                     static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
                 );
@@ -435,7 +487,7 @@ pub mod __support {
             // On non-WASM platforms, we can store the value directly (repr(transparent) allows this).
             #[cfg(not(target_family="wasm"))]
             $crate::__add_section_link_attribute!(
-                data section $section $($aux)?
+                item data section $section $($aux)?
                 #[link_section = __]
                 $($meta)*
                 $vis static $ident: $crate::reference::Ref<$crate::__in_section_crate!(@type_select $path)> = $crate::reference::Ref::new($value);

--- a/link-section/src/platform/apple.rs
+++ b/link-section/src/platform/apple.rs
@@ -5,11 +5,25 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __get_section_apple {
+    (movable, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
+        {
+            $crate::__support::MovableBounds::new(
+                $crate::__support::PtrBounds::new(
+                    $crate::__address_of_symbol!(item data start $ident $($aux)?),
+                    $crate::__address_of_symbol!(item data end $ident $($aux)?),
+                ),
+                $crate::__support::PtrBounds::new(
+                    $crate::__address_of_symbol!(backref data start $ident $($aux)?),
+                    $crate::__address_of_symbol!(backref data end $ident $($aux)?),
+                ),
+            )
+        }
+    };
     ($section_type:ident, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
         {
             $crate::__support::PtrBounds::new(
-                $crate::__address_of_symbol!(data start $ident $($aux)?),
-                $crate::__address_of_symbol!(data end $ident $($aux)?),
+                $crate::__address_of_symbol!(item data start $ident $($aux)?),
+                $crate::__address_of_symbol!(item data end $ident $($aux)?),
             )
         }
     }
@@ -29,6 +43,7 @@ crate::__def_section_name! {
         data end =>     ("\x01section$end$__DATA$") __ ();
     }
     AUXILIARY = "_";
+    REFS = "_r_";
     MAX_LENGTH = 16;
     HASH_LENGTH = 6;
     VALID_SECTION_CHARS = "_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -102,26 +102,32 @@ impl PtrMovableBounds {
         Self { values, refs }
     }
 
+    /// Start pointer for the movable item section.
     #[inline(always)]
     pub fn start_ptr(&self) -> *const () {
         self.values.start_ptr()
     }
+    /// End pointer for the movable item section.
     #[inline(always)]
     pub fn end_ptr(&self) -> *const () {
         self.values.end_ptr()
     }
+    /// Length in bytes of the movable item section.
     #[inline(always)]
     pub fn byte_len(&self) -> usize {
         self.values.byte_len()
     }
+    /// Start pointer for the movable backref section.
     #[inline(always)]
     pub fn backrefs_start_ptr(&self) -> *const () {
         self.refs.start_ptr()
     }
+    /// End pointer for the movable backref section.
     #[inline(always)]
     pub fn backrefs_end_ptr(&self) -> *const () {
         self.refs.end_ptr()
     }
+    /// Length in bytes of the movable backref section.
     #[inline(always)]
     pub fn backrefs_byte_len(&self) -> usize {
         self.refs.byte_len()

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -18,24 +18,9 @@ pub use windows::{get_section, section_name};
 
 // Select the appropriate bounds type for the platform.
 #[cfg(target_family = "wasm")]
-pub use wasm::Bounds;
+pub use {wasm::Bounds, wasm::MovableBounds};
 #[cfg(not(target_family = "wasm"))]
-pub use PtrBounds as Bounds;
-
-/// Bounds for a movable section and its associated backref section.
-pub struct MovableBounds {
-    /// Bounds for the submitted values.
-    pub values: Bounds,
-    /// Bounds for the submitted backrefs.
-    pub refs: Bounds,
-}
-
-impl MovableBounds {
-    /// Create movable-section bounds.
-    pub const fn new(values: Bounds, refs: Bounds) -> Self {
-        Self { values, refs }
-    }
-}
+pub use {PtrBounds as Bounds, PtrMovableBounds as MovableBounds};
 
 /// Rejects section names that cannot be represented on the current target.
 pub const fn validate_section_name(name: &str) {
@@ -100,6 +85,46 @@ impl PtrBounds {
     /// Length in bytes (`end - start`).
     pub fn byte_len(&self) -> usize {
         self.end as usize - self.start as usize
+    }
+}
+
+/// Bounds for a movable section and its associated backref section.
+pub struct PtrMovableBounds {
+    /// Bounds for the submitted values.
+    values: PtrBounds,
+    /// Bounds for the submitted backrefs.
+    refs: PtrBounds,
+}
+
+impl PtrMovableBounds {
+    /// Create movable-section bounds.
+    pub const fn new(values: PtrBounds, refs: PtrBounds) -> Self {
+        Self { values, refs }
+    }
+
+    #[inline(always)]
+    pub fn start_ptr(&self) -> *const () {
+        self.values.start_ptr()
+    }
+    #[inline(always)]
+    pub fn end_ptr(&self) -> *const () {
+        self.values.end_ptr()
+    }
+    #[inline(always)]
+    pub fn byte_len(&self) -> usize {
+        self.values.byte_len()
+    }
+    #[inline(always)]
+    pub fn backrefs_start_ptr(&self) -> *const () {
+        self.refs.start_ptr()
+    }
+    #[inline(always)]
+    pub fn backrefs_end_ptr(&self) -> *const () {
+        self.refs.end_ptr()
+    }
+    #[inline(always)]
+    pub fn backrefs_byte_len(&self) -> usize {
+        self.refs.byte_len()
     }
 }
 

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -22,6 +22,21 @@ pub use wasm::Bounds;
 #[cfg(not(target_family = "wasm"))]
 pub use PtrBounds as Bounds;
 
+/// Bounds for a movable section and its associated backref section.
+pub struct MovableBounds {
+    /// Bounds for the submitted values.
+    pub values: Bounds,
+    /// Bounds for the submitted backrefs.
+    pub refs: Bounds,
+}
+
+impl MovableBounds {
+    /// Create movable-section bounds.
+    pub const fn new(values: Bounds, refs: Bounds) -> Self {
+        Self { values, refs }
+    }
+}
+
 /// Rejects section names that cannot be represented on the current target.
 pub const fn validate_section_name(name: &str) {
     if cfg!(target_vendor = "apple") {
@@ -102,6 +117,12 @@ impl<T> SyncUnsafeCell<T> {
             cell: ::core::cell::UnsafeCell::new(value),
         }
     }
+
+    /// Get a raw pointer to the contained value.
+    #[inline]
+    pub const fn get(&self) -> *mut T {
+        self.cell.get()
+    }
 }
 
 unsafe impl<T> Sync for SyncUnsafeCell<T> {}
@@ -136,6 +157,7 @@ macro_rules! __def_section_name {
             $__section:ident $__type:ident => $__prefix:tt __ $__suffix:tt;
         )*}
         AUXILIARY = $__aux_sep:literal;
+        REFS = $__refs_sep:literal;
         MAX_LENGTH = $__max_length:literal;
         HASH_LENGTH = $__hash_length:literal;
         VALID_SECTION_CHARS = $__valid_section_chars:literal;
@@ -145,22 +167,34 @@ macro_rules! __def_section_name {
         #[doc(hidden)]
         macro_rules! $__name {
             $(
-                (raw $__section $__type $name:ident) => {
+                (raw item $__section $__type $name:ident) => {
                     concat!(concat! $__prefix, stringify!($name), concat! $__suffix);
                 };
-                (raw $__section $__type $name:ident $aux:ident) => {
+                (raw item $__section $__type $name:ident $aux:ident) => {
                     concat!(concat! $__prefix, stringify!($name), $__aux_sep, stringify!($aux), concat! $__suffix);
                 };
-                ($pattern:tt $__section $__type $name:ident) => {
+                (raw backref $__section $__type $name:ident) => {
+                    concat!(concat! $__prefix, stringify!($name), $__refs_sep, concat! $__suffix);
+                };
+                (raw backref $__section $__type $name:ident $aux:ident) => {
+                    concat!(concat! $__prefix, stringify!($name), $__aux_sep, stringify!($aux), $__refs_sep, concat! $__suffix);
+                };
+                ($pattern:tt item $__section $__type $name:ident) => {
                     $crate::__support::hash!($pattern ($__prefix) $name ($__suffix) $__hash_length $__max_length $__valid_section_chars);
                 };
-                ($pattern:tt $__section $__type $name:ident $aux:ident) => {
+                ($pattern:tt item $__section $__type $name:ident $aux:ident) => {
                     $crate::__support::hash!($pattern ($__prefix) ($name $__aux_sep $aux) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
                 };
+                ($pattern:tt backref $__section $__type $name:ident) => {
+                    $crate::__support::hash!($pattern ($__prefix) ($name $__refs_sep) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
+                };
+                ($pattern:tt backref $__section $__type $name:ident $aux:ident) => {
+                    $crate::__support::hash!($pattern ($__prefix) ($name $__aux_sep $aux $__refs_sep) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
+                };
             )*
-            ($pattern:tt $unknown_section:ident $unknown_type:ident $name:ident) => {
+            ($pattern:tt $unknown_ref_or_item:ident $unknown_section:ident $unknown_type:ident $name:ident) => {
                 const _: () = {
-                    compile_error!(concat!("Unknown section type: `", stringify!($unknown_section), "/", stringify!($unknown_type), "`"));
+                    compile_error!(concat!("Unknown section type: `", stringify!($unknown_ref_or_item), "/", stringify!($unknown_section), "/", stringify!($unknown_type), "`"));
                 };
             };
         }

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -181,6 +181,26 @@ impl<T> Alignment<T> {
 /// Declares the section_name macro.
 #[macro_export]
 #[doc(hidden)]
+#[cfg(feature = "proc_macro")]
+macro_rules! __section_name_string {
+    ($name:ident $($rest:tt)*) => {
+        $crate::$name!((__) $($rest)*)
+    };
+}
+
+/// Declares the section_name macro.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "proc_macro"))]
+macro_rules! __section_name_string {
+    ($name:ident $($rest:tt)*) => {
+        $crate::$name!(raw $($rest)*)
+    };
+}
+
+/// Declares the section_name macro.
+#[macro_export]
+#[doc(hidden)]
 macro_rules! __def_section_name {
     (
         $__name:ident,
@@ -209,6 +229,12 @@ macro_rules! __def_section_name {
                 };
                 (raw backref $__section $__type $name:ident $aux:ident) => {
                     concat!(concat! $__prefix, stringify!($name), $__aux_sep, stringify!($aux), $__refs_sep, concat! $__suffix);
+                };
+                (string $ref_or_item:ident $__section $__type $name:ident) => {
+                    $crate::__section_name_string!($__name $ref_or_item $__section $__type $name)
+                };
+                (string $ref_or_item:ident $__section $__type $name:ident $aux:ident) => {
+                    $crate::__section_name_string!($__name $ref_or_item $__section $__type $name $aux)
                 };
                 ($pattern:tt item $__section $__type $name:ident) => {
                     $crate::__support::hash!($pattern ($__prefix) $name ($__suffix) $__hash_length $__max_length $__valid_section_chars);

--- a/link-section/src/platform/standard.rs
+++ b/link-section/src/platform/standard.rs
@@ -5,11 +5,25 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __get_section_standard {
+    (movable, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
+        {
+            $crate::__support::MovableBounds::new(
+                $crate::__support::PtrBounds::new(
+                    $crate::__address_of_symbol!(item data start $ident $($aux)?),
+                    $crate::__address_of_symbol!(item data end $ident $($aux)?),
+                ),
+                $crate::__support::PtrBounds::new(
+                    $crate::__address_of_symbol!(backref data start $ident $($aux)?),
+                    $crate::__address_of_symbol!(backref data end $ident $($aux)?),
+                ),
+            )
+        }
+    };
     ($section_type:ident, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
         {
             $crate::__support::PtrBounds::new(
-                $crate::__address_of_symbol!(data start $ident $($aux)?),
-                $crate::__address_of_symbol!(data end $ident $($aux)?),
+                $crate::__address_of_symbol!(item data start $ident $($aux)?),
+                $crate::__address_of_symbol!(item data end $ident $($aux)?),
             )
         }
     }
@@ -30,6 +44,7 @@ crate::__def_section_name! {
         code end =>     ("__stop_", "_text", "_link_section_") __ ();
     }
     AUXILIARY = "_";
+    REFS = "_r_";
     MAX_LENGTH = 64;
     HASH_LENGTH = 10;
     VALID_SECTION_CHARS = "_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -10,7 +10,7 @@ macro_rules! __get_section_wasm {
     (movable, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
         {
             static __LINK_SECTION_NAME: &'static str = $crate::__support::section_name!(
-                (__) item data bare $ident $($aux)?
+                string item data bare $ident $($aux)?
             );
             $crate::__support::add_section_link_attribute!(
                 item data bounds $ident $($aux)?
@@ -28,7 +28,7 @@ macro_rules! __get_section_wasm {
     ($section_type:ident, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
         {
             static __LINK_SECTION_NAME: &'static str = $crate::__support::section_name!(
-                (__) item data bare $ident $($aux)?
+                string item data bare $ident $($aux)?
             );
             $crate::__support::add_section_link_attribute!(
                 item data bounds $ident $($aux)?

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -7,13 +7,42 @@ use core::sync::atomic::{AtomicU8, Ordering};
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __get_section_wasm {
+    (movable, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
+        {
+            static __LINK_SECTION_NAME: &'static str = $crate::__support::section_name!(
+                (__) item data bare $ident $($aux)?
+            );
+            $crate::__support::add_section_link_attribute!(
+                item data bounds $ident $($aux)?
+                #[export_name = __]
+                #[used]
+                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo = $crate::__support::wasm::LinkSectionRawInfo::new::<$generic_ty>(__LINK_SECTION_NAME);
+            );
+
+            static __LINK_SECTION_BACKREF_NAME: &'static str = $crate::__support::section_name!(
+                (__) backref data bare $ident $($aux)?
+            );
+            $crate::__support::add_section_link_attribute!(
+                backref data bounds $ident $($aux)?
+                #[export_name = __]
+                #[used]
+                static __LINK_SECTION_BACKREF_INFO: $crate::__support::wasm::LinkSectionRawInfo =
+                    $crate::__support::wasm::LinkSectionRawInfo::new::<$crate::MovableBackref<$generic_ty>>(__LINK_SECTION_BACKREF_NAME);
+            );
+
+            $crate::__support::MovableBounds::new(
+                unsafe { $crate::__support::Bounds::new(&raw const __LINK_SECTION_INFO) },
+                unsafe { $crate::__support::Bounds::new(&raw const __LINK_SECTION_BACKREF_INFO) },
+            )
+        }
+    };
     ($section_type:ident, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
         {
             static __LINK_SECTION_NAME: &'static str = $crate::__support::section_name!(
-                raw data bare $ident $($aux)?
+                (__) item data bare $ident $($aux)?
             );
             $crate::__support::add_section_link_attribute!(
-                data bounds $ident $($aux)?
+                item data bounds $ident $($aux)?
                 #[export_name = __]
                 #[used]
                 static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo = $crate::__support::wasm::LinkSectionRawInfo::new::<$generic_ty>(__LINK_SECTION_NAME);
@@ -36,6 +65,7 @@ crate::__def_section_name! {
         data bounds =>  (".data", ".link_section.") __ (".bounds");
     }
     AUXILIARY = ".";
+    REFS = ".r.";
     MAX_LENGTH = 16;
     HASH_LENGTH = 6;
     VALID_SECTION_CHARS = "_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -49,6 +79,14 @@ macro_rules! __register_wasm_item {
     (value=$value:expr, $(ref=$ident:ident,)? section=$section:ident $($aux:ident)?) => {};
 }
 
+#[cfg(not(target_family = "wasm"))]
+#[doc(hidden)]
+#[macro_export]
+#[allow(unknown_lints, edition_2024_expr_fragment_specifier)]
+macro_rules! __register_wasm_movable_item {
+    (value=$value:expr, type=$ty:ty, section=$section:ident $($aux:ident)?) => {};
+}
+
 #[cfg(target_family = "wasm")]
 #[doc(hidden)]
 #[macro_export]
@@ -57,13 +95,13 @@ macro_rules! __register_wasm_item {
     (value=$value:expr, $(ref=$ident:ident,)? section=$section:ident $($aux:ident)?) => {
         // Register a counting item
         $crate::__add_section_link_attribute!(
-            data section $section $($aux)?
+            item data section $section $($aux)?
             #[link_section = __]
             static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
         );
 
         $crate::__add_section_link_attribute!(
-            data bounds $section $($aux)?
+            item data bounds $section $($aux)?
             #[link_name = __]
             extern "C" {
                 static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo;
@@ -85,6 +123,72 @@ macro_rules! __register_wasm_item {
                     $(
                         $ident.set(ptr);
                     )?
+                }
+            }
+            __LINK_SECTION_ITEM_FN
+        };
+    }
+}
+
+#[cfg(target_family = "wasm")]
+#[doc(hidden)]
+#[macro_export]
+#[allow(unknown_lints, edition_2024_expr_fragment_specifier)]
+macro_rules! __register_wasm_movable_item {
+    (value=$value:expr, type=$ty:ty, section=$section:ident $($aux:ident)?) => {
+        // Register counting items for both the value section and its backref section.
+        $crate::__add_section_link_attribute!(
+            item data section $section $($aux)?
+            #[link_section = __]
+            static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+        );
+        $crate::__add_section_link_attribute!(
+            backref data section $section $($aux)?
+            #[link_section = __]
+            static __LINK_SECTION_BACKREF_COUNTING_ITEM: u8 = 0;
+        );
+
+        $crate::__add_section_link_attribute!(
+            item data bounds $section $($aux)?
+            #[link_name = __]
+            extern "C" {
+                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo;
+            }
+        );
+        $crate::__add_section_link_attribute!(
+            backref data bounds $section $($aux)?
+            #[link_name = __]
+            extern "C" {
+                static __LINK_SECTION_BACKREF_INFO: $crate::__support::wasm::LinkSectionRawInfo;
+            }
+        );
+
+        static __LINK_SECTION_MOVABLE_PTR: $crate::__support::SyncUnsafeCell<*const $ty> =
+            $crate::__support::SyncUnsafeCell::new(::core::ptr::null());
+
+        #[link_section = ".init_array.0"]
+        #[used] // TODO: used(linker) with linktime_used_linker feature
+        #[allow(non_snake_case)]
+        static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() = {
+            extern "C" fn __LINK_SECTION_ITEM_FN() {
+                static DISARMED: ::core::sync::atomic::AtomicBool = ::core::sync::atomic::AtomicBool::new(false);
+                if DISARMED.swap(true, ::core::sync::atomic::Ordering::Relaxed) {
+                    return;
+                }
+                unsafe {
+                    let ptr = $crate::__support::wasm::register_wasm_link_section_item::<$ty>(
+                        &raw const __LINK_SECTION_INFO,
+                    );
+                    ::core::ptr::write(ptr, $value);
+                    *__LINK_SECTION_MOVABLE_PTR.get() = ptr;
+
+                    let backref = $crate::__support::wasm::register_wasm_link_section_item::<
+                        $crate::MovableBackref<$ty>,
+                    >(&raw const __LINK_SECTION_BACKREF_INFO);
+                    ::core::ptr::write(
+                        backref,
+                        $crate::MovableBackref::new(ptr, &raw const __LINK_SECTION_MOVABLE_PTR),
+                    );
                 }
             }
             __LINK_SECTION_ITEM_FN

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -204,8 +204,11 @@ impl<I: LinkSectionInfoInit> LinkSection<I> {
     ///
     /// # Safety
     ///
-    /// `info_ptr` must be non-null, properly aligned, and point to a live
-    /// `LinkSectionInfoLock<I>` for the duration of the returned handle.
+    /// `info_ptr` must be non-null, properly aligned, and point to the
+    /// macro-generated `LinkSectionInfoLock<I>` static for the section's entire
+    /// lifetime. The section must only be initialized and accessed from a single
+    /// thread during pre-`main` registration and ctor setup (concurrent access
+    /// during initialization may panic).
     pub const unsafe fn new(info_ptr: *const LinkSectionInfoLock<I>) -> Self {
         Self(unsafe { NonNull::new_unchecked(info_ptr as *mut _) })
     }
@@ -446,7 +449,9 @@ impl LinkSectionInfoInit for LinkSectionMovableInfo {
 ///
 /// # Safety
 ///
-/// This is called by the `in_section` procedural macro.
+/// For macro-generated use only. `info_ptr` must be the matching
+/// `LinkSectionInfoLock` static. Must run during single-threaded pre-`main`
+/// registration before the section is marked initialized.
 pub unsafe fn register_wasm_link_section_item<T>(
     info_ptr: *const LinkSectionInfoLock<LinkSectionInfo>,
 ) -> *mut T {
@@ -476,7 +481,9 @@ pub unsafe fn register_wasm_link_section_item<T>(
 ///
 /// # Safety
 ///
-/// This is called by the `in_section` procedural macro.
+/// For macro-generated use only. `info_ptr` and `backref_slot` must be the
+/// macro-generated statics for this submission. Must run during single-threaded
+/// pre-`main` registration before the section is marked initialized.
 pub unsafe fn register_wasm_link_section_movable_item<T: 'static>(
     info_ptr: *const LinkSectionInfoLock<LinkSectionMovableInfo>,
     backref_slot: *const UnsafeCell<*const T>,
@@ -537,7 +544,8 @@ impl Bounds {
     ///
     /// # Safety
     ///
-    /// This is called by the `section` procedural macro.
+    /// For macro-generated use only. `info_ptr` must be the section's
+    /// `LinkSectionInfoLock` static (see [`LinkSection::new`]).
     pub const unsafe fn new(info_ptr: *const LinkSectionInfoLock<LinkSectionInfo>) -> Self {
         unsafe { Self(LinkSection::new(info_ptr)) }
     }
@@ -576,7 +584,8 @@ impl MovableBounds {
     ///
     /// # Safety
     ///
-    /// This is called by the `section` procedural macro.
+    /// For macro-generated use only. `info_ptr` must be the movable section's
+    /// `LinkSectionInfoLock` static (see [`LinkSection::new`]).
     pub const unsafe fn new(info_ptr: *const LinkSectionInfoLock<LinkSectionMovableInfo>) -> Self {
         unsafe { Self(LinkSection::new(info_ptr)) }
     }

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -16,24 +16,13 @@ macro_rules! __get_section_wasm {
                 item data bounds $ident $($aux)?
                 #[export_name = __]
                 #[used]
-                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo = $crate::__support::wasm::LinkSectionRawInfo::new::<$generic_ty>(__LINK_SECTION_NAME);
+                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionInfoLock<$crate::__support::wasm::LinkSectionMovableInfo> =
+                    $crate::__support::wasm::LinkSectionInfoLock::new(
+                        $crate::__support::wasm::LinkSectionMovableInfo::new::<$generic_ty>(__LINK_SECTION_NAME)
+                    );
             );
 
-            static __LINK_SECTION_BACKREF_NAME: &'static str = $crate::__support::section_name!(
-                (__) backref data bare $ident $($aux)?
-            );
-            $crate::__support::add_section_link_attribute!(
-                backref data bounds $ident $($aux)?
-                #[export_name = __]
-                #[used]
-                static __LINK_SECTION_BACKREF_INFO: $crate::__support::wasm::LinkSectionRawInfo =
-                    $crate::__support::wasm::LinkSectionRawInfo::new::<$crate::MovableBackref<$generic_ty>>(__LINK_SECTION_BACKREF_NAME);
-            );
-
-            $crate::__support::MovableBounds::new(
-                unsafe { $crate::__support::Bounds::new(&raw const __LINK_SECTION_INFO) },
-                unsafe { $crate::__support::Bounds::new(&raw const __LINK_SECTION_BACKREF_INFO) },
-            )
+            unsafe { $crate::__support::MovableBounds::new(&raw const __LINK_SECTION_INFO) }
         }
     };
     ($section_type:ident, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
@@ -45,7 +34,10 @@ macro_rules! __get_section_wasm {
                 item data bounds $ident $($aux)?
                 #[export_name = __]
                 #[used]
-                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo = $crate::__support::wasm::LinkSectionRawInfo::new::<$generic_ty>(__LINK_SECTION_NAME);
+                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionInfoLock<$crate::__support::wasm::LinkSectionInfo> =
+                    $crate::__support::wasm::LinkSectionInfoLock::new(
+                        $crate::__support::wasm::LinkSectionInfo::new::<$generic_ty>(__LINK_SECTION_NAME)
+                    );
             );
 
             unsafe { $crate::__support::Bounds::new(&raw const __LINK_SECTION_INFO) }
@@ -54,6 +46,7 @@ macro_rules! __get_section_wasm {
 }
 
 pub use crate::__get_section_wasm as get_section;
+use crate::MovableBackref;
 
 crate::__def_section_name! {
     __section_name_wasm,
@@ -76,15 +69,7 @@ crate::__def_section_name! {
 #[macro_export]
 #[allow(unknown_lints, edition_2024_expr_fragment_specifier)]
 macro_rules! __register_wasm_item {
-    (value=$value:expr, $(ref=$ident:ident,)? section=$section:ident $($aux:ident)?) => {};
-}
-
-#[cfg(not(target_family = "wasm"))]
-#[doc(hidden)]
-#[macro_export]
-#[allow(unknown_lints, edition_2024_expr_fragment_specifier)]
-macro_rules! __register_wasm_movable_item {
-    (value=$value:expr, type=$ty:ty, section=$section:ident $($aux:ident)?) => {};
+    ($($args:tt)*) => {};
 }
 
 #[cfg(target_family = "wasm")]
@@ -92,7 +77,43 @@ macro_rules! __register_wasm_movable_item {
 #[macro_export]
 #[allow(unknown_lints, edition_2024_expr_fragment_specifier)]
 macro_rules! __register_wasm_item {
-    (value=$value:expr, $(ref=$ident:ident,)? section=$section:ident $($aux:ident)?) => {
+    (movable, value=$value:expr, slot=$slot:expr, section=$section:ident $($aux:ident)?) => {
+        // Register a counting item.
+        $crate::__add_section_link_attribute!(
+            item data section $section $($aux)?
+            #[link_section = __]
+            static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+        );
+
+        $crate::__add_section_link_attribute!(
+            item data bounds $section $($aux)?
+            #[link_name = __]
+            extern "C" {
+                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionInfoLock<$crate::__support::wasm::LinkSectionMovableInfo>;
+            }
+        );
+
+        #[link_section = ".init_array.0"]
+        #[used] // TODO: used(linker) with linktime_used_linker feature
+        #[allow(non_snake_case)]
+        static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() = {
+            extern "C" fn __LINK_SECTION_ITEM_FN() {
+                static DISARMED: ::core::sync::atomic::AtomicBool = ::core::sync::atomic::AtomicBool::new(false);
+                if DISARMED.swap(true, ::core::sync::atomic::Ordering::Relaxed) {
+                    return;
+                }
+                unsafe {
+                    let ptr = $crate::__support::wasm::register_wasm_link_section_movable_item::<_>(
+                        &raw const __LINK_SECTION_INFO,
+                        $slot,
+                    );
+                    ::core::ptr::write(ptr as *mut _, $value);
+                }
+            }
+            __LINK_SECTION_ITEM_FN
+        };
+    };
+    ($section_type:ident, value=$value:expr, $(ref=$ident:ident,)? section=$section:ident $($aux:ident)?) => {
         // Register a counting item
         $crate::__add_section_link_attribute!(
             item data section $section $($aux)?
@@ -104,7 +125,7 @@ macro_rules! __register_wasm_item {
             item data bounds $section $($aux)?
             #[link_name = __]
             extern "C" {
-                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo;
+                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionInfoLock<$crate::__support::wasm::LinkSectionInfo>;
             }
         );
 
@@ -123,72 +144,6 @@ macro_rules! __register_wasm_item {
                     $(
                         $ident.set(ptr);
                     )?
-                }
-            }
-            __LINK_SECTION_ITEM_FN
-        };
-    }
-}
-
-#[cfg(target_family = "wasm")]
-#[doc(hidden)]
-#[macro_export]
-#[allow(unknown_lints, edition_2024_expr_fragment_specifier)]
-macro_rules! __register_wasm_movable_item {
-    (value=$value:expr, type=$ty:ty, section=$section:ident $($aux:ident)?) => {
-        // Register counting items for both the value section and its backref section.
-        $crate::__add_section_link_attribute!(
-            item data section $section $($aux)?
-            #[link_section = __]
-            static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
-        );
-        $crate::__add_section_link_attribute!(
-            backref data section $section $($aux)?
-            #[link_section = __]
-            static __LINK_SECTION_BACKREF_COUNTING_ITEM: u8 = 0;
-        );
-
-        $crate::__add_section_link_attribute!(
-            item data bounds $section $($aux)?
-            #[link_name = __]
-            extern "C" {
-                static __LINK_SECTION_INFO: $crate::__support::wasm::LinkSectionRawInfo;
-            }
-        );
-        $crate::__add_section_link_attribute!(
-            backref data bounds $section $($aux)?
-            #[link_name = __]
-            extern "C" {
-                static __LINK_SECTION_BACKREF_INFO: $crate::__support::wasm::LinkSectionRawInfo;
-            }
-        );
-
-        static __LINK_SECTION_MOVABLE_PTR: $crate::__support::SyncUnsafeCell<*const $ty> =
-            $crate::__support::SyncUnsafeCell::new(::core::ptr::null());
-
-        #[link_section = ".init_array.0"]
-        #[used] // TODO: used(linker) with linktime_used_linker feature
-        #[allow(non_snake_case)]
-        static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() = {
-            extern "C" fn __LINK_SECTION_ITEM_FN() {
-                static DISARMED: ::core::sync::atomic::AtomicBool = ::core::sync::atomic::AtomicBool::new(false);
-                if DISARMED.swap(true, ::core::sync::atomic::Ordering::Relaxed) {
-                    return;
-                }
-                unsafe {
-                    let ptr = $crate::__support::wasm::register_wasm_link_section_item::<$ty>(
-                        &raw const __LINK_SECTION_INFO,
-                    );
-                    ::core::ptr::write(ptr, $value);
-                    *__LINK_SECTION_MOVABLE_PTR.get() = ptr;
-
-                    let backref = $crate::__support::wasm::register_wasm_link_section_item::<
-                        $crate::MovableBackref<$ty>,
-                    >(&raw const __LINK_SECTION_BACKREF_INFO);
-                    ::core::ptr::write(
-                        backref,
-                        $crate::MovableBackref::new(ptr, &raw const __LINK_SECTION_MOVABLE_PTR),
-                    );
                 }
             }
             __LINK_SECTION_ITEM_FN
@@ -242,17 +197,17 @@ enum LockState {
 ///
 /// Note that we cannot predict when the first access will be.
 #[derive(Clone, Copy)]
-pub struct LinkSection(NonNull<LinkSectionRawInfo>);
+pub struct LinkSection<I>(NonNull<LinkSectionInfoLock<I>>);
 
-impl LinkSection {
-    /// Create a new link section.
-    pub const fn new(info_ptr: NonNull<LinkSectionRawInfo>) -> Self {
-        Self(info_ptr)
+impl<I: LinkSectionInfoInit> LinkSection<I> {
+    /// Get a handle to the lock.
+    pub const unsafe fn new(info_ptr: *const LinkSectionInfoLock<I>) -> Self {
+        Self(unsafe { NonNull::new_unchecked(info_ptr as *mut _) })
     }
 
     /// Lock the link section and return a guard.
     #[inline(always)]
-    pub fn lock<'a>(&'a self) -> LinkSectionLockGuard<'a> {
+    pub fn lock<'a>(&'a self) -> LinkSectionLockGuard<'a, I> {
         let lock_state = unsafe { self.lock_ref() };
         if let Err(old) = lock_state.compare_exchange(
             LockState::Unlocked as _,
@@ -268,7 +223,7 @@ impl LinkSection {
 
     #[cold]
     #[inline(never)]
-    fn maybe_lock_uninit<'a>(&'a self, old: u8) -> LinkSectionLockGuard<'a> {
+    fn maybe_lock_uninit<'a>(&'a self, old: u8) -> LinkSectionLockGuard<'a, I> {
         let lock_state = unsafe { self.lock_ref() };
         if old == LockState::Uninitialized as u8 {
             if lock_state
@@ -302,7 +257,7 @@ impl LinkSection {
 
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
-    unsafe fn as_mut(&self) -> &mut LinkSectionInfo {
+    unsafe fn as_mut(&self) -> &mut I {
         unsafe {
             let unsafe_cell = ptr::addr_of!((*self.0.as_ptr()).info);
             // as_mut_unchecked when we bump MSRV
@@ -312,19 +267,19 @@ impl LinkSection {
 }
 
 /// Lightweight lock guard for the link section.
-pub struct LinkSectionLockGuard<'a>(&'a AtomicU8, &'a mut LinkSectionInfo);
-impl<'a> core::ops::Deref for LinkSectionLockGuard<'a> {
-    type Target = LinkSectionInfo;
+pub struct LinkSectionLockGuard<'a, I>(&'a AtomicU8, &'a mut I);
+impl<'a, I> core::ops::Deref for LinkSectionLockGuard<'a, I> {
+    type Target = I;
     fn deref(&self) -> &Self::Target {
         self.1
     }
 }
-impl<'a> core::ops::DerefMut for LinkSectionLockGuard<'a> {
+impl<'a, I> core::ops::DerefMut for LinkSectionLockGuard<'a, I> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.1
     }
 }
-impl<'a> Drop for LinkSectionLockGuard<'a> {
+impl<'a, I> Drop for LinkSectionLockGuard<'a, I> {
     fn drop(&mut self) {
         self.0.store(LockState::Unlocked as _, Ordering::Release);
     }
@@ -332,16 +287,20 @@ impl<'a> Drop for LinkSectionLockGuard<'a> {
 
 /// The current state of the link section.
 #[repr(C)]
-pub struct LinkSectionRawInfo {
+pub struct LinkSectionInfoLock<I> {
     lock: AtomicU8,
-    info: UnsafeCell<LinkSectionInfo>,
+    info: UnsafeCell<I>,
 }
 
 // SAFETY:
 
 // Mutation of `LinkSectionInfo` is guarded by `LinkSection::lock`, which
 // synchronize via `AtomicU8`.
-unsafe impl Sync for LinkSectionRawInfo {}
+unsafe impl<I> Sync for LinkSectionInfoLock<I> {}
+
+pub trait LinkSectionInfoInit {
+    fn initialize(&mut self) -> usize;
+}
 
 /// A record describing the WASM link section.
 #[repr(C)]
@@ -356,28 +315,56 @@ pub struct LinkSectionInfo {
     align_of: usize,
 }
 
-impl LinkSectionRawInfo {
-    /// Create a new link section raw info.
-    pub const fn new<T>(name: &'static str) -> Self {
+impl LinkSectionInfo {
+    pub const fn new<T: 'static>(name: &'static str) -> Self {
         Self {
-            lock: AtomicU8::new(LockState::Uninitialized as _),
-            info: UnsafeCell::new(LinkSectionInfo {
-                state: LinkSectionState::Uninitialized as _,
-                name_length: name.len() as _,
-                name: name.as_ptr(),
-                start: ptr::null_mut(),
-                end: ptr::null_mut(),
-                current: ptr::null_mut(),
-                size_of: ::core::mem::size_of::<T>(),
-                align_of: ::core::mem::align_of::<T>(),
-            }),
+            state: LinkSectionState::Uninitialized as _,
+            name_length: name.len() as _,
+            name: name.as_ptr(),
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+            current: ptr::null_mut(),
+            size_of: ::core::mem::size_of::<T>(),
+            align_of: ::core::mem::align_of::<T>(),
         }
     }
 }
 
-impl LinkSectionInfo {
+#[repr(C)]
+pub struct LinkSectionMovableInfo {
+    base: LinkSectionInfo,
+    backrefs_start: *const (),
+    backrefs_current: *const (),
+    backrefs_end: *const (),
+}
+
+const BACKREF_SIZE_OF: usize = ::core::mem::size_of::<crate::MovableBackref<()>>();
+const BACKREF_ALIGN_OF: usize = ::core::mem::align_of::<crate::MovableBackref<()>>();
+
+impl LinkSectionMovableInfo {
+    pub const fn new<T: 'static>(name: &'static str) -> Self {
+        Self {
+            base: LinkSectionInfo::new::<T>(name),
+            backrefs_start: ptr::null_mut(),
+            backrefs_current: ptr::null_mut(),
+            backrefs_end: ptr::null_mut(),
+        }
+    }
+}
+
+impl<I> LinkSectionInfoLock<I> {
+    /// Create a new link section raw info.
+    pub const fn new(info: I) -> Self {
+        Self {
+            lock: AtomicU8::new(LockState::Uninitialized as _),
+            info: UnsafeCell::new(info),
+        }
+    }
+}
+
+impl LinkSectionInfoInit for LinkSectionInfo {
     /// Initialize the link section.
-    pub fn initialize(&mut self) {
+    fn initialize(&mut self) -> usize {
         let size =
             unsafe { read_custom_section(self.name, self.name_length as _, ptr::null_mut(), 0) };
 
@@ -390,7 +377,7 @@ impl LinkSectionInfo {
             self.end = dangling;
             self.current = dangling;
             self.state = LinkSectionState::Initialized as _;
-            return;
+            return 0;
         }
 
         let layout_bytes = size
@@ -408,6 +395,39 @@ impl LinkSectionInfo {
             self.end = (ptr as *mut u8).add(layout_bytes) as *const ();
         }
         self.state = LinkSectionState::Initializing as _;
+
+        size
+    }
+}
+
+impl LinkSectionInfoInit for LinkSectionMovableInfo {
+    fn initialize(&mut self) -> usize {
+        let size = self.base.initialize();
+        if size == 0 {
+            let dangling = NonNull::<u8>::dangling().as_ptr() as *const ();
+            self.backrefs_start = dangling;
+            self.backrefs_current = dangling;
+            self.backrefs_end = dangling;
+            return 0;
+        }
+
+        let layout_bytes = size
+            .checked_mul(BACKREF_SIZE_OF)
+            .unwrap_or_else(|| panic!("Link section backref size overflow"));
+        unsafe {
+            // We got these from a type, so they are always valid.
+            let ptr = allocate(
+                Layout::from_size_align(layout_bytes, BACKREF_ALIGN_OF).unwrap_unchecked(),
+            );
+            if ptr.is_null() {
+                panic!("Link section backref allocation failed");
+            }
+            self.backrefs_start = ptr as *const ();
+            self.backrefs_current = ptr as *const ();
+            self.backrefs_end = (ptr as *mut u8).add(layout_bytes) as *const ();
+        }
+
+        size
     }
 }
 
@@ -416,8 +436,10 @@ impl LinkSectionInfo {
 /// # Safety
 ///
 /// This is called by the `in_section` procedural macro.
-pub unsafe fn register_wasm_link_section_item<T>(info_ptr: *const LinkSectionRawInfo) -> *mut T {
-    let link_section = unsafe { LinkSection::new(NonNull::new_unchecked(info_ptr as _)) };
+pub unsafe fn register_wasm_link_section_item<T>(
+    info_ptr: *const LinkSectionInfoLock<LinkSectionInfo>,
+) -> *mut T {
+    let link_section = unsafe { LinkSection::new(info_ptr) };
     let mut info = link_section.lock();
 
     unsafe {
@@ -439,6 +461,49 @@ pub unsafe fn register_wasm_link_section_item<T>(info_ptr: *const LinkSectionRaw
     }
 }
 
+/// Register a movable link section item and its associated backref slot.
+///
+/// # Safety
+///
+/// This is called by the `in_section` procedural macro.
+pub unsafe fn register_wasm_link_section_movable_item<T: 'static>(
+    info_ptr: *const LinkSectionInfoLock<LinkSectionMovableInfo>,
+    backref_slot: *const UnsafeCell<*const T>,
+) -> *mut T {
+    let link_section = unsafe { LinkSection::new(info_ptr) };
+    let mut info = link_section.lock();
+
+    unsafe {
+        if info.base.state == LinkSectionState::Initialized as u8 {
+            panic!("Link section already initialized");
+        }
+
+        let slot = info.base.current;
+        let next = slot.cast::<u8>().add(info.base.size_of) as *const ();
+        if next > info.base.end {
+            panic!("Link section overflow: too many registered items");
+        }
+        info.base.current = next;
+
+        let backref = info.backrefs_current as *mut MovableBackref<T>;
+        let backref_next = backref.cast::<u8>().add(BACKREF_SIZE_OF) as *const ();
+        if backref_next > info.backrefs_end {
+            panic!("Link section backref overflow: too many registered items");
+        }
+        info.backrefs_current = backref_next;
+
+        if next == info.base.end {
+            info.base.state = LinkSectionState::Initialized as u8;
+        }
+
+        // Create a new backref record and set the existing slot to the new item.
+        ptr::write(backref, MovableBackref::new(backref_slot));
+        ptr::write(UnsafeCell::raw_get(backref_slot), slot.cast());
+
+        slot as *mut T
+    }
+}
+
 #[cfg(target_family = "wasm")]
 unsafe fn allocate(layout: Layout) -> *mut () {
     use alloc::alloc::alloc;
@@ -454,7 +519,7 @@ unsafe fn allocate(_layout: Layout) -> *mut () {
 /// On WASM, we use an atomic pointer to the start and end of the
 /// section. The host environment is responsible for registering the
 /// section with the runtime.
-pub struct Bounds(LinkSection);
+pub struct Bounds(LinkSection<LinkSectionInfo>);
 
 impl Bounds {
     /// Create a new bounds struct.
@@ -462,10 +527,8 @@ impl Bounds {
     /// # Safety
     ///
     /// This is called by the `section` procedural macro.
-    pub const unsafe fn new(info_ptr: *const LinkSectionRawInfo) -> Self {
-        Self(LinkSection::new(unsafe {
-            NonNull::new_unchecked(info_ptr as _)
-        }))
+    pub const unsafe fn new(info_ptr: *const LinkSectionInfoLock<LinkSectionInfo>) -> Self {
+        unsafe { Self(LinkSection::new(info_ptr)) }
     }
 
     /// Get the start pointer of the link section.
@@ -491,5 +554,70 @@ impl Bounds {
     pub fn byte_len(&self) -> usize {
         let lock = self.0.lock();
         unsafe { (lock.end.cast::<u8>()).offset_from(lock.start.cast::<u8>()) as usize }
+    }
+}
+
+pub struct MovableBounds(LinkSection<LinkSectionMovableInfo>);
+
+impl MovableBounds {
+    /// Create a new movable bounds struct.
+    ///
+    /// # Safety
+    ///
+    /// This is called by the `section` procedural macro.
+    pub const unsafe fn new(info_ptr: *const LinkSectionInfoLock<LinkSectionMovableInfo>) -> Self {
+        unsafe { Self(LinkSection::new(info_ptr)) }
+    }
+
+    /// Get the start pointer of the movable item section.
+    pub fn start_ptr(&self) -> *const () {
+        let lock = self.0.lock();
+        if lock.base.state != LinkSectionState::Initialized as u8 {
+            panic!("Link section not initialized: possible ctor ordering issue");
+        }
+        lock.base.start
+    }
+
+    /// Get the end pointer of the movable item section.
+    pub fn end_ptr(&self) -> *const () {
+        let lock = self.0.lock();
+        if lock.base.state != LinkSectionState::Initialized as u8 {
+            panic!("Link section not initialized: possible ctor ordering issue");
+        }
+        lock.base.end
+    }
+
+    /// This is intentionally safe to call before the section is fully
+    /// initialized.
+    pub fn byte_len(&self) -> usize {
+        let lock = self.0.lock();
+        unsafe { (lock.base.end.cast::<u8>()).offset_from(lock.base.start.cast::<u8>()) as usize }
+    }
+
+    /// Get the start pointer of the movable backref section.
+    pub fn backrefs_start_ptr(&self) -> *const () {
+        let lock = self.0.lock();
+        if lock.base.state != LinkSectionState::Initialized as u8 {
+            panic!("Link section not initialized: possible ctor ordering issue");
+        }
+        lock.backrefs_start
+    }
+
+    /// Get the end pointer of the movable backref section.
+    pub fn backrefs_end_ptr(&self) -> *const () {
+        let lock = self.0.lock();
+        if lock.base.state != LinkSectionState::Initialized as u8 {
+            panic!("Link section not initialized: possible ctor ordering issue");
+        }
+        lock.backrefs_end
+    }
+
+    /// This is intentionally safe to call before the section is fully
+    /// initialized.
+    pub fn backrefs_byte_len(&self) -> usize {
+        let lock = self.0.lock();
+        unsafe {
+            (lock.backrefs_end.cast::<u8>()).offset_from(lock.backrefs_start.cast::<u8>()) as usize
+        }
     }
 }

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -201,6 +201,11 @@ pub struct LinkSection<I>(NonNull<LinkSectionInfoLock<I>>);
 
 impl<I: LinkSectionInfoInit> LinkSection<I> {
     /// Get a handle to the lock.
+    ///
+    /// # Safety
+    ///
+    /// `info_ptr` must be non-null, properly aligned, and point to a live
+    /// `LinkSectionInfoLock<I>` for the duration of the returned handle.
     pub const unsafe fn new(info_ptr: *const LinkSectionInfoLock<I>) -> Self {
         Self(unsafe { NonNull::new_unchecked(info_ptr as *mut _) })
     }
@@ -298,7 +303,10 @@ pub struct LinkSectionInfoLock<I> {
 // synchronize via `AtomicU8`.
 unsafe impl<I> Sync for LinkSectionInfoLock<I> {}
 
+/// Initialization behavior for WASM link-section metadata records.
 pub trait LinkSectionInfoInit {
+    /// Initialize the backing storage and return the number of registered
+    /// items expected in the section.
     fn initialize(&mut self) -> usize;
 }
 
@@ -316,6 +324,7 @@ pub struct LinkSectionInfo {
 }
 
 impl LinkSectionInfo {
+    /// Create metadata for a WASM link section storing `T`.
     pub const fn new<T: 'static>(name: &'static str) -> Self {
         Self {
             state: LinkSectionState::Uninitialized as _,
@@ -330,6 +339,7 @@ impl LinkSectionInfo {
     }
 }
 
+/// A record describing a movable WASM link section and its backref storage.
 #[repr(C)]
 pub struct LinkSectionMovableInfo {
     base: LinkSectionInfo,
@@ -342,6 +352,7 @@ const BACKREF_SIZE_OF: usize = ::core::mem::size_of::<crate::MovableBackref<()>>
 const BACKREF_ALIGN_OF: usize = ::core::mem::align_of::<crate::MovableBackref<()>>();
 
 impl LinkSectionMovableInfo {
+    /// Create metadata for a movable WASM link section storing `T`.
     pub const fn new<T: 'static>(name: &'static str) -> Self {
         Self {
             base: LinkSectionInfo::new::<T>(name),
@@ -557,6 +568,7 @@ impl Bounds {
     }
 }
 
+/// Runtime bounds for a WASM movable link section and its backref section.
 pub struct MovableBounds(LinkSection<LinkSectionMovableInfo>);
 
 impl MovableBounds {

--- a/link-section/src/platform/windows.rs
+++ b/link-section/src/platform/windows.rs
@@ -6,6 +6,61 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __get_section_windows {
+    // Movable sections have an additional backref section.
+    (movable, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
+        {
+            use $crate::__support::Alignment;
+            use $crate::__support::PtrBounds;
+            use $crate::__support::add_section_link_attribute;
+            use core::mem;
+            use $crate::__support::SyncUnsafeCell;
+
+            if cfg!(miri) {
+                // Miri doesn't support link section sorting
+                $crate::__support::MovableBounds::new(
+                    PtrBounds::new(::core::ptr::null(), ::core::ptr::null()),
+                    PtrBounds::new(::core::ptr::null(), ::core::ptr::null()),
+                )
+            } else {
+                add_section_link_attribute!(
+                    item data start $ident $($aux)?
+                    #[link_section = __]
+                    static __START: SyncUnsafeCell<Alignment<$generic_ty>> = SyncUnsafeCell::new(Alignment::new());
+                );
+                let start = unsafe {
+                    let start = &raw const __START;
+                    start.cast::<u8>().add(mem::size_of::<Alignment<$generic_ty>>()) as *const()
+                };
+                add_section_link_attribute!(
+                    item data end $ident $($aux)?
+                    #[link_section = __]
+                    static __END: SyncUnsafeCell<Alignment<$generic_ty>> = SyncUnsafeCell::new(Alignment::new());
+                );
+                let end = unsafe { &raw const __END as *const () };
+
+                add_section_link_attribute!(
+                    backref data start $ident $($aux)?
+                    #[link_section = __]
+                    static __REF_START: Alignment<$crate::MovableBackref<$generic_ty>> = Alignment::new();
+                );
+                let ref_start = unsafe {
+                    let start = &raw const __REF_START;
+                    start.cast::<u8>().add(mem::size_of::<Alignment<$crate::MovableBackref<$generic_ty>>>()) as *const()
+                };
+                add_section_link_attribute!(
+                    backref data end $ident $($aux)?
+                    #[link_section = __]
+                    static __REF_END: Alignment<$crate::MovableBackref<$generic_ty>> = Alignment::new();
+                );
+                let ref_end = unsafe { &raw const __REF_END as *const () };
+
+                $crate::__support::MovableBounds::new(
+                    PtrBounds::new(start, end),
+                    PtrBounds::new(ref_start, ref_end),
+                )
+            }
+        }
+    };
     // Mutable sections must use UnsafeCell to match items
     (mutable, name=$ident:ident, type=$generic_ty:ty $(, aux=$aux:ident )?) => {
         {
@@ -20,7 +75,7 @@ macro_rules! __get_section_windows {
                 PtrBounds::new(::core::ptr::null(), ::core::ptr::null())
             } else {
                 add_section_link_attribute!(
-                    data start $ident $($aux)?
+                    item data start $ident $($aux)?
                     #[link_section = __]
                     static __START: SyncUnsafeCell<Alignment<$generic_ty>> = SyncUnsafeCell::new(Alignment::new());
                 );
@@ -29,7 +84,7 @@ macro_rules! __get_section_windows {
                     start.cast::<u8>().add(mem::size_of::<Alignment<$generic_ty>>()) as *const()
                 };
                 add_section_link_attribute!(
-                    data end $ident $($aux)?
+                    item data end $ident $($aux)?
                     #[link_section = __]
                     static __END: SyncUnsafeCell<Alignment<$generic_ty>> = SyncUnsafeCell::new(Alignment::new());
                 );
@@ -51,7 +106,7 @@ macro_rules! __get_section_windows {
                 PtrBounds::new(::core::ptr::null(), ::core::ptr::null())
             } else {
                 add_section_link_attribute!(
-                    data start $ident $($aux)?
+                    item data start $ident $($aux)?
                     #[link_section = __]
                     static __START: Alignment<$generic_ty> = Alignment::new();
                 );
@@ -60,7 +115,7 @@ macro_rules! __get_section_windows {
                     start.cast::<u8>().add(mem::size_of::<Alignment<$generic_ty>>()) as *const()
                 };
                 add_section_link_attribute!(
-                    data end $ident $($aux)?
+                    item data end $ident $($aux)?
                     #[link_section = __]
                     static __END: Alignment<$generic_ty> = Alignment::new();
                 );
@@ -87,6 +142,7 @@ crate::__def_section_name! {
         code end =>     (".text", "$") __ ("$c");
     }
     AUXILIARY = "$d$";
+    REFS = "$r$";
     MAX_LENGTH = 64;
     HASH_LENGTH = 10;
     VALID_SECTION_CHARS = "_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";

--- a/link-section/src/platform/windows.rs
+++ b/link-section/src/platform/windows.rs
@@ -41,7 +41,8 @@ macro_rules! __get_section_windows {
                 add_section_link_attribute!(
                     backref data start $ident $($aux)?
                     #[link_section = __]
-                    static __REF_START: Alignment<$crate::MovableBackref<$generic_ty>> = Alignment::new();
+                    static __REF_START: SyncUnsafeCell<Alignment<$crate::MovableBackref<$generic_ty>>> =
+                        SyncUnsafeCell::new(Alignment::new());
                 );
                 let ref_start = unsafe {
                     let start = &raw const __REF_START;
@@ -50,7 +51,8 @@ macro_rules! __get_section_windows {
                 add_section_link_attribute!(
                     backref data end $ident $($aux)?
                     #[link_section = __]
-                    static __REF_END: Alignment<$crate::MovableBackref<$generic_ty>> = Alignment::new();
+                    static __REF_END: SyncUnsafeCell<Alignment<$crate::MovableBackref<$generic_ty>>> =
+                        SyncUnsafeCell::new(Alignment::new());
                 );
                 let ref_end = unsafe { &raw const __REF_END as *const () };
 

--- a/link-section/src/section_parse.rs
+++ b/link-section/src/section_parse.rs
@@ -233,7 +233,7 @@ macro_rules! __section_parse_impl {
                 static SECTION: $collection = {
                 let section = $crate::__support::get_section!($section_type, name=$ident, type=$generic_ty $(, aux=$aux )?);
                     let name = $crate::__support::section_name!(
-                        raw item data bare $($aux)? $ident // swap
+                        string item data bare $ident $($aux)?
                     );
                     $crate::__support::validate_section_name(name);
                     unsafe { <$collection>::new(name, section) }

--- a/link-section/src/section_parse.rs
+++ b/link-section/src/section_parse.rs
@@ -122,6 +122,8 @@ macro_rules! __section_parse_impl {
     (@validate type=$type:tt final=TypedSection) => { compile_error!("Use #[section(typed)] to create a typed section"); };
     (@validate type=mutable final=TypedMutableSection) => {};
     (@validate type=$type:tt final=TypedMutableSection) => { compile_error!("Use #[section(mutable)] to create a mutable typed section"); };
+    (@validate type=movable final=TypedMovableSection) => {};
+    (@validate type=$type:tt final=TypedMovableSection) => { compile_error!("Use #[section(movable)] to create a movable typed section"); };
     (@validate type=reference final=TypedReferenceSection) => {};
     (@validate type=$type:tt final=TypedReferenceSection) => { compile_error!("Use #[section(reference)] to create a reference section"); };
     (@validate type=$type:tt final=$final:ident) => { compile_error!(concat!("Unexpected section type: ", stringify!($type), " for section type: ", stringify!($final))); };
@@ -231,7 +233,7 @@ macro_rules! __section_parse_impl {
                 static SECTION: $collection = {
                 let section = $crate::__support::get_section!($section_type, name=$ident, type=$generic_ty $(, aux=$aux )?);
                     let name = $crate::__support::section_name!(
-                        raw data bare $($aux)? $ident // swap
+                        raw item data bare $($aux)? $ident // swap
                     );
                     $crate::__support::validate_section_name(name);
                     unsafe { <$collection>::new(name, section) }
@@ -262,7 +264,7 @@ macro_rules! __section_parse_impl {
         const _: () = {
             // Ensure that untyped data sections are never empty.
             $crate::__add_section_link_attribute!(
-                data section $ident $($aux)?
+                item data section $ident $($aux)?
                 #[link_section = __]
                 static __LINK_SECTION_CONST_ITEM: u8 = 0;
             );
@@ -317,6 +319,10 @@ macro_rules! __section_declare_submission_macro {
     ([$dollar:tt] macro=(no_macro=(), proc_macro=$proc_macro:tt, macro_unique_name=$macro_unique_name:tt, args=(),) type=mutable vis=$vis:vis name=$name:ident) => {
         #[doc(hidden)]
         $vis use $crate::__in_section_helper_macro_generic_mutable as $name;
+    };
+    ([$dollar:tt] macro=(no_macro=(), proc_macro=$proc_macro:tt, macro_unique_name=$macro_unique_name:tt, args=(),) type=movable vis=$vis:vis name=$name:ident) => {
+        #[doc(hidden)]
+        $vis use $crate::__in_section_helper_macro_generic_movable as $name;
     };
     ([$dollar:tt] macro=(no_macro=(), proc_macro=$proc_macro:tt, macro_unique_name=$macro_unique_name:tt, args=(),) type=reference vis=$vis:vis name=$name:ident) => {
         #[doc(hidden)]

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -386,17 +386,18 @@ impl<T: 'static> TypedMovableSection<T> {
     ///
     /// The caller must ensure no other threads are accessing the movable slice.
     /// It is recommended to only use this in a `ctor`.
+    #[allow(unsafe_code)]
     pub unsafe fn sort_unstable(&self)
     where
         T: Ord,
     {
         // Trivial case.
-        let main = self.as_mut_slice();
+        let main = unsafe { self.as_mut_slice() };
         if main.len() <= 1 {
             return;
         }
 
-        let refs = self.as_mut_backrefs();
+        let refs = unsafe { self.as_mut_backrefs() };
         debug_assert_eq!(main.len(), refs.len());
 
         fn partition<T: Ord, R>(main: &mut [T], refs: &mut [R]) -> usize {
@@ -495,15 +496,8 @@ impl<T> MovableBackref<T> {
         Self { slot }
     }
 
-    /// Current value of the stable pointer slot.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure no other threads are accessing the movable slice.
-    /// No references must be live to any of the static items.
-    ///
-    /// It is recommended to only use this in a `ctor`.
-    pub unsafe fn current_ptr(&self) -> *const T {
+    /// Current value of the stable pointer slot as a pointer.
+    pub fn current_ptr(&self) -> *const T {
         unsafe { ptr::read(UnsafeCell::raw_get(self.slot)) }
     }
 

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -13,6 +13,10 @@ pub struct Section {
 }
 
 impl Section {
+    /// # Safety
+    ///
+    /// For macro-generated use only. `bounds` must match the linker-resolved
+    /// (or WASM-initialized) section range for `name`.
     #[doc(hidden)]
     pub const unsafe fn new(name: &'static str, bounds: Bounds) -> Self {
         Self { name, bounds }
@@ -61,6 +65,10 @@ pub trait IsUntypedSection {}
 
 macro_rules! impl_section_new {
     ($generic:ident) => {
+        /// # Safety
+        ///
+        /// For macro-generated use only. `bounds` must match the linker-resolved
+        /// (or WASM-initialized) section range for `name`.
         #[doc(hidden)]
         pub const unsafe fn new(name: &'static str, bounds: Bounds) -> Self {
             assert!(
@@ -210,6 +218,10 @@ impl_bounds_traits!(TypedSection<T>);
 /// underlying data is (unsafely) mutable and enumerable.
 ///
 /// Only `const` items may be submitted to a [`TypedMutableSection`].
+///
+/// Mutating the section (for example via [`TypedMutableSection::as_mut_slice`])
+/// requires exclusive access. See [Exclusive access](crate#exclusive-access) for
+/// more information.
 #[repr(C)]
 pub struct TypedMutableSection<T: 'static> {
     name: &'static str,
@@ -248,8 +260,8 @@ impl<T: 'static> TypedMutableSection<T> {
     ///
     /// # Safety
     ///
-    /// This cannot be safely used and is _absolutely unsound_ if any other
-    /// slices are live.
+    /// Mutating the section requires exclusive access. See
+    /// [Exclusive access](crate#exclusive-access) for more information.
     #[allow(clippy::mut_from_ref)]
     #[inline]
     pub unsafe fn as_mut_slice(&self) -> &mut [T] {
@@ -265,11 +277,16 @@ impl_bounds_traits!(TypedMutableSection<T>);
 
 /// A movable typed link section that can be used to store any sized type. The
 /// underlying data is (unsafely) mutable, enumerable, and expected to be
-/// relocated or reordered during startup initialization.
-///
-///
+/// reordered during startup initialization. Each item is paired with a
+/// [`MovableBackref`] that updates a stable [`MovableRef`] slot when the
+/// section is sorted.
 ///
 /// Only `static` items may be submitted to a [`TypedMovableSection`].
+///
+/// Mutating or reordering the section requires exclusive access. See
+/// [Exclusive access](crate#exclusive-access) for more information.
+/// [`TypedMovableSection::sort_unstable`] also updates every [`MovableRef`]; any
+/// `&T` obtained before sorting may be stale afterward.
 #[repr(C)]
 pub struct TypedMovableSection<T: 'static> {
     name: &'static str,
@@ -280,6 +297,10 @@ pub struct TypedMovableSection<T: 'static> {
 }
 
 impl<T: 'static> TypedMovableSection<T> {
+    /// # Safety
+    ///
+    /// For macro-generated use only. `bounds` must describe the final layout of
+    /// the linker (or WASM runtime) section after all items are registered.
     #[doc(hidden)]
     pub const unsafe fn new(name: &'static str, bounds: MovableBounds) -> Self {
         assert!(
@@ -312,8 +333,8 @@ impl<T: 'static> TypedMovableSection<T> {
     ///
     /// # Safety
     ///
-    /// This cannot be safely used and is _absolutely unsound_ if any other
-    /// slices are live.
+    /// Mutating the section requires exclusive access. See
+    /// [Exclusive access](crate#exclusive-access) for more information.
     #[allow(clippy::mut_from_ref)]
     #[inline]
     pub unsafe fn as_mut_slice(&self) -> &mut [T] {
@@ -329,9 +350,10 @@ impl<T: 'static> TypedMovableSection<T> {
     ///
     /// # Safety
     ///
-    /// This returns mutable access from a shared section handle and must not be
-    /// called while any other slices into either the value or backref sections
-    /// are live.
+    /// Mutating the backref section requires exclusive access. See
+    /// [Exclusive access](crate#exclusive-access) for more information. Do not
+    /// call while any other slice into either the value or backref linker
+    /// sections is live.
     #[allow(clippy::mut_from_ref)]
     #[inline]
     pub unsafe fn as_mut_backrefs(&self) -> &mut [MovableBackref<T>] {
@@ -384,8 +406,11 @@ impl<T: 'static> TypedMovableSection<T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure no other threads are accessing the movable slice.
-    /// It is recommended to only use this in a `ctor`.
+    /// Reordering the section requires exclusive access. See
+    /// [Exclusive access](crate#exclusive-access) for more information. After
+    /// this returns, every [`MovableRef`] slot points at the new location of its
+    /// item; any `&T` obtained through [`MovableRef`] before the sort must not
+    /// be used.
     #[allow(unsafe_code)]
     pub unsafe fn sort_unstable(&self)
     where
@@ -447,6 +472,10 @@ impl<T: 'static> TypedMovableSection<T> {
 impl_bounds_traits!(TypedMovableSection<T>);
 
 /// A reference to a movable item through a stable pointer slot.
+///
+/// The slot is updated when a [`TypedMovableSection`] is reordered (for example
+/// by [`TypedMovableSection::sort_unstable`]). Do not keep an `&T` from
+/// dereferencing this handle across such an update.
 #[repr(transparent)]
 pub struct MovableRef<T: 'static> {
     slot: SyncUnsafeCell<*const T>,
@@ -505,10 +534,9 @@ impl<T> MovableBackref<T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure no other threads are accessing the movable slice.
-    /// No references must be live to any of the static items.
-    ///
-    /// It is recommended to only use this in a `ctor`.
+    /// Updating the slot requires exclusive access. See
+    /// [Exclusive access](crate#exclusive-access) for more information. Any live
+    /// `&T` or [`MovableRef`] dereference may alias the old or new target.
     pub unsafe fn set_current_ptr(&self, ptr: *const T) {
         unsafe {
             ptr::write(UnsafeCell::raw_get(self.slot), ptr);
@@ -572,6 +600,11 @@ impl<T> Ref<T> {
         }
     }
 
+    /// # Safety
+    ///
+    /// For macro/runtime registration only. `ptr` must refer to the item's final
+    /// location in the WASM link section. Requires exclusive access. See
+    /// [Exclusive access](crate#exclusive-access) for more information.
     #[cfg(target_family = "wasm")]
     #[doc(hidden)]
     pub unsafe fn set(&self, ptr: *const T) {

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -1,4 +1,6 @@
-use crate::__support::Bounds;
+use core::sync::atomic::{AtomicU8, Ordering};
+
+use crate::__support::{Bounds, MovableBounds, SyncUnsafeCell};
 
 /// An untyped link section that can be used to store any type. The underlying
 /// data is not enumerable.
@@ -252,6 +254,267 @@ impl<T: 'static> TypedMutableSection<T> {
 }
 
 impl_bounds_traits!(TypedMutableSection<T>);
+
+/// A movable typed link section that can be used to store any sized type. The
+/// underlying data is (unsafely) mutable, enumerable, and expected to be
+/// relocated or reordered during startup initialization.
+///
+/// Only `const` items may be submitted to a [`TypedMovableSection`].
+#[repr(C)]
+pub struct TypedMovableSection<T: 'static> {
+    name: &'static str,
+    bounds: MovableBounds,
+    backref_state: AtomicU8,
+    _phantom: ::core::marker::PhantomData<T>,
+}
+
+impl<T: 'static> TypedMovableSection<T> {
+    #[doc(hidden)]
+    pub const unsafe fn new(name: &'static str, bounds: MovableBounds) -> Self {
+        assert!(
+            ::core::mem::size_of::<T>() > 0,
+            "Zero-sized types are not supported"
+        );
+        Self {
+            name,
+            bounds,
+            backref_state: AtomicU8::new(0),
+            _phantom: ::core::marker::PhantomData,
+        }
+    }
+
+    /// The start address of the section.
+    #[inline(always)]
+    pub fn start_ptr(&self) -> *const T {
+        self.bounds.values.start_ptr() as *const T
+    }
+
+    /// The end address of the section.
+    #[inline(always)]
+    pub fn end_ptr(&self) -> *const T {
+        self.bounds.values.end_ptr() as *const T
+    }
+
+    /// The stride of the typed section.
+    #[inline(always)]
+    pub const fn stride(&self) -> usize {
+        assert!(
+            ::core::mem::size_of::<T>() > 0
+                && ::core::mem::size_of::<T>() * 2 == ::core::mem::size_of::<[T; 2]>()
+        );
+        ::core::mem::size_of::<T>()
+    }
+
+    /// The byte length of the section.
+    #[inline]
+    pub fn byte_len(&self) -> usize {
+        self.bounds.values.byte_len()
+    }
+
+    /// The number of elements in the section.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.byte_len() / self.stride()
+    }
+
+    /// True if the section is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The section as a slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        if self.is_empty() {
+            &[]
+        } else {
+            unsafe { ::core::slice::from_raw_parts(self.start_ptr(), self.len()) }
+        }
+    }
+
+    /// The offset of the item in the section, if it is in the section.
+    #[inline]
+    pub fn offset_of(&self, item: &T) -> Option<usize> {
+        let ptr = item as *const T;
+        if ptr < self.start_ptr() || ptr >= self.end_ptr() {
+            None
+        } else {
+            Some(unsafe { ptr.offset_from(self.start_ptr()) as usize })
+        }
+    }
+
+    /// The start address of the section.
+    #[inline]
+    pub fn start_ptr_mut(&self) -> *mut T {
+        self.bounds.values.start_ptr() as *mut T
+    }
+
+    /// The end address of the section.
+    #[inline]
+    pub fn end_ptr_mut(&self) -> *mut T {
+        self.bounds.values.end_ptr() as *mut T
+    }
+
+    /// The section as a mutable slice.
+    ///
+    /// # Safety
+    ///
+    /// This cannot be safely used and is _absolutely unsound_ if any other
+    /// slices are live.
+    #[allow(clippy::mut_from_ref)]
+    #[inline]
+    pub unsafe fn as_mut_slice(&self) -> &mut [T] {
+        if self.is_empty() {
+            &mut []
+        } else {
+            unsafe { ::core::slice::from_raw_parts_mut(self.start_ptr() as *mut T, self.len()) }
+        }
+    }
+
+    /// The backrefs as a mutable slice, ordered to match the current value
+    /// section addresses.
+    ///
+    /// # Safety
+    ///
+    /// This returns mutable access from a shared section handle and must not be
+    /// called while any other slices into either the value or backref sections
+    /// are live.
+    #[allow(clippy::mut_from_ref)]
+    #[inline]
+    pub unsafe fn as_mut_backrefs(&self) -> &mut [MovableBackref<T>] {
+        let backrefs = if self.backrefs_is_empty() {
+            &mut []
+        } else {
+            unsafe {
+                ::core::slice::from_raw_parts_mut(
+                    self.backrefs_start_ptr() as *mut MovableBackref<T>,
+                    self.backrefs_len(),
+                )
+            }
+        };
+        unsafe { self.fixup_backrefs(backrefs) };
+        backrefs
+    }
+
+    /// The start address of the backref section.
+    #[inline(always)]
+    pub fn backrefs_start_ptr(&self) -> *const MovableBackref<T> {
+        self.bounds.refs.start_ptr() as *const MovableBackref<T>
+    }
+
+    /// The end address of the backref section.
+    #[inline(always)]
+    pub fn backrefs_end_ptr(&self) -> *const MovableBackref<T> {
+        self.bounds.refs.end_ptr() as *const MovableBackref<T>
+    }
+
+    /// The number of backref records in the section.
+    #[inline]
+    pub fn backrefs_len(&self) -> usize {
+        self.bounds.refs.byte_len() / ::core::mem::size_of::<MovableBackref<T>>()
+    }
+
+    /// True if there are no backrefs.
+    #[inline]
+    pub fn backrefs_is_empty(&self) -> bool {
+        self.backrefs_len() == 0
+    }
+
+    unsafe fn fixup_backrefs(&self, backrefs: &mut [MovableBackref<T>]) {
+        match self
+            .backref_state
+            .compare_exchange(0, 1, Ordering::Acquire, Ordering::Acquire)
+        {
+            Ok(_) => {}
+            Err(2) => return,
+            Err(_) => panic!("movable section backrefs already being initialized"),
+        }
+
+        if backrefs.len() != self.len() {
+            panic!("movable section backref count does not match item count");
+        }
+
+        backrefs.sort_unstable_by_key(|backref| backref.original);
+        self.backref_state.store(2, Ordering::Release);
+    }
+}
+
+impl_bounds_traits!(TypedMovableSection<T>);
+
+/// A reference to a movable item through a stable pointer slot.
+#[repr(transparent)]
+pub struct MovableRef<T: 'static> {
+    slot: &'static SyncUnsafeCell<*const T>,
+}
+
+impl<T> MovableRef<T> {
+    #[doc(hidden)]
+    pub const fn new(slot: &'static SyncUnsafeCell<*const T>) -> Self {
+        Self { slot }
+    }
+
+    /// Raw pointer to the value currently referenced by this slot.
+    pub fn as_ptr(&self) -> *const T {
+        unsafe { *self.slot.get() }
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn set(&self, ptr: *const T) {
+        unsafe {
+            *self.slot.get() = ptr;
+        }
+    }
+}
+
+impl<T> ::core::ops::Deref for MovableRef<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.as_ptr().as_ref().expect("MovableRef not initialized") }
+    }
+}
+
+unsafe impl<T> Send for MovableRef<T> where T: Send {}
+unsafe impl<T> Sync for MovableRef<T> where T: Sync {}
+
+/// A backref record submitted alongside each item in a [`TypedMovableSection`].
+#[repr(C)]
+pub struct MovableBackref<T: 'static> {
+    original: *const T,
+    slot: *const SyncUnsafeCell<*const T>,
+}
+
+impl<T> MovableBackref<T> {
+    #[doc(hidden)]
+    pub const fn new(original: *const T, slot: *const SyncUnsafeCell<*const T>) -> Self {
+        Self { original, slot }
+    }
+
+    /// Original value-section cell for this backref.
+    pub fn original_ptr(&self) -> *const T {
+        self.original
+    }
+
+    /// Current value of the stable pointer slot.
+    pub fn current_ptr(&self) -> *const T {
+        unsafe { *(*self.slot).get() }
+    }
+
+    /// Update the stable pointer slot.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `ptr` points to the logical item associated with
+    /// this backref.
+    pub unsafe fn set_current_ptr(&self, ptr: *const T) {
+        unsafe {
+            *(*self.slot).get() = ptr;
+        }
+    }
+}
+
+unsafe impl<T> Send for MovableBackref<T> where T: Send {}
+unsafe impl<T> Sync for MovableBackref<T> where T: Sync {}
 
 /// A typed link section that can be used to store any sized type. The
 /// underlying data is enumerable.

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -1,4 +1,8 @@
-use core::sync::atomic::{AtomicU8, Ordering};
+use core::{
+    cell::UnsafeCell,
+    ptr,
+    sync::atomic::{AtomicU8, Ordering},
+};
 
 use crate::__support::{Bounds, MovableBounds, SyncUnsafeCell};
 
@@ -57,7 +61,7 @@ unsafe impl Send for Section {}
 /// Marker: untyped [`Section`] handle.
 pub trait IsUntypedSection {}
 
-macro_rules! impl_bounds_fns {
+macro_rules! impl_section_new {
     ($generic:ident) => {
         #[doc(hidden)]
         pub const unsafe fn new(name: &'static str, bounds: Bounds) -> Self {
@@ -71,7 +75,11 @@ macro_rules! impl_bounds_fns {
                 _phantom: ::core::marker::PhantomData,
             }
         }
+    };
+}
 
+macro_rules! impl_bounds_fns {
+    ($generic:ident) => {
         /// The start address of the section.
         #[inline(always)]
         pub fn start_ptr(&self) -> *const T {
@@ -183,6 +191,7 @@ pub struct TypedSection<T: 'static> {
 }
 
 impl<T: 'static> TypedSection<T> {
+    impl_section_new!(T);
     impl_bounds_fns!(T);
 
     /// The offset of the item in the section, if it is in the section.
@@ -211,6 +220,7 @@ pub struct TypedMutableSection<T: 'static> {
 }
 
 impl<T: 'static> TypedMutableSection<T> {
+    impl_section_new!(T);
     impl_bounds_fns!(T);
 
     /// The offset of the item in the section, if it is in the section.
@@ -283,55 +293,7 @@ impl<T: 'static> TypedMovableSection<T> {
         }
     }
 
-    /// The start address of the section.
-    #[inline(always)]
-    pub fn start_ptr(&self) -> *const T {
-        self.bounds.values.start_ptr() as *const T
-    }
-
-    /// The end address of the section.
-    #[inline(always)]
-    pub fn end_ptr(&self) -> *const T {
-        self.bounds.values.end_ptr() as *const T
-    }
-
-    /// The stride of the typed section.
-    #[inline(always)]
-    pub const fn stride(&self) -> usize {
-        assert!(
-            ::core::mem::size_of::<T>() > 0
-                && ::core::mem::size_of::<T>() * 2 == ::core::mem::size_of::<[T; 2]>()
-        );
-        ::core::mem::size_of::<T>()
-    }
-
-    /// The byte length of the section.
-    #[inline]
-    pub fn byte_len(&self) -> usize {
-        self.bounds.values.byte_len()
-    }
-
-    /// The number of elements in the section.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.byte_len() / self.stride()
-    }
-
-    /// True if the section is empty.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// The section as a slice.
-    #[inline]
-    pub fn as_slice(&self) -> &[T] {
-        if self.is_empty() {
-            &[]
-        } else {
-            unsafe { ::core::slice::from_raw_parts(self.start_ptr(), self.len()) }
-        }
-    }
+    impl_bounds_fns!(T);
 
     /// The offset of the item in the section, if it is in the section.
     #[inline]
@@ -342,18 +304,6 @@ impl<T: 'static> TypedMovableSection<T> {
         } else {
             Some(unsafe { ptr.offset_from(self.start_ptr()) as usize })
         }
-    }
-
-    /// The start address of the section.
-    #[inline]
-    pub fn start_ptr_mut(&self) -> *mut T {
-        self.bounds.values.start_ptr() as *mut T
-    }
-
-    /// The end address of the section.
-    #[inline]
-    pub fn end_ptr_mut(&self) -> *mut T {
-        self.bounds.values.end_ptr() as *mut T
     }
 
     /// The section as a mutable slice.
@@ -383,42 +333,20 @@ impl<T: 'static> TypedMovableSection<T> {
     #[allow(clippy::mut_from_ref)]
     #[inline]
     pub unsafe fn as_mut_backrefs(&self) -> &mut [MovableBackref<T>] {
-        let backrefs = if self.backrefs_is_empty() {
+        let backrefs_len =
+            self.bounds.backrefs_byte_len() / ::core::mem::size_of::<MovableBackref<T>>();
+        let backrefs = if backrefs_len == 0 {
             &mut []
         } else {
             unsafe {
                 ::core::slice::from_raw_parts_mut(
-                    self.backrefs_start_ptr() as *mut MovableBackref<T>,
-                    self.backrefs_len(),
+                    self.bounds.backrefs_start_ptr() as *mut MovableBackref<T>,
+                    backrefs_len,
                 )
             }
         };
         unsafe { self.fixup_backrefs(backrefs) };
         backrefs
-    }
-
-    /// The start address of the backref section.
-    #[inline(always)]
-    pub fn backrefs_start_ptr(&self) -> *const MovableBackref<T> {
-        self.bounds.refs.start_ptr() as *const MovableBackref<T>
-    }
-
-    /// The end address of the backref section.
-    #[inline(always)]
-    pub fn backrefs_end_ptr(&self) -> *const MovableBackref<T> {
-        self.bounds.refs.end_ptr() as *const MovableBackref<T>
-    }
-
-    /// The number of backref records in the section.
-    #[inline]
-    pub fn backrefs_len(&self) -> usize {
-        self.bounds.refs.byte_len() / ::core::mem::size_of::<MovableBackref<T>>()
-    }
-
-    /// True if there are no backrefs.
-    #[inline]
-    pub fn backrefs_is_empty(&self) -> bool {
-        self.backrefs_len() == 0
     }
 
     unsafe fn fixup_backrefs(&self, backrefs: &mut [MovableBackref<T>]) {
@@ -435,7 +363,7 @@ impl<T: 'static> TypedMovableSection<T> {
             panic!("movable section backref count does not match item count");
         }
 
-        backrefs.sort_unstable_by_key(|backref| backref.original);
+        backrefs.sort_unstable_by_key(|backref| backref.current_ptr());
         self.backref_state.store(2, Ordering::Release);
     }
 }
@@ -445,25 +373,27 @@ impl_bounds_traits!(TypedMovableSection<T>);
 /// A reference to a movable item through a stable pointer slot.
 #[repr(transparent)]
 pub struct MovableRef<T: 'static> {
-    slot: &'static SyncUnsafeCell<*const T>,
+    slot: SyncUnsafeCell<*const T>,
 }
 
 impl<T> MovableRef<T> {
     #[doc(hidden)]
-    pub const fn new(slot: &'static SyncUnsafeCell<*const T>) -> Self {
-        Self { slot }
+    pub const fn new(ptr: *const T) -> Self {
+        Self {
+            slot: SyncUnsafeCell::new(ptr),
+        }
+    }
+
+    /// Get a raw pointer to the stable pointer slot inside this handle. Note
+    /// that both this and the SyncUnsafeCell are transparent.
+    #[doc(hidden)]
+    pub const fn slot_ptr(this: *const Self) -> *const UnsafeCell<*const T> {
+        this.cast::<UnsafeCell<*const T>>()
     }
 
     /// Raw pointer to the value currently referenced by this slot.
     pub fn as_ptr(&self) -> *const T {
         unsafe { *self.slot.get() }
-    }
-
-    #[doc(hidden)]
-    pub unsafe fn set(&self, ptr: *const T) {
-        unsafe {
-            *self.slot.get() = ptr;
-        }
     }
 }
 
@@ -478,37 +408,41 @@ unsafe impl<T> Send for MovableRef<T> where T: Send {}
 unsafe impl<T> Sync for MovableRef<T> where T: Sync {}
 
 /// A backref record submitted alongside each item in a [`TypedMovableSection`].
+/// This points to a [`MovableRef`] that lives outside of the section.
 #[repr(C)]
 pub struct MovableBackref<T: 'static> {
-    original: *const T,
-    slot: *const SyncUnsafeCell<*const T>,
+    slot: *const UnsafeCell<*const T>,
 }
 
 impl<T> MovableBackref<T> {
     #[doc(hidden)]
-    pub const fn new(original: *const T, slot: *const SyncUnsafeCell<*const T>) -> Self {
-        Self { original, slot }
-    }
-
-    /// Original value-section cell for this backref.
-    pub fn original_ptr(&self) -> *const T {
-        self.original
+    pub const fn new(slot: *const UnsafeCell<*const T>) -> Self {
+        Self { slot }
     }
 
     /// Current value of the stable pointer slot.
-    pub fn current_ptr(&self) -> *const T {
-        unsafe { *(*self.slot).get() }
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure no other threads are accessing the movable slice.
+    /// No references must be live to any of the static items.
+    ///
+    /// It is recommended to only use this in a `ctor`.
+    pub unsafe fn current_ptr(&self) -> *const T {
+        unsafe { ptr::read(UnsafeCell::raw_get(self.slot)) }
     }
 
     /// Update the stable pointer slot.
     ///
     /// # Safety
     ///
-    /// The caller must ensure `ptr` points to the logical item associated with
-    /// this backref.
+    /// The caller must ensure no other threads are accessing the movable slice.
+    /// No references must be live to any of the static items.
+    ///
+    /// It is recommended to only use this in a `ctor`.
     pub unsafe fn set_current_ptr(&self, ptr: *const T) {
         unsafe {
-            *(*self.slot).get() = ptr;
+            ptr::write(UnsafeCell::raw_get(self.slot), ptr);
         }
     }
 }
@@ -526,6 +460,7 @@ pub struct TypedReferenceSection<T: 'static> {
 }
 
 impl<T: 'static> TypedReferenceSection<T> {
+    impl_section_new!(T);
     impl_bounds_fns!(T);
 
     /// The offset of the item in the section, if it is in the section.

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -1,8 +1,6 @@
-use core::{
-    cell::UnsafeCell,
-    ptr,
-    sync::atomic::{AtomicU8, Ordering},
-};
+#[cfg(not(target_family = "wasm"))]
+use core::sync::atomic::{AtomicU8, Ordering};
+use core::{cell::UnsafeCell, ptr};
 
 use crate::__support::{Bounds, MovableBounds, SyncUnsafeCell};
 
@@ -269,11 +267,14 @@ impl_bounds_traits!(TypedMutableSection<T>);
 /// underlying data is (unsafely) mutable, enumerable, and expected to be
 /// relocated or reordered during startup initialization.
 ///
-/// Only `const` items may be submitted to a [`TypedMovableSection`].
+///
+///
+/// Only `static` items may be submitted to a [`TypedMovableSection`].
 #[repr(C)]
 pub struct TypedMovableSection<T: 'static> {
     name: &'static str,
     bounds: MovableBounds,
+    #[cfg(not(target_family = "wasm"))]
     backref_state: AtomicU8,
     _phantom: ::core::marker::PhantomData<T>,
 }
@@ -288,6 +289,7 @@ impl<T: 'static> TypedMovableSection<T> {
         Self {
             name,
             bounds,
+            #[cfg(not(target_family = "wasm"))]
             backref_state: AtomicU8::new(0),
             _phantom: ::core::marker::PhantomData,
         }
@@ -345,10 +347,19 @@ impl<T: 'static> TypedMovableSection<T> {
                 )
             }
         };
-        unsafe { self.fixup_backrefs(backrefs) };
+        #[cfg(not(target_family = "wasm"))]
+        unsafe {
+            self.fixup_backrefs(backrefs)
+        };
         backrefs
     }
 
+    /// As we cannot guarantee that the linker placed the items and backrefs in
+    /// the same order, we need to sort the backrefs to match the items.
+    ///
+    /// The exception, of course, is WASM where we placed both of them
+    /// ourselves.
+    #[cfg(not(target_family = "wasm"))]
     unsafe fn fixup_backrefs(&self, backrefs: &mut [MovableBackref<T>]) {
         match self
             .backref_state
@@ -365,6 +376,70 @@ impl<T: 'static> TypedMovableSection<T> {
 
         backrefs.sort_unstable_by_key(|backref| backref.current_ptr());
         self.backref_state.store(2, Ordering::Release);
+    }
+
+    /// Sort the section and backrefs in place.
+    ///
+    /// This algorithm is currently implemented as a quicksort.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure no other threads are accessing the movable slice.
+    /// It is recommended to only use this in a `ctor`.
+    pub unsafe fn sort_unstable(&self)
+    where
+        T: Ord,
+    {
+        // Trivial case.
+        let main = self.as_mut_slice();
+        if main.len() <= 1 {
+            return;
+        }
+
+        let refs = self.as_mut_backrefs();
+        debug_assert_eq!(main.len(), refs.len());
+
+        fn partition<T: Ord, R>(main: &mut [T], refs: &mut [R]) -> usize {
+            let n = main.len();
+            if n == 0 {
+                return 0;
+            }
+            let pivot = n - 1;
+            let mut i = 0;
+            for j in 0..pivot {
+                if main[j] <= main[pivot] {
+                    main.swap(i, j);
+                    refs.swap(i, j);
+                    i += 1;
+                }
+            }
+            main.swap(i, pivot);
+            refs.swap(i, pivot);
+            i
+        }
+
+        fn recurse<T: Ord, R>(main: &mut [T], refs: &mut [R]) {
+            let n = main.len();
+            if n <= 1 {
+                return;
+            }
+            let p = partition(main, refs);
+            let (ml, mr) = main.split_at_mut(p);
+            let (rl, rr) = refs.split_at_mut(p);
+            recurse(ml, rl);
+            if mr.len() > 1 {
+                recurse(&mut mr[1..], &mut rr[1..]);
+            }
+        }
+
+        recurse(main, refs);
+
+        // TODO: could we avoid the fixup if no changes are made?
+        for (item, backref) in main.iter().zip(refs.iter()) {
+            unsafe {
+                backref.set_current_ptr(item as *const T);
+            }
+        }
     }
 }
 

--- a/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
@@ -30,8 +30,9 @@ impl FOO {
                         #[used]
                         #[used]
                         static __LINK_SECTION_INFO:
-                            ::link_section::__support::wasm::LinkSectionRawInfo =
-                            ::link_section::__support::wasm::LinkSectionRawInfo::new::<(Driver)>(__LINK_SECTION_NAME);
+                            ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>
+                            =
+                            ::link_section::__support::wasm::LinkSectionInfoLock::new(::link_section::__support::wasm::LinkSectionInfo::new::<(Driver)>(__LINK_SECTION_NAME));
                         unsafe {
                             ::link_section::__support::Bounds::new(&raw const __LINK_SECTION_INFO)
                         }
@@ -82,7 +83,7 @@ const DRIVER: Driver =
                 #[link_name = ".data.link_section.FOO.bounds"]
                 #[allow(unsafe_code)]
                 static __LINK_SECTION_INFO:
-                    ::link_section::__support::wasm::LinkSectionRawInfo;
+                    ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
             }
             #[link_section = ".init_array.0"]
             #[used]

--- a/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
@@ -22,8 +22,9 @@ impl FOO {
                         #[used]
                         #[used]
                         static __LINK_SECTION_INFO:
-                            ::link_section::__support::wasm::LinkSectionRawInfo =
-                            ::link_section::__support::wasm::LinkSectionRawInfo::new::<(fn())>(__LINK_SECTION_NAME);
+                            ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>
+                            =
+                            ::link_section::__support::wasm::LinkSectionInfoLock::new(::link_section::__support::wasm::LinkSectionInfo::new::<(fn())>(__LINK_SECTION_NAME));
                         unsafe {
                             ::link_section::__support::Bounds::new(&raw const __LINK_SECTION_INFO)
                         }
@@ -74,7 +75,7 @@ fn foo() {
                     #[link_name = ".data.link_section.FOO.bounds"]
                     #[allow(unsafe_code)]
                     static __LINK_SECTION_INFO:
-                        ::link_section::__support::wasm::LinkSectionRawInfo;
+                        ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
                 }
                 #[link_section = ".init_array.0"]
                 #[used]

--- a/linktime/src/lib.rs
+++ b/linktime/src/lib.rs
@@ -25,7 +25,8 @@ pub mod link_section {
 
     #[doc(inline)]
     pub use link_section::{
-        reference, Section, TypedMutableSection, TypedReferenceSection, TypedSection,
+        reference, MovableBackref, MovableRef, Section, TypedMovableSection, TypedMutableSection,
+        TypedReferenceSection, TypedSection,
     };
 
     /// Declarative `section` / `in_section` macros (no proc-macro feature).

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["data-structures", "development-tools::build-utils", "no-std"]
 
 [dependencies]
 link-section = { workspace = true, features = ["proc_macro"] }
-ctor.workspace = true
+ctor = { workspace = true, features = ["proc_macro", "priority", "std"] }
 scattered-collect-proc-macro = { path = "../scattered-collect-proc-macro" }
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "const_xxh3"] }
 wide = "1.3"

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -3,10 +3,14 @@
 #![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 
+pub mod referenced_slice;
 pub mod slice;
+pub mod sorted_referenced_slice;
 pub mod sorted_slice;
 
+pub use referenced_slice::ScatteredReferencedSlice;
 pub use slice::ScatteredSlice;
+pub use sorted_referenced_slice::ScatteredSortedReferencedSlice;
 pub use sorted_slice::ScatteredSortedSlice;
 
 #[doc(hidden)]
@@ -20,7 +24,6 @@ macro_rules! __scatter_parse {
             $($item)*
         );
     };
-
     (#[scatter] $($rest:tt)* ) => {
         compile_error!("Unknown collection type");
     };

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -8,10 +8,10 @@ pub use link_section::reference::Ref;
 /// A collection of sized items available both as a slice over the gathered
 /// section and as `static` handles at each declaration site.
 ///
-/// Storage uses [`TypedReferenceSection`] (see `link_section`); the slice is in
-/// arbitrary link order. For a sorted slice without per-item handles, use
-/// [`crate::ScatteredSlice`]. For sorted data with stable per-item references,
-/// use [`crate::ScatteredSortedReferencedSlice`].
+/// The slice is in an arbitrary link order which is platform-dependent. For a
+/// sorted slice without per-item handles, use [`crate::ScatteredSlice`]. For
+/// sorted data with stable per-item references, use
+/// [`crate::ScatteredSortedReferencedSlice`].
 pub struct ScatteredReferencedSlice<T: 'static> {
     section: &'static TypedReferenceSection<T>,
 }

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -41,6 +41,7 @@ impl<T: 'static> ::core::ops::Deref for ScatteredReferencedSlice<T> {
     }
 }
 
+/// Declare a scattered referenced slice.
 #[macro_export]
 macro_rules! __referenced_slice {
     (gather $vis:vis $name:ident: $ty:ty) => {

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -1,0 +1,103 @@
+//! A collection of items collected into a slice (link order), with each entry
+//! wrapped as [`Ref`] so `static` items work on targets such as WASM.
+
+use link_section::TypedReferenceSection;
+
+pub use link_section::reference::Ref;
+
+/// A collection of sized items available both as a slice over the gathered
+/// section and as `static` handles at each declaration site.
+///
+/// Storage uses [`TypedReferenceSection`] (see `link_section`); the slice is in
+/// arbitrary link order. For a sorted slice without per-item handles, use
+/// [`crate::ScatteredSlice`]. For sorted data with stable per-item references,
+/// use [`crate::ScatteredSortedReferencedSlice`].
+pub struct ScatteredReferencedSlice<T: 'static> {
+    section: &'static TypedReferenceSection<T>,
+}
+
+impl<T: 'static> ScatteredReferencedSlice<T> {
+    #[doc(hidden)]
+    #[allow(unsafe_code)]
+    pub const unsafe fn new(section: &'static TypedReferenceSection<T>) -> Self {
+        Self { section }
+    }
+
+    /// The number of items in the slice.
+    pub fn len(&self) -> usize {
+        self.section.len()
+    }
+
+    /// True if the slice is empty.
+    pub fn is_empty(&self) -> bool {
+        self.section.is_empty()
+    }
+}
+
+impl<T: 'static> ::core::ops::Deref for ScatteredReferencedSlice<T> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        self.section.as_slice()
+    }
+}
+
+#[macro_export]
+macro_rules! __referenced_slice {
+    (gather $vis:vis $name:ident: $ty:ty) => {
+        #[doc(hidden)]
+        $crate::__support::ident_concat!((#[macro_export] macro_rules!) (__ $name __referenced_slice_private_macro__) ({
+            ($passthru:tt) => {
+                $crate::__referenced_slice!(@scatter $passthru);
+            };
+        }));
+
+        $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __referenced_slice_private_macro__) (as $name;));
+
+        #[allow(unused)]
+        #[allow(non_snake_case)]
+        #[doc(hidden)]
+        $vis mod $name {
+            $crate::__support::link_section::declarative::section!(
+                #[section(reference)]
+                pub static $name: $crate::__support::link_section::TypedReferenceSection<$ty>;
+            );
+        }
+
+        $vis static $name: $crate::referenced_slice::ScatteredReferencedSlice<$ty> = {
+            unsafe {
+                $crate::referenced_slice::ScatteredReferencedSlice::new(
+                    self::$name::$name.const_deref(),
+                )
+            }
+        };
+    };
+    (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
+        $collection ! (( $collection => $vis $name: $ty = $expr ));
+    };
+    (@scatter ($collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr)) => {
+        $crate::__support::link_section::declarative::in_section!(
+            #[in_section($collection::$collection)]
+            $vis static $name: $ty = $expr;
+        );
+    };
+}
+
+#[cfg(all(test, not(miri)))]
+mod tests {
+    __referenced_slice!(gather pub TEST_REF_SLICE: u32);
+    __referenced_slice!(scatter TEST_REF_SLICE => pub REF_SLICE_ITEM_A: u32 = 1);
+    __referenced_slice!(scatter TEST_REF_SLICE => pub REF_SLICE_ITEM_B: u32 = 3);
+    __referenced_slice!(scatter TEST_REF_SLICE => pub REF_SLICE_ITEM_C: u32 = 2);
+
+    #[test]
+    fn test_scattered_referenced_slice() {
+        assert_eq!(TEST_REF_SLICE.len(), 3);
+        assert!(TEST_REF_SLICE.contains(&1));
+        assert!(TEST_REF_SLICE.contains(&2));
+        assert!(TEST_REF_SLICE.contains(&3));
+
+        assert_eq!(*REF_SLICE_ITEM_A, 1);
+        assert_eq!(*REF_SLICE_ITEM_B, 3);
+        assert_eq!(*REF_SLICE_ITEM_C, 2);
+    }
+}

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -27,10 +27,12 @@ impl<T: Ord + 'static> ScatteredSortedReferencedSlice<T> {
         }
     }
 
+    /// The number of items in the sorted referenced slice.
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
+    /// True if the sorted referenced slice is empty.
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
@@ -68,6 +70,7 @@ impl<T> ::core::ops::Deref for Ref<T> {
 }
 
 impl<T> Ref<T> {
+    #[doc(hidden)]
     pub const fn new(ptr: *const T) -> Self {
         Self {
             tag: 0,
@@ -76,7 +79,9 @@ impl<T> Ref<T> {
     }
 }
 
+#[allow(unsafe_code)]
 unsafe impl<T: Sync> Sync for Ref<T> {}
+#[allow(unsafe_code)]
 unsafe impl<T: Send> Send for Ref<T> {}
 
 /// Used by [`__sorted_referenced_slice!`] scatter arm; do not call directly.
@@ -152,6 +157,7 @@ fn co_sort_unstable_by_main<T: Ord, R>(main: &mut [T], refs: &mut [R]) {
 /// unique target addresses, and that this runs exactly once before any
 /// concurrent read of `refs` through [`Ref::deref`].
 #[doc(hidden)]
+#[allow(clippy::needless_range_loop)]
 pub unsafe fn initialize_scattered_sorted_referenced_slice<T: Ord>(
     main: &mut [T],
     refs: &mut [Ref<T>],
@@ -188,6 +194,7 @@ pub unsafe fn initialize_scattered_sorted_referenced_slice<T: Ord>(
     }
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! __sorted_referenced_slice {
     (gather $vis:vis $name:ident: $ty:ty) => {

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -1,0 +1,267 @@
+//! A collection of sized items available both as a sorted slice and as stable
+//! handles at each declaration site.
+
+use core::cell::UnsafeCell;
+use link_section::TypedMutableSection;
+
+/// A collection of sized items that are available both via sorted slice and via
+/// reference at the declaration site.
+///
+/// The gathered items are accessed via `&'static` references; the main section
+/// is sorted by `T` before `main()` and ref slots are fixed up in place.
+///
+/// If the reference to the individual items is not required, a sorted slice may
+/// be used instead.
+pub struct ScatteredSortedReferencedSlice<T: Ord + 'static> {
+    data: &'static TypedMutableSection<T>,
+    _marker: core::marker::PhantomData<T>,
+}
+
+impl<T: Ord + 'static> ScatteredSortedReferencedSlice<T> {
+    #[doc(hidden)]
+    #[allow(unsafe_code)]
+    pub const unsafe fn new(data: &'static TypedMutableSection<T>) -> Self {
+        Self {
+            data,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl<T: Ord + 'static> ::core::ops::Deref for ScatteredSortedReferencedSlice<T> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        self.data.as_slice()
+    }
+}
+
+impl<T: Ord + 'static> ::core::iter::IntoIterator for &'static ScatteredSortedReferencedSlice<T> {
+    type Item = &'static T;
+    type IntoIter = ::core::slice::Iter<'static, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.as_slice().iter()
+    }
+}
+
+/// Link-section reference to an item in the slice. As the final sort order is
+/// not known until after initialization, referencing an item in the slice
+/// requires an indirect load.
+#[repr(C)]
+pub struct Ref<T> {
+    tag: u32,
+    ptr: UnsafeCell<*const T>,
+}
+
+impl<T> ::core::ops::Deref for Ref<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &**self.ptr.get() }
+    }
+}
+
+impl<T> Ref<T> {
+    pub const fn new(ptr: *const T) -> Self {
+        Self {
+            tag: 0,
+            ptr: UnsafeCell::new(ptr),
+        }
+    }
+}
+
+unsafe impl<T: Sync> Sync for Ref<T> {}
+unsafe impl<T: Send> Send for Ref<T> {}
+
+/// Used by [`__sorted_referenced_slice!`] scatter arm; do not call directly.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __sorted_referenced_slice_decl_rslot {
+    (
+        $collection:ident,
+        $vis:vis,
+        $name:ident,
+        $ty:ty,
+        $expr:expr
+    ) => {
+        $crate::__support::link_section::declarative::in_section!(
+            #[in_section($collection::SLOTS)]
+            $vis const $name: $crate::sorted_referenced_slice::Ref<$ty> = {
+                $crate::__support::link_section::declarative::in_section!(
+                    #[in_section($collection::$collection)]
+                    $vis const $name: $ty = $expr;
+                );
+                $crate::sorted_referenced_slice::Ref::new(::core::ptr::from_ref(&$name))
+            };
+        );
+    };
+}
+
+fn co_sort_unstable_by_main<T: Ord, R>(main: &mut [T], refs: &mut [R]) {
+    debug_assert_eq!(main.len(), refs.len());
+    fn partition<T: Ord, R>(main: &mut [T], refs: &mut [R]) -> usize {
+        let n = main.len();
+        if n == 0 {
+            return 0;
+        }
+        let pivot = n - 1;
+        let mut i = 0;
+        for j in 0..pivot {
+            if main[j] <= main[pivot] {
+                main.swap(i, j);
+                refs.swap(i, j);
+                i += 1;
+            }
+        }
+        main.swap(i, pivot);
+        refs.swap(i, pivot);
+        i
+    }
+
+    fn recurse<T: Ord, R>(main: &mut [T], refs: &mut [R]) {
+        let n = main.len();
+        if n <= 1 {
+            return;
+        }
+        let p = partition(main, refs);
+        let (ml, mr) = main.split_at_mut(p);
+        let (rl, rr) = refs.split_at_mut(p);
+        recurse(ml, rl);
+        if mr.len() > 1 {
+            recurse(&mut mr[1..], &mut rr[1..]);
+        }
+    }
+
+    recurse(main, refs);
+}
+
+/// Run the four-phase algorithm (sort refs by target address, co-sort main + refs,
+/// repoint refs at sorted cells, restore ref slot order). `main` and `refs` must
+/// have the same length; each ref must initially point at some `main` cell
+/// (one-to-one). No heap allocation.
+///
+/// # Safety
+///
+/// Caller must ensure `refs` and `main` describe the same collection, with
+/// unique target addresses, and that this runs exactly once before any
+/// concurrent read of `refs` through [`Ref::deref`].
+#[doc(hidden)]
+pub unsafe fn initialize_scattered_sorted_referenced_slice<T: Ord>(
+    main: &mut [T],
+    refs: &mut [Ref<T>],
+) {
+    assert_eq!(main.len(), refs.len());
+    let n = main.len();
+    if n == 0 {
+        return;
+    }
+
+    // Phase 1: tag by current ref index, then sort refs by target address.
+    for k in 0..n {
+        refs[k].tag = k as u32;
+    }
+    refs.sort_unstable_by_key(|ref_slot| unsafe { *ref_slot.ptr.get() });
+
+    // Phase 2: co-sort main and refs by T.
+    co_sort_unstable_by_main(main, refs);
+
+    // Phase 3: pointers follow sorted main order.
+    for i in 0..n {
+        unsafe {
+            *refs[i].ptr.get() = core::ptr::from_ref(&main[i]);
+        }
+    }
+
+    // Phase 4: permute refs back to original slot order (tags are pre-phase-1 indices).
+    for i in 0..n {
+        while refs[i].tag as usize != i {
+            let t = refs[i].tag as usize;
+            debug_assert!(t < n);
+            refs.swap(i, t);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! __sorted_referenced_slice {
+    (gather $vis:vis $name:ident: $ty:ty) => {
+        #[doc(hidden)]
+        $crate::__support::ident_concat!((#[macro_export] macro_rules!) (__ $name __sorted_referenced_slice_private_macro__) ({
+            ($passthru:tt) => {
+                $crate::__sorted_referenced_slice!(@scatter $passthru);
+            };
+        }));
+
+        $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __sorted_referenced_slice_private_macro__) (as $name;));
+
+        #[allow(unused)]
+        #[allow(non_snake_case)]
+        #[doc(hidden)]
+        $vis mod $name {
+            $crate::__support::link_section::declarative::section!(
+                #[section(mutable)]
+                pub static $name: $crate::__support::link_section::TypedMutableSection<$ty>;
+            );
+
+            $crate::__support::link_section::declarative::section!(
+                #[section(mutable, aux(main = $name))]
+                pub static SLOTS: $crate::__support::link_section::TypedMutableSection<
+                    $crate::sorted_referenced_slice::Ref<$ty>
+                >;
+            );
+
+            $crate::__support::ctor::declarative::ctor!(
+                #[ctor(unsafe, anonymous, priority = 0)]
+                fn __sorted_referenced_slice_init() {
+                    unsafe {
+                        let main = $name.as_mut_slice();
+                        let refs = SLOTS.as_mut_slice();
+                        $crate::sorted_referenced_slice::initialize_scattered_sorted_referenced_slice(
+                            main,
+                            refs,
+                        );
+                    }
+                }
+            );
+        }
+
+        $vis static $name: $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice<$ty> = unsafe {
+            $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice::new(self::$name::$name.const_deref())
+        };
+    };
+    (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
+        $collection ! (( $collection => $vis $name: $ty = $expr ));
+    };
+    (@scatter ($collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr)) => {
+        $crate::__sorted_referenced_slice_decl_rslot!(
+            $collection,
+            $vis,
+            $name,
+            $ty,
+            $expr
+        );
+    };
+}
+
+#[cfg(all(test, not(miri)))]
+mod tests {
+    __sorted_referenced_slice!(gather pub TEST_SORT_REF: u32);
+    __sorted_referenced_slice!(scatter TEST_SORT_REF => pub SORT_REF_ITEM_A: u32 = 1);
+    __sorted_referenced_slice!(scatter TEST_SORT_REF => pub SORT_REF_ITEM_B: u32 = 3);
+    __sorted_referenced_slice!(scatter TEST_SORT_REF => pub SORT_REF_ITEM_C: u32 = 2);
+
+    #[test]
+    fn test_scattered_sorted_referenced_slice() {
+        assert_eq!(TEST_SORT_REF.len(), 3);
+        assert_eq!(&*TEST_SORT_REF, [1, 2, 3].as_slice());
+        assert_eq!(*SORT_REF_ITEM_A, 1);
+        assert_eq!(*SORT_REF_ITEM_B, 3);
+        assert_eq!(*SORT_REF_ITEM_C, 2);
+    }
+}

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -76,14 +76,6 @@ macro_rules! __sorted_referenced_slice_decl_rslot {
     };
 }
 
-/// Sort the scattered items and update declaration-site handles.
-#[doc(hidden)]
-pub unsafe fn initialize_scattered_sorted_referenced_slice<T: Ord + 'static>(
-    section: &TypedMovableSection<T>,
-) {
-    unsafe { section.sort_unstable() };
-}
-
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __sorted_referenced_slice {
@@ -97,8 +89,7 @@ macro_rules! __sorted_referenced_slice {
 
         $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __sorted_referenced_slice_private_macro__) (as $name;));
 
-        #[allow(unused)]
-        #[allow(non_snake_case)]
+        #[allow(unused, non_snake_case, unsafe_code)]
         #[doc(hidden)]
         $vis mod $name {
             $crate::__support::link_section::declarative::section!(
@@ -110,9 +101,7 @@ macro_rules! __sorted_referenced_slice {
                 #[ctor(unsafe, anonymous, priority = 0)]
                 fn __sorted_referenced_slice_init() {
                     unsafe {
-                        $crate::sorted_referenced_slice::initialize_scattered_sorted_referenced_slice(
-                            &$name,
-                        );
+                        $name.sort_unstable();
                     }
                 }
             );

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -1,26 +1,31 @@
 //! A collection of sized items available both as a sorted slice and as stable
 //! handles at each declaration site.
 
-use core::cell::UnsafeCell;
-use link_section::TypedMutableSection;
+use link_section::TypedMovableSection;
+
+/// Link-section reference to an item in the slice. As the final sort order is
+/// not known until after initialization, referencing an item in the slice
+/// requires an indirect load.
+pub type Ref<T> = link_section::MovableRef<T>;
 
 /// A collection of sized items that are available both via sorted slice and via
 /// reference at the declaration site.
 ///
 /// The gathered items are accessed via `&'static` references; the main section
-/// is sorted by `T` before `main()` and ref slots are fixed up in place.
+/// is sorted by `T` before `main()` and declaration-site handles are fixed up
+/// in place.
 ///
 /// If the reference to the individual items is not required, a sorted slice may
 /// be used instead.
 pub struct ScatteredSortedReferencedSlice<T: Ord + 'static> {
-    data: &'static TypedMutableSection<T>,
+    data: &'static TypedMovableSection<T>,
     _marker: core::marker::PhantomData<T>,
 }
 
 impl<T: Ord + 'static> ScatteredSortedReferencedSlice<T> {
     #[doc(hidden)]
     #[allow(unsafe_code)]
-    pub const unsafe fn new(data: &'static TypedMutableSection<T>) -> Self {
+    pub const unsafe fn new(data: &'static TypedMovableSection<T>) -> Self {
         Self {
             data,
             _marker: core::marker::PhantomData,
@@ -53,37 +58,6 @@ impl<T: Ord + 'static> ::core::iter::IntoIterator for &'static ScatteredSortedRe
     }
 }
 
-/// Link-section reference to an item in the slice. As the final sort order is
-/// not known until after initialization, referencing an item in the slice
-/// requires an indirect load.
-#[repr(C)]
-pub struct Ref<T> {
-    tag: u32,
-    ptr: UnsafeCell<*const T>,
-}
-
-impl<T> ::core::ops::Deref for Ref<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        unsafe { &**self.ptr.get() }
-    }
-}
-
-impl<T> Ref<T> {
-    #[doc(hidden)]
-    pub const fn new(ptr: *const T) -> Self {
-        Self {
-            tag: 0,
-            ptr: UnsafeCell::new(ptr),
-        }
-    }
-}
-
-#[allow(unsafe_code)]
-unsafe impl<T: Sync> Sync for Ref<T> {}
-#[allow(unsafe_code)]
-unsafe impl<T: Send> Send for Ref<T> {}
-
 /// Used by [`__sorted_referenced_slice!`] scatter arm; do not call directly.
 #[macro_export]
 #[doc(hidden)]
@@ -96,102 +70,18 @@ macro_rules! __sorted_referenced_slice_decl_rslot {
         $expr:expr
     ) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section($collection::SLOTS)]
-            $vis const $name: $crate::sorted_referenced_slice::Ref<$ty> = {
-                $crate::__support::link_section::declarative::in_section!(
-                    #[in_section($collection::$collection)]
-                    $vis const $name: $ty = $expr;
-                );
-                $crate::sorted_referenced_slice::Ref::new(::core::ptr::from_ref(&$name))
-            };
+            #[in_section($collection::$collection)]
+            $vis static $name: $ty = $expr;
         );
     };
 }
 
-fn co_sort_unstable_by_main<T: Ord, R>(main: &mut [T], refs: &mut [R]) {
-    debug_assert_eq!(main.len(), refs.len());
-    fn partition<T: Ord, R>(main: &mut [T], refs: &mut [R]) -> usize {
-        let n = main.len();
-        if n == 0 {
-            return 0;
-        }
-        let pivot = n - 1;
-        let mut i = 0;
-        for j in 0..pivot {
-            if main[j] <= main[pivot] {
-                main.swap(i, j);
-                refs.swap(i, j);
-                i += 1;
-            }
-        }
-        main.swap(i, pivot);
-        refs.swap(i, pivot);
-        i
-    }
-
-    fn recurse<T: Ord, R>(main: &mut [T], refs: &mut [R]) {
-        let n = main.len();
-        if n <= 1 {
-            return;
-        }
-        let p = partition(main, refs);
-        let (ml, mr) = main.split_at_mut(p);
-        let (rl, rr) = refs.split_at_mut(p);
-        recurse(ml, rl);
-        if mr.len() > 1 {
-            recurse(&mut mr[1..], &mut rr[1..]);
-        }
-    }
-
-    recurse(main, refs);
-}
-
-/// Run the four-phase algorithm (sort refs by target address, co-sort main + refs,
-/// repoint refs at sorted cells, restore ref slot order). `main` and `refs` must
-/// have the same length; each ref must initially point at some `main` cell
-/// (one-to-one). No heap allocation.
-///
-/// # Safety
-///
-/// Caller must ensure `refs` and `main` describe the same collection, with
-/// unique target addresses, and that this runs exactly once before any
-/// concurrent read of `refs` through [`Ref::deref`].
+/// Sort the scattered items and update declaration-site handles.
 #[doc(hidden)]
-#[allow(clippy::needless_range_loop)]
-pub unsafe fn initialize_scattered_sorted_referenced_slice<T: Ord>(
-    main: &mut [T],
-    refs: &mut [Ref<T>],
+pub unsafe fn initialize_scattered_sorted_referenced_slice<T: Ord + 'static>(
+    section: &TypedMovableSection<T>,
 ) {
-    assert_eq!(main.len(), refs.len());
-    let n = main.len();
-    if n == 0 {
-        return;
-    }
-
-    // Phase 1: tag by current ref index, then sort refs by target address.
-    for k in 0..n {
-        refs[k].tag = k as u32;
-    }
-    refs.sort_unstable_by_key(|ref_slot| unsafe { *ref_slot.ptr.get() });
-
-    // Phase 2: co-sort main and refs by T.
-    co_sort_unstable_by_main(main, refs);
-
-    // Phase 3: pointers follow sorted main order.
-    for i in 0..n {
-        unsafe {
-            *refs[i].ptr.get() = core::ptr::from_ref(&main[i]);
-        }
-    }
-
-    // Phase 4: permute refs back to original slot order (tags are pre-phase-1 indices).
-    for i in 0..n {
-        while refs[i].tag as usize != i {
-            let t = refs[i].tag as usize;
-            debug_assert!(t < n);
-            refs.swap(i, t);
-        }
-    }
+    unsafe { section.sort_unstable() };
 }
 
 #[doc(hidden)]
@@ -212,26 +102,16 @@ macro_rules! __sorted_referenced_slice {
         #[doc(hidden)]
         $vis mod $name {
             $crate::__support::link_section::declarative::section!(
-                #[section(mutable)]
-                pub static $name: $crate::__support::link_section::TypedMutableSection<$ty>;
-            );
-
-            $crate::__support::link_section::declarative::section!(
-                #[section(mutable, aux(main = $name))]
-                pub static SLOTS: $crate::__support::link_section::TypedMutableSection<
-                    $crate::sorted_referenced_slice::Ref<$ty>
-                >;
+                #[section(movable)]
+                pub static $name: $crate::__support::link_section::TypedMovableSection<$ty>;
             );
 
             $crate::__support::ctor::declarative::ctor!(
                 #[ctor(unsafe, anonymous, priority = 0)]
                 fn __sorted_referenced_slice_init() {
                     unsafe {
-                        let main = $name.as_mut_slice();
-                        let refs = SLOTS.as_mut_slice();
                         $crate::sorted_referenced_slice::initialize_scattered_sorted_referenced_slice(
-                            main,
-                            refs,
+                            &$name,
                         );
                     }
                 }

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -16,7 +16,7 @@ $ cargo run --quiet
 ! TYPED_LINK_SECTION: TypedSection { name: "%{DATA}TYPED_LINK%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 2, stride: 4 }
 ! address of TYPED_LINK_SECTION[0]: %{BASE16NUM}
 ! address of TYPED_LINK_SECTION[1]: %{BASE16NUM}
-! AUX_LINK_SECTION: TypedSection { name: "%{DATA}AUX_LINK_SECTION%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 1, stride: 4 }
+! AUX_LINK_SECTION: TypedSection { name: "%{DATA}AUX_LINK_S%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 1, stride: 4 }
 ! aux: 1234
 ! CODE_SECTION: TypedSection { name: "%{DATA}FN_ARRAY%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 3, stride: 8 }
 ! [%{BASE16NUM}, %{BASE16NUM}, %{BASE16NUM}]
@@ -44,7 +44,7 @@ defer {
     $ cargo clean --quiet
 }
 $ cargo run --quiet
-! INTERIOR_MUT_LINK_SECTION: TypedSection { name: "%{DATA}INTERIOR_MUT_LINK_SECTION%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 2, stride: 8 }
+! INTERIOR_MUT_LINK_SECTION: TypedSection { name: "%{DATA}INTERIOR_M%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 2, stride: 8 }
 unordered {
     ! item before: InteriorMutItem { value: 1, atomic: 1 }
     ! item after: InteriorMutItem { value: 1, atomic: 2 }
@@ -63,7 +63,7 @@ defer {
     $ cargo clean --quiet
 }
 $ cargo run --quiet
-! MUT_LINK_SECTION: TypedMutableSection { name: "%{DATA}MUT_LINK_SECTION%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 5, stride: 4 }
+! MUT_LINK_SECTION: TypedMutableSection { name: "%{DATA}MUT_LINK_S%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 5, stride: 4 }
 """
 item: 1
 item: 2
@@ -71,13 +71,13 @@ item: 3
 item: 4
 item: 5
 """
-! AUX_MUT_LINK_SECTION: TypedMutableSection { name: "%{DATA}AUX_MUT_LINK_SECTION%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 3, stride: 4 }
+! AUX_MUT_LINK_SECTION: TypedMutableSection { name: "%{DATA}AUX_MUT_LI%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 3, stride: 4 }
 """
 aux item: 1234
 aux item: 2341
 aux item: 4321
 """
-! MOVABLE_LINK_SECTION: TypedMovableSection { name: "%{DATA}MOVABLE_LINK_SECTION%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 4, stride: 4 }
+! MOVABLE_LINK_SECTION: TypedMovableSection { name: "%{DATA}MOVABLE_LI%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 4, stride: 4 }
 ! MOVABLE_BACKREFS: 4
 """
 movable item: 10

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -77,6 +77,18 @@ aux item: 1234
 aux item: 2341
 aux item: 4321
 """
+! MOVABLE_LINK_SECTION: TypedMovableSection { name: "%{DATA}MOVABLE_LINK_SECTION%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 4, stride: 4 }
+! MOVABLE_BACKREFS: 4
+"""
+movable item: 10
+movable item: 20
+movable item: 30
+movable item: 40
+"""
+! MOVABLE_40: 40
+! MOVABLE_20: 20
+! MOVABLE_10: 10
+! MOVABLE_30: 30
 "#
 );
 

--- a/tests/link_section/mut/src/main.rs
+++ b/tests/link_section/mut/src/main.rs
@@ -71,13 +71,13 @@ pub fn ctor() {
         assert_eq!(movable_section.len(), movable_backrefs.len());
         // Check that the backrefs are in the same order as the items.
         for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
-            unsafe {
-                assert_eq!(backref.current_ptr(), item as *const u32);
-            }
+            assert_eq!(backref.current_ptr(), item as *const u32);
         }
     }
 
-    unsafe { MOVABLE_LINK_SECTION.sort_unstable(); }
+    unsafe {
+        MOVABLE_LINK_SECTION.sort_unstable();
+    }
 }
 
 pub fn main() {
@@ -85,7 +85,10 @@ pub fn main() {
     for item in MUT_LINK_SECTION {
         libc_eprintln!("item: {item}");
     }
-    libc_eprintln!("AUX_MUT_LINK_SECTION: {:?}", aux_section::AUX_MUT_LINK_SECTION);
+    libc_eprintln!(
+        "AUX_MUT_LINK_SECTION: {:?}",
+        aux_section::AUX_MUT_LINK_SECTION
+    );
     for item in aux_section::AUX_MUT_LINK_SECTION {
         libc_eprintln!("aux item: {item}");
     }

--- a/tests/link_section/mut/src/main.rs
+++ b/tests/link_section/mut/src/main.rs
@@ -22,6 +22,21 @@ const _: u32 = 3;
 #[in_section(MUT_LINK_SECTION)]
 const _: u32 = 5;
 
+#[section(movable)]
+pub static MOVABLE_LINK_SECTION: link_section::TypedMovableSection<u32>;
+
+#[in_section(MOVABLE_LINK_SECTION)]
+static MOVABLE_40: u32 = 40;
+
+#[in_section(MOVABLE_LINK_SECTION)]
+static MOVABLE_20: u32 = 20;
+
+#[in_section(MOVABLE_LINK_SECTION)]
+static MOVABLE_10: u32 = 10;
+
+#[in_section(MOVABLE_LINK_SECTION)]
+static MOVABLE_30: u32 = 30;
+
 mod aux_section {
     use ctor::ctor;
     use link_section::{in_section, section};
@@ -49,6 +64,26 @@ mod aux_section {
 pub fn ctor() {
     let section = unsafe { MUT_LINK_SECTION.as_mut_slice() };
     section.sort_unstable();
+
+    let movable_section = unsafe { MOVABLE_LINK_SECTION.as_mut_slice() };
+    let movable_backrefs = unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() };
+    assert_eq!(movable_section.len(), movable_backrefs.len());
+    for backref in movable_backrefs.iter() {
+        assert_eq!(backref.current_ptr(), backref.original_ptr());
+    }
+    for i in 0..movable_section.len() {
+        for j in i + 1..movable_section.len() {
+            if movable_section[i] > movable_section[j] {
+                movable_section.swap(i, j);
+                movable_backrefs.swap(i, j);
+            }
+        }
+    }
+    for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
+        unsafe {
+            backref.set_current_ptr(item as *const u32);
+        }
+    }
 }
 
 pub fn main() {
@@ -60,4 +95,16 @@ pub fn main() {
     for item in aux_section::AUX_MUT_LINK_SECTION {
         libc_eprintln!("aux item: {item}");
     }
+    libc_eprintln!("MOVABLE_LINK_SECTION: {:?}", MOVABLE_LINK_SECTION);
+    libc_eprintln!(
+        "MOVABLE_BACKREFS: {}",
+        unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() }.len()
+    );
+    for item in MOVABLE_LINK_SECTION {
+        libc_eprintln!("movable item: {item}");
+    }
+    libc_eprintln!("MOVABLE_40: {}", *MOVABLE_40);
+    libc_eprintln!("MOVABLE_20: {}", *MOVABLE_20);
+    libc_eprintln!("MOVABLE_10: {}", *MOVABLE_10);
+    libc_eprintln!("MOVABLE_30: {}", *MOVABLE_30);
 }

--- a/tests/link_section/mut/src/main.rs
+++ b/tests/link_section/mut/src/main.rs
@@ -65,25 +65,19 @@ pub fn ctor() {
     let section = unsafe { MUT_LINK_SECTION.as_mut_slice() };
     section.sort_unstable();
 
-    let movable_section = unsafe { MOVABLE_LINK_SECTION.as_mut_slice() };
-    let movable_backrefs = unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() };
-    assert_eq!(movable_section.len(), movable_backrefs.len());
-    for backref in movable_backrefs.iter() {
-        assert_eq!(backref.current_ptr(), backref.original_ptr());
-    }
-    for i in 0..movable_section.len() {
-        for j in i + 1..movable_section.len() {
-            if movable_section[i] > movable_section[j] {
-                movable_section.swap(i, j);
-                movable_backrefs.swap(i, j);
+    {
+        let movable_section = unsafe { MOVABLE_LINK_SECTION.as_mut_slice() };
+        let movable_backrefs = unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() };
+        assert_eq!(movable_section.len(), movable_backrefs.len());
+        // Check that the backrefs are in the same order as the items.
+        for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
+            unsafe {
+                assert_eq!(backref.current_ptr(), item as *const u32);
             }
         }
     }
-    for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
-        unsafe {
-            backref.set_current_ptr(item as *const u32);
-        }
-    }
+
+    unsafe { MOVABLE_LINK_SECTION.sort_unstable(); }
 }
 
 pub fn main() {

--- a/tests/wasm/rust/src/lib.rs
+++ b/tests/wasm/rust/src/lib.rs
@@ -60,6 +60,7 @@ mod link_section {
     mod movable {
         use linktime::ctor;
         use linktime::link_section::{section, in_section, TypedMovableSection};
+        use libc_print::*;
 
         #[section(movable)]
         pub static MOVABLE_LINK_SECTION: TypedMovableSection<u32>;
@@ -75,20 +76,22 @@ mod link_section {
 
         #[ctor(unsafe, priority = 1)]
         pub fn ctor() {
-            let movable_backrefs = unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() };
-            let movable_section = unsafe { MOVABLE_LINK_SECTION.as_mut_slice() };
+            {
+                let movable_backrefs = unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() };
+                let movable_section = unsafe { MOVABLE_LINK_SECTION.as_mut_slice() };
 
-            for i in 0..movable_section.len() {
-                for j in i + 1..movable_section.len() {
-                    if movable_section[i] > movable_section[j] {
-                        movable_section.swap(i, j);
-                        movable_backrefs.swap(i, j);
+                for i in 0..movable_section.len() {
+                    for j in i + 1..movable_section.len() {
+                        if movable_section[i] > movable_section[j] {
+                            movable_section.swap(i, j);
+                            movable_backrefs.swap(i, j);
+                        }
                     }
                 }
-            }
-            for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
-                unsafe {
-                    backref.set_current_ptr(item as *const u32);
+                for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
+                    unsafe {
+                        backref.set_current_ptr(item as *const u32);
+                    }
                 }
             }
 
@@ -96,6 +99,8 @@ mod link_section {
             assert_eq!(*MOVABLE_20, 20);
             assert_eq!(*MOVABLE_10, 10);
             assert_eq!(*MOVABLE_30, 30);
+
+            libc_println!("MOVABLE_LINK_SECTION: {:?}", MOVABLE_LINK_SECTION.as_slice());
         }
     }
 

--- a/tests/wasm/rust/src/lib.rs
+++ b/tests/wasm/rust/src/lib.rs
@@ -57,6 +57,48 @@ mod link_section {
         pub static DRIVER: Driver = Driver::new("driver", || libc_println!("driver"));
     }
 
+    mod movable {
+        use linktime::ctor;
+        use linktime::link_section::{section, in_section, TypedMovableSection};
+
+        #[section(movable)]
+        pub static MOVABLE_LINK_SECTION: TypedMovableSection<u32>;
+
+        #[in_section(MOVABLE_LINK_SECTION)]
+        pub static MOVABLE_40: u32 = 40;
+        #[in_section(MOVABLE_LINK_SECTION)]
+        pub static MOVABLE_20: u32 = 20;
+        #[in_section(MOVABLE_LINK_SECTION)]
+        pub static MOVABLE_10: u32 = 10;
+        #[in_section(MOVABLE_LINK_SECTION)]
+        pub static MOVABLE_30: u32 = 30;
+
+        #[ctor(unsafe, priority = 1)]
+        pub fn ctor() {
+            let movable_backrefs = unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() };
+            let movable_section = unsafe { MOVABLE_LINK_SECTION.as_mut_slice() };
+
+            for i in 0..movable_section.len() {
+                for j in i + 1..movable_section.len() {
+                    if movable_section[i] > movable_section[j] {
+                        movable_section.swap(i, j);
+                        movable_backrefs.swap(i, j);
+                    }
+                }
+            }
+            for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
+                unsafe {
+                    backref.set_current_ptr(item as *const u32);
+                }
+            }
+
+            assert_eq!(*MOVABLE_40, 40);
+            assert_eq!(*MOVABLE_20, 20);
+            assert_eq!(*MOVABLE_10, 10);
+            assert_eq!(*MOVABLE_30, 30);
+        }
+    }
+
     pub fn test_link_section() {
         libc_println!("test_link_section");
         libc_println!("DRIVER: {}", reference::DRIVER.name);

--- a/tests/wasm/rust/src/lib.rs
+++ b/tests/wasm/rust/src/lib.rs
@@ -76,23 +76,8 @@ mod link_section {
 
         #[ctor(unsafe, priority = 1)]
         pub fn ctor() {
-            {
-                let movable_backrefs = unsafe { MOVABLE_LINK_SECTION.as_mut_backrefs() };
-                let movable_section = unsafe { MOVABLE_LINK_SECTION.as_mut_slice() };
-
-                for i in 0..movable_section.len() {
-                    for j in i + 1..movable_section.len() {
-                        if movable_section[i] > movable_section[j] {
-                            movable_section.swap(i, j);
-                            movable_backrefs.swap(i, j);
-                        }
-                    }
-                }
-                for (item, backref) in movable_section.iter().zip(movable_backrefs.iter()) {
-                    unsafe {
-                        backref.set_current_ptr(item as *const u32);
-                    }
-                }
+            unsafe {
+                MOVABLE_LINK_SECTION.sort_unstable();
             }
 
             assert_eq!(*MOVABLE_40, 40);


### PR DESCRIPTION
This implements the `ScatteredSortedReferenceSlice` and the underlying `movable` link section that tracks 1) items and 2) backrefs, allowing for init-time fixup of static references.

The backrefs are stored in a section that is "near" the items themselves, and we perform a sort of those backrefs before the first time we access them.