### PR TITLE
Clean up the link-section macros

### DIFF
--- a/.github/jobs/_init.sh
+++ b/.github/jobs/_init.sh
@@ -1,4 +1,5 @@
-DEFAULT_TARGET=`rustc --print host-tuple`
+# This actually fails on older rustc
+DEFAULT_TARGET=`rustc --print host-tuple || echo x86_64-unknown-linux-gnu`
 TARGET="${TARGET:-$DEFAULT_TARGET}"
 
 CLIPPY_LINTS=$(cat <<EOF

--- a/.github/jobs/_init.sh
+++ b/.github/jobs/_init.sh
@@ -1,0 +1,21 @@
+DEFAULT_TARGET=`rustc --print host-tuple`
+TARGET="${TARGET:-$DEFAULT_TARGET}"
+
+CLIPPY_LINTS=$(cat <<EOF
+    -D clippy::all
+    -D deprecated-safe
+    -D future-incompatible
+    -D keyword-idents
+    -D let-underscore
+    -D nonstandard-style
+    -D refining-impl-trait
+    -D rust-2018-compatibility
+    -D rust-2018-idioms
+    -D rust-2021-compatibility
+    -D rust-2024-compatibility
+    -D unused
+    -D unsafe_code
+    -D unreachable-pub
+    -D missing-docs
+EOF
+)

--- a/.github/jobs/_init.sh
+++ b/.github/jobs/_init.sh
@@ -1,5 +1,5 @@
 # This actually fails on older rustc
-DEFAULT_TARGET=`rustc --print host-tuple || echo x86_64-unknown-linux-gnu`
+DEFAULT_TARGET=`rustc --print host-tuple || echo invalid-tuple-specify-one-explicitly`
 TARGET="${TARGET:-$DEFAULT_TARGET}"
 
 CLIPPY_LINTS=$(cat <<EOF

--- a/.github/jobs/build-ctor-minimal.sh
+++ b/.github/jobs/build-ctor-minimal.sh
@@ -9,11 +9,8 @@ rm Cargo.lock || true
 minimal_crates=(
   tests/ctor/edition-2018
   tests/ctor/edition-2021
+  tests/ctor/priority
   tests/dtor/link-section
-  tests/link_section/basic
-  tests/link_section/interior_mut
-  tests/link_section/mut
-  tests/link_section/no-default-features
 )
 for dir in "${minimal_crates[@]}"; do
   (cd "$dir" && (rm Cargo.lock || true) && cargo run --target "$TARGET")

--- a/.github/jobs/build-ctor-minimal.sh
+++ b/.github/jobs/build-ctor-minimal.sh
@@ -9,7 +9,6 @@ rm Cargo.lock || true
 minimal_crates=(
   tests/ctor/edition-2018
   tests/ctor/edition-2021
-  tests/ctor/priority
   tests/dtor/link-section
 )
 for dir in "${minimal_crates[@]}"; do

--- a/.github/jobs/build-minimal.sh
+++ b/.github/jobs/build-minimal.sh
@@ -9,6 +9,11 @@ rm Cargo.lock || true
 minimal_crates=(
   tests/ctor/edition-2018
   tests/ctor/edition-2021
+  tests/dtor/link-section
+  tests/link_section/basic
+  tests/link_section/interior_mut
+  tests/link_section/mut
+  tests/link_section/no-default-features
 )
 for dir in "${minimal_crates[@]}"; do
   (cd "$dir" && cargo run --target "$TARGET")

--- a/.github/jobs/build-minimal.sh
+++ b/.github/jobs/build-minimal.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 # Remove Cargo.lock for testing down-level Rust versions
 rm Cargo.lock || true
 

--- a/.github/jobs/build.sh
+++ b/.github/jobs/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 cargo build
 
 ctor_examples=(ctor-example ctor-advanced)

--- a/.github/jobs/lint.sh
+++ b/.github/jobs/lint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 cargo clippy --examples --bins --all --target "$TARGET" -- ${CLIPPY_LINTS}
 cargo fmt --check --all
 

--- a/.github/jobs/miri.sh
+++ b/.github/jobs/miri.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 # https://blog.rust-lang.org/2022/09/15/const-eval-safety-rule-revision/
 export RUSTFLAGS="-Z extra-const-ub-checks"
 # https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance

--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -14,5 +14,13 @@ sanitize_runs=(
 for spec in "${sanitize_runs[@]}"; do
   pkg="${spec%%:*}"
   example="${spec#*:}"
-  RUSTFLAGS="-Z sanitizer=address" cargo +nightly run -p "$pkg" --example "$example" --target "$TARGET"
+  RUSTFLAGS="--cfg linktime_asan" \
+    cargo +nightly rustc -p "$pkg" --example "$example" --target "$TARGET" -- \
+    -Z sanitizer=address -Z "crate-attr=feature(sanitize)"
+  if [[ -n "${TARGET:-}" ]]; then
+    example_exe="target/${TARGET}/debug/examples/${example}"
+  else
+    example_exe="target/debug/examples/${example}"
+  fi
+  "$example_exe"
 done

--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 # pkg:example pairs for address-sanitizer smoke runs
 sanitize_runs=(
   "ctor:ctor-example"
@@ -17,10 +19,5 @@ for spec in "${sanitize_runs[@]}"; do
   RUSTFLAGS="--cfg linktime_asan" \
     cargo +nightly rustc -p "$pkg" --example "$example" --target "$TARGET" -- \
     -Z sanitizer=address -Z "crate-attr=feature(sanitize)"
-  if [[ -n "${TARGET:-}" ]]; then
-    example_exe="target/${TARGET}/debug/examples/${example}"
-  else
-    example_exe="target/debug/examples/${example}"
-  fi
-  "$example_exe"
+  "target/${TARGET}/debug/examples/${example}"
 done

--- a/.github/jobs/test-used-linker.sh
+++ b/.github/jobs/test-used-linker.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 RUSTDOCFLAGS='--cfg linktime_used_linker' \
     RUSTFLAGS='-D warnings --cfg linktime_used_linker' \
     cargo test --no-fail-fast --target "$TARGET"

--- a/.github/jobs/test.sh
+++ b/.github/jobs/test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 RUSTFLAGS='-D warnings' cargo test --no-fail-fast --target "$TARGET"

--- a/.github/jobs/wasm.sh
+++ b/.github/jobs/wasm.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 cd "$ROOT/tests/wasm/rust"

--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+. $(dirname "$0")/_init.sh
+
 cargo zigbuild --workspace --bins --examples --target "$TARGET"
 
 zig_examples=(

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
                 target: x86_64-unknown-linux-musl
               macos:
                 os: macOS-latest
-                job: [lint, test, test-used-linker, miri, zigbuild, sanitize, build-minimal, build-ctor-minimal]
+                job: [lint, test, test-used-linker, miri, zigbuild, sanitize, build-minimal]
                 target: aarch64-apple-darwin
               windows:
                 os: windows-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
                 target: x86_64-unknown-linux-musl
               macos:
                 os: macOS-latest
-                job: [lint, test, test-used-linker, miri, zigbuild]
+                job: [lint, test, test-used-linker, miri, zigbuild, sanitize]
                 target: aarch64-apple-darwin
               windows:
                 os: windows-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,10 +47,10 @@ jobs:
               linux:
                 os:
                   ubuntu-latest:
-                    job: [test, test-used-linker, miri, wasm]
+                    job: [test, test-used-linker, miri, wasm, build, build-minimal, build-ctor-minimal]
                     target: x86_64-unknown-linux-gnu
                   ubuntu-slim:
-                    job: [build, build-minimal, lint, sanitize]
+                    job: [lint, sanitize]
                     target: x86_64-unknown-linux-gnu
               linux-musl:
                 os: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
                 target: x86_64-unknown-linux-musl
               macos:
                 os: macOS-latest
-                job: [lint, test, test-used-linker, miri, zigbuild, sanitize]
+                job: [lint, test, test-used-linker, miri, zigbuild, sanitize, build-minimal, build-ctor-minimal]
                 target: aarch64-apple-darwin
               windows:
                 os: windows-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,8 @@ jobs:
                 "this.job == 'lint'": [stable, nightly]
                 "this.job == 'test-used-linker'": nightly
                 "this.job == 'build'": [stable, beta, nightly]
-                "this.job == 'build-minimal'": ["1.65"]
+                "this.job == 'build-minimal'": ["1.85"]
+                "this.job == 'build-ctor-minimal'": ["1.65"]
                 "this.job == 'wasm'": ["1.85"]
                 "true": "stable"
             rust-extra-target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -321,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -1222,9 +1222,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -26,7 +26,8 @@ proc_macro = ["dep:linktime-proc-macro"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(linktime_no_fail_on_missing_unsafe)',
-    'cfg(linktime_used_linker)'
+    'cfg(linktime_used_linker)',
+    'cfg(linktime_asan)'
 ] }
 
 [dependencies]

--- a/ctor/README.md
+++ b/ctor/README.md
@@ -26,6 +26,8 @@ fn foo() {
 
 For most platforms, this library currently has a MSRV of **Rust >= 1.60**.
 
+The priority feature requires a MSRV of **Rust >= 1.85** on macOS targets.
+
 MSRV for WASM targets is **Rust >= 1.85**.
 
 ## Lightweight

--- a/ctor/docs/PREAMBLE.md
+++ b/ctor/docs/PREAMBLE.md
@@ -15,6 +15,8 @@ fn foo() {
 
 For most platforms, this library currently has a MSRV of **Rust >= 1.60**.
 
+The priority feature requires a MSRV of **Rust >= 1.85** on macOS targets.
+
 MSRV for WASM targets is **Rust >= 1.85**.
 
 ## Lightweight

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -9,10 +9,7 @@
     all(target_vendor = "apple", linktime_used_linker),
     feature(used_with_arg)
 )]
-#![cfg_attr(
-    all(target_vendor = "apple", linktime_asan),
-    feature(sanitize)
-)]
+#![cfg_attr(all(target_vendor = "apple", linktime_asan), feature(sanitize))]
 #![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 
 #[cfg(feature = "std")]

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -202,10 +202,9 @@ pub mod collect {
         };
     }
 
-    #[doc(hidden)]
     link_section::declarative::section!(
         #[section(typed)]
-        pub static _CTR0GR_ISIZE_FN: link_section::TypedSection<AtomicU8>;
+        static _CTR0GR_ISIZE_FN: link_section::TypedSection<AtomicU8>;
     );
 
     link_section::declarative::in_section!(

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -9,6 +9,10 @@
     all(target_vendor = "apple", linktime_used_linker),
     feature(used_with_arg)
 )]
+#![cfg_attr(
+    all(target_vendor = "apple", linktime_asan),
+    feature(sanitize)
+)]
 #![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 
 #[cfg(feature = "std")]

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -140,10 +140,9 @@ pub mod collect {
     // Note: The section names must be <= 16 characters long to fit in the mach-o limits.
     // These sections are shared between multiple versions of the ctor crate.
 
-    #[doc(hidden)]
     link_section::declarative::section!(
         #[section(mutable, no_macro)]
-        pub static _CTOR0_ISIZE_FN: link_section::TypedMutableSection<Constructor>;
+        static _CTOR0_ISIZE_FN: link_section::TypedMutableSection<Constructor>;
     );
 
     #[macro_export]

--- a/ctor/src/parse.rs
+++ b/ctor/src/parse.rs
@@ -809,7 +809,7 @@ macro_rules! __ctor_parse_impl {
         item = ($vis:vis static $ident:ident : &[fn()] = const $body:block;)
     ) ) => {
         $($meta)*
-        $vis static $ident: &[fn()] = const {
+        $vis static $ident: &[fn()] = /*const*/ {
             const __EXTERN_C_FNS: [extern "C" fn(); $ident.len()] = {
                 use ::core::mem::MaybeUninit;
                 let mut array: MaybeUninit<[extern "C" fn(); $ident.len()]> = MaybeUninit::uninit();

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -14,7 +14,7 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -14,7 +14,7 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -22,8 +22,8 @@ unsafe fn foo() {
                 priority: 500,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -15,7 +15,7 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            const _: ::ctor::collect::Constructor = const {
+            const _: ::ctor::collect::Constructor = {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,
                 > as ::link_section::__support::SectionItemType>::Item;
@@ -52,7 +52,7 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            const _: ::ctor::collect::Constructor = const {
+            const _: ::ctor::collect::Constructor = {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,
                 > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -23,8 +23,8 @@ const _: () = {
                     priority: 500,
                     ctor: __ctor_private,
                 };
-                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 #[used]
+                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                     __InSecStoredTy,
                 > = ::link_section::__support::SyncUnsafeCell::new(
@@ -60,8 +60,8 @@ const _: () = {
                     priority: 500,
                     ctor: __ctor_private,
                 };
-                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 #[used]
+                #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
                 static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                     __InSecStoredTy,
                 > = ::link_section::__support::SyncUnsafeCell::new(

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -15,7 +15,7 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            const _: ::ctor::collect::Constructor = {
+            const _: ::ctor::collect::Constructor = const {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,
                 > as ::link_section::__support::SectionItemType>::Item;
@@ -52,7 +52,7 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
-            const _: ::ctor::collect::Constructor = {
+            const _: ::ctor::collect::Constructor = const {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,
                 > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -26,8 +26,8 @@ unsafe fn foo() {
                 priority: 500,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -18,7 +18,7 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -18,7 +18,7 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -10,7 +10,7 @@ fn early() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -41,7 +41,7 @@ fn priority1() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -72,7 +72,7 @@ fn priority900() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -103,7 +103,7 @@ fn late() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -134,7 +134,7 @@ fn priority_default() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -165,7 +165,7 @@ fn priority_unspecified() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -10,7 +10,7 @@ fn early() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -41,7 +41,7 @@ fn priority1() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -72,7 +72,7 @@ fn priority900() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -103,7 +103,7 @@ fn late() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -134,7 +134,7 @@ fn priority_default() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;
@@ -165,7 +165,7 @@ fn priority_unspecified() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -18,8 +18,8 @@ fn early() {
                 priority: 101,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(
@@ -49,8 +49,8 @@ fn priority1() {
                 priority: 1,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(
@@ -80,8 +80,8 @@ fn priority900() {
                 priority: 900,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(
@@ -111,8 +111,8 @@ fn late() {
                 priority: (::ctor::collect::LATE),
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(
@@ -142,8 +142,8 @@ fn priority_default() {
                 priority: 500,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(
@@ -173,8 +173,8 @@ fn priority_unspecified() {
                 priority: 500,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -17,7 +17,7 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
-    const _: ::ctor::collect::Constructor = const {
+    const _: ::ctor::collect::Constructor = {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,
         > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -17,7 +17,7 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
-    const _: ::ctor::collect::Constructor = {
+    const _: ::ctor::collect::Constructor = const {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,
         > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -25,8 +25,8 @@ const _: () = {
             priority: 500,
             ctor: __ctor_private,
         };
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
         #[used]
+        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
             __InSecStoredTy,
         > = ::link_section::__support::SyncUnsafeCell::new(

--- a/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
@@ -17,7 +17,7 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
-    const _: ::ctor::collect::Constructor = const {
+    const _: ::ctor::collect::Constructor = {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,
         > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
@@ -17,7 +17,7 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
-    const _: ::ctor::collect::Constructor = {
+    const _: ::ctor::collect::Constructor = const {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,
         > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
@@ -25,8 +25,8 @@ const _: () = {
             priority: 500,
             ctor: __ctor_private,
         };
-        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
         #[used]
+        #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
             __InSecStoredTy,
         > = ::link_section::__support::SyncUnsafeCell::new(

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -14,7 +14,7 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -14,7 +14,7 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -22,8 +22,8 @@ unsafe fn foo() {
                 priority: 500,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -14,7 +14,7 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = const {
+        const _: ::ctor::collect::Constructor = {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -14,7 +14,7 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
-        const _: ::ctor::collect::Constructor = {
+        const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
             > as ::link_section::__support::SectionItemType>::Item;

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -22,8 +22,8 @@ fn foo() {
                 priority: 500,
                 ctor: __ctor_private,
             };
-            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             #[used]
+            #[link_section = "__DATA,_CTOR0_ISIZE_FN,regular,no_dead_strip"]
             static __LINK_SECTION_CONST_ITEM: ::link_section::__support::SyncUnsafeCell<
                 __InSecStoredTy,
             > = ::link_section::__support::SyncUnsafeCell::new(

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped MSRV to 1.85.0.
 - Significant rewrite to link-section's internal implementation.
 - Sections require a type: `#[section(typed)]`, `#[section(untyped)]`,
   `#[section(mutable)]`, `#[section(movable)]`, or `#[section(reference)]`.

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -26,6 +26,7 @@ tempfile = "3"
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(linktime_used_linker)',
+    'cfg(linktime_asan)',
 ] }
 
 [[example]]

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -317,7 +317,7 @@ pub mod __support {
                 item data section $section $($aux)?
                 #[link_section = __]
                 $($meta)*
-                $vis static $ident: $crate::__in_section_crate!(@type_select $path) = const{
+                $vis static $ident: $crate::__in_section_crate!(@type_select $path) = const {
                     const _: () = {
                         let _: *const <$path as $crate::__support::SectionItemTyped<$ty>>::Item = ::core::ptr::null();
                     };
@@ -357,7 +357,7 @@ pub mod __support {
         // movable static items expose a MovableRef and submit hidden value/backref records.
         (@typed[movable] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis static $ident:ident: $ty:ty = $value:expr;)) => {
             $($meta)*
-            $vis static $ident: $crate::MovableRef<$crate::__in_section_crate!(@type_select $path)> = {
+            $vis static $ident: $crate::MovableRef<$crate::__in_section_crate!(@type_select $path)> = const {
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 #[cfg(not(target_family = "wasm"))]
@@ -408,7 +408,7 @@ pub mod __support {
         // const items are the same across all other types
         (@typed[$section_type:ident] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis const $ident:tt: $ty:ty = $value:expr;)) => {
             $($meta)*
-            $vis const $ident: $ty = /*const*/ {
+            $vis const $ident: $ty = const {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
 

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -10,6 +10,7 @@ pub mod life_before_main {}
 
 mod item;
 mod macros;
+mod meta;
 mod platform;
 mod section_parse;
 mod sections;
@@ -126,49 +127,15 @@ pub mod __support {
     #[cfg(feature = "proc_macro")]
     pub use linktime_proc_macro::ident_concat;
 
-    #[cfg(not(linktime_used_linker))]
     #[doc(hidden)]
     #[macro_export]
-    macro_rules! __add_used {
-        (
-            $ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
-            $(#[$meta:meta])*
-            $vis:vis static $ident:ident : $($static:tt)*
-        ) => {
-            $crate::__add_section_link_attribute_impl!(
-                $ref_or_item $section $type $name $($aux)? #[$attr = __]
-                $(#[$meta])*
-                #[used]
-                #[cfg_attr(target_os = "aix", export_name = concat!("_", env!("CARGO_PKG_NAME"), "_",
-                    ::core::module_path!(), "_",
-                    stringify!($ident),
-                    "_L", line!(), "C", column!()))]
-                $vis static $ident : $($static)*
-            );
+    macro_rules! __hash_no_proc_macro {
+        ((__) (($($__prefix:tt)*)) ($($name:tt)*) (($($__suffix:tt)*)) $__hash_length:literal $__max_length:literal $__valid_section_chars:literal) => {
+            concat!($($__prefix),*, $(stringify!($name)),*, $($__suffix),*);
         };
     }
-
-    #[cfg(linktime_used_linker)]
-    #[doc(hidden)]
-    #[macro_export]
-    macro_rules! __add_used {
-        (
-            $ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
-            $(#[$meta:meta])*
-            $vis:vis static $ident:ident : $($static:tt)*
-        ) => {
-            $crate::__add_section_link_attribute_impl!(
-                $ref_or_item $section $type $name $($aux)? #[$attr = __]
-                $(#[$meta])*
-                #[used(linker)]
-                #[cfg_attr(target_os = "aix", export_name = concat!("_", env!("CARGO_PKG_NAME"), "_",
-                    ::core::module_path!(), "_",
-                    stringify!($ident),
-                    "_L", line!(), "C", column!()))]
-                $vis static $ident : $($static)*
-            );
-        };
-    }
+    #[cfg(not(feature = "proc_macro"))]
+    pub use __hash_no_proc_macro as hash;
 
     #[cfg(miri)]
     #[doc(hidden)]
@@ -189,10 +156,9 @@ pub mod __support {
             {
                 // These are not valid items, but they are valid pointers.
                 // We cannot safely use them - only take pointers to them.
-                $crate::__support::add_section_link_attribute!(
-                    $ref_or_item $section $type $name $($aux)?
-                    #[link_name = __]
+                $crate::__add_linktime_attributes_to_static!(
                     extern "C" {
+                        #[link_name = $crate::__support::section_name!(string $ref_or_item $section $type $name $($aux)?)]
                         static __SYMBOL: u8;
                     }
                 );
@@ -209,8 +175,8 @@ pub mod __support {
             $(#[$meta:meta])*
             $vis:vis static $($static:tt)*
         ) => {
-            $crate::__add_used!(
-                $ref_or_item $section $type $name $($aux)? #[$attr = __]
+            $crate::__add_linktime_attributes_to_static!(
+                #[$attr = $crate::__support::section_name!(string $ref_or_item $section $type $name $($aux)?)]
                 $(#[$meta])*
                 $vis static $($static)*
             );
@@ -221,46 +187,21 @@ pub mod __support {
                 $vis:vis static $($static:tt)*
             }
         ) => {
-            extern "C" {
-                $crate::__add_section_link_attribute_impl!(
-                    $ref_or_item $section $type $name $($aux)? #[$attr = __]
+            $crate::__add_linktime_attributes_to_static!(
+                extern "C" {
+                    #[link_name = $crate::__support::section_name!(string $ref_or_item $section $type $name $($aux)?)]
                     $(#[$meta])*
-                    #[allow(unsafe_code)]
                     $vis static $($static)*
-                );
-            }
+                }
+            );
         };
         ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __]
             $($item:tt)*) => {
-            $crate::__add_section_link_attribute_impl!(
-                $ref_or_item $section $type $name $($aux)? #[$attr = __]
-                #[allow(unsafe_code)]
+            $crate::__add_linktime_attributes_to_static!(
+                #[$attr = $crate::__support::section_name!(string $ref_or_item $section $type $name $($aux)?)]
                 $($item)*
             );
         };
-    );
-
-    #[cfg(feature = "proc_macro")]
-    #[doc(hidden)]
-    #[macro_export]
-    macro_rules! __add_section_link_attribute_impl(
-        ($ref_or_item:ident $section:ident $type:ident $name:ident $($aux:ident)? #[$attr:ident = __] $($item:tt)*) => {
-            $crate::__support::section_name!(
-                (#[$attr = __] #[allow(unsafe_code)] $($item)*)
-                $ref_or_item $section $type $name $($aux)?
-            );
-        }
-    );
-
-    #[cfg(not(feature = "proc_macro"))]
-    #[doc(hidden)]
-    #[macro_export]
-    macro_rules! __add_section_link_attribute_impl(
-        ($ref_or_item:ident $section:ident $type:ident $name:ident #[$attr:ident = __] $($item:tt)*) => {
-            #[$attr = $crate::__support::section_name!(
-                raw $ref_or_item $section $type $name
-            )] $($item)*
-        }
     );
 
     // Without the proc macro, only name/type supported (no `aux`).

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -163,7 +163,9 @@ pub mod __support {
                     }
                 );
                 // TODO: black_box when hint is stable
-                unsafe { &raw const __SYMBOL as *const () }
+                // TODO: MSRV: we can use &raw const once we bump MSRV
+                // unsafe { &raw const __SYMBOL as *const () }
+                unsafe { ::core::ptr::addr_of!(__SYMBOL) as *const () }
             }
         };
     }
@@ -331,7 +333,7 @@ pub mod __support {
         // mutable const items live in SyncUnsafeCell
         (@typed[mutable] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis const $ident:tt: $ty:ty = $value:expr;)) => {
             $($meta)*
-            $vis const $ident: $ty = const {
+            $vis const $ident: $ty = /*const*/ {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
 
@@ -355,7 +357,7 @@ pub mod __support {
         // movable static items expose a MovableRef and submit hidden value/backref records.
         (@typed[movable] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis static $ident:ident: $ty:ty = $value:expr;)) => {
             $($meta)*
-            $vis static $ident: $crate::MovableRef<$crate::__in_section_crate!(@type_select $path)> = const {
+            $vis static $ident: $crate::MovableRef<$crate::__in_section_crate!(@type_select $path)> = {
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 #[cfg(not(target_family = "wasm"))]
@@ -406,7 +408,7 @@ pub mod __support {
         // const items are the same across all other types
         (@typed[$section_type:ident] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis const $ident:tt: $ty:ty = $value:expr;)) => {
             $($meta)*
-            $vis const $ident: $ty = const {
+            $vis const $ident: $ty = /*const*/ {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
 
@@ -426,7 +428,7 @@ pub mod __support {
         (@typed[reference] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis static $ident:ident: $ty:ty = $value:expr;)) => {
             #[cfg(target_family="wasm")]
             $($meta)*
-            $vis static $ident: $crate::reference::Ref<$crate::__in_section_crate!(@type_select $path)> = const {
+            $vis static $ident: $crate::reference::Ref<$crate::__in_section_crate!(@type_select $path)> = {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
                 $crate::__register_wasm_item!(reference, value=__LINK_SECTION_CONST_ITEM_VALUE, ref=$ident, section=$section $($aux)?);

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -333,7 +333,7 @@ pub mod __support {
         // mutable const items live in SyncUnsafeCell
         (@typed[mutable] $section:tt, $($aux:ident)?, $path:path, ($($meta:tt)*) ($vis:vis const $ident:tt: $ty:ty = $value:expr;)) => {
             $($meta)*
-            $vis const $ident: $ty = /*const*/ {
+            $vis const $ident: $ty = const {
                 type __InSecStoredTy = $crate::__in_section_crate!(@type_select $path);
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = $value;
 

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -130,8 +130,8 @@ pub mod __support {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! __hash_no_proc_macro {
-        ((__) (($($__prefix:tt)*)) ($($name:tt)*) (($($__suffix:tt)*)) $__hash_length:literal $__max_length:literal $__valid_section_chars:literal) => {
-            concat!($($__prefix),*, $(stringify!($name)),*, $($__suffix),*);
+        ((__) (($($__prefix:literal $(,)?)*)) ($($name:tt)*) (($($__suffix:literal $(,)?)*)) $__hash_length:literal $__max_length:literal $__valid_section_chars:literal) => {
+            concat!($($__prefix,)* $(stringify!($name)),* $(,$__suffix)*);
         };
     }
     #[cfg(not(feature = "proc_macro"))]

--- a/link-section/src/meta.rs
+++ b/link-section/src/meta.rs
@@ -61,6 +61,7 @@ macro_rules! __generate_macro {
     (@entry next=$next:path[$next_args:tt], input=(all=($($all:tt)*) export=($($export:tt)*)), args=[$dollar:tt]) => {
         #[doc(hidden)]
         #[macro_export]
+        #[allow(edition_2024_expr_fragment_specifier)]
         macro_rules! __add_linktime_attributes_to_static {
             (
                 #[link_section = $link_section:expr]

--- a/link-section/src/meta.rs
+++ b/link-section/src/meta.rs
@@ -1,4 +1,5 @@
 //! Generate a macro to add the various `used` and other attributes to a static.
+#![allow(unknown_lints, edition_2024_expr_fragment_specifier)]
 
 use crate::{__chain, __perform};
 
@@ -60,7 +61,6 @@ macro_rules! __generate_macro {
     (@entry next=$next:path[$next_args:tt], input=(all=($($all:tt)*) export=($(($($export:tt)*))?)), args=[$dollar:tt]) => {
         #[doc(hidden)]
         #[macro_export]
-        #[allow(edition_2024_expr_fragment_specifier)]
         macro_rules! __add_linktime_attributes_to_static {
             (
                 #[link_section = $link_section:expr]

--- a/link-section/src/meta.rs
+++ b/link-section/src/meta.rs
@@ -41,8 +41,8 @@ macro_rules! __add_asan {
 macro_rules! __add_export_name {
     (@entry next=$next:path[$next_args:tt], input=(all=$all:tt export=($($input:tt)*)), args=[$dollar:tt]) => {
         $next!($next_args, (all=$all export=((
-            "_P", env!("CARGO_PKG_NAME"), 
-            "_M", ::core::module_path!(), 
+            "_P", env!("CARGO_PKG_NAME"),
+            "_M", ::core::module_path!(),
             "_L", line!(),
             "_C", column!()
         ))));

--- a/link-section/src/meta.rs
+++ b/link-section/src/meta.rs
@@ -89,6 +89,7 @@ macro_rules! __generate_macro {
                     $dollar (#[$meta:meta])* $vis:vis static $ident:ident : $ty:ty;
                 }
             ) => {
+                #[allow(missing_unsafe_on_extern)] // MSRV
                 extern "C" {
                     #[link_name = $link_name]
                     $dollar (#[$meta])* $vis static $ident : $ty;

--- a/link-section/src/meta.rs
+++ b/link-section/src/meta.rs
@@ -1,0 +1,109 @@
+//! Generate a macro to add the various `used` and other attributes to a static.
+
+use crate::{__chain, __perform};
+
+__perform!((all=() export=()), __chain[
+    __add_used,
+    __add_asan,
+    __add_export_name,
+    __generate_macro[$],
+]);
+
+#[cfg(linktime_used_linker)]
+macro_rules! __add_used {
+    (@entry next=$next:path[$next_args:tt], input=(all=($($input:tt)*) export=$export:tt)) => {
+        $next!($next_args, (all=($($input)* #[used(linker)]) export=$export));
+    };
+}
+
+#[cfg(not(linktime_used_linker))]
+macro_rules! __add_used {
+    (@entry next=$next:path[$next_args:tt], input=(all=($($input:tt)*) export=$export:tt)) => {
+        $next!($next_args, (all=($($input)* #[used]) export=$export));
+    };
+}
+
+#[cfg(linktime_asan)]
+macro_rules! __add_asan {
+    (@entry next=$next:path[$next_args:tt], input=(all=($($input:tt)*) export=$export:tt)) => {
+        $next!($next_args, (all=($($input)* #[sanitize(address = "off")]) export=$export));
+    };
+}
+
+#[cfg(not(linktime_asan))]
+macro_rules! __add_asan {
+    (@entry next=$next:path[$next_args:tt], input=$input:tt) => {
+        $next!($next_args, $input);
+    };
+}
+
+#[cfg(target_os = "aix")]
+macro_rules! __add_export_name {
+    (@entry next=$next:path[$next_args:tt], input=(all=$all:tt export=($($input:tt)*))) => {
+        $next!($next_args, (all=$all export=($($input)* #[export_name = concat!(
+            "_", env!("CARGO_PKG_NAME"), "_",
+            ::core::module_path!(), "_",
+            stringify!($ident),
+            "_L", line!(),
+            "_C", column!()
+        )])));
+    };
+}
+
+#[cfg(not(target_os = "aix"))]
+macro_rules! __add_export_name {
+    (@entry next=$next:path[$next_args:tt], input=$input:tt) => {
+        $next!($next_args, $input);
+    };
+}
+
+macro_rules! __generate_macro {
+    (@entry next=$next:path[$next_args:tt], input=(all=($($all:tt)*) export=($($export:tt)*)), args=[$dollar:tt]) => {
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! __add_linktime_attributes_to_static {
+            (
+                #[link_section = $link_section:expr]
+                $dollar (#[$meta:meta])* $vis:vis static $ident:ident : $dollar ($static:tt)*
+            ) => {
+                $($all)*
+                $($export)*
+                $dollar (#[$meta])*
+                #[link_section = $link_section]
+                $vis static $ident : $dollar ($static)*
+            };
+
+            (
+                #[export_name = $export_name:expr]
+                $dollar (#[$meta:meta])* $vis:vis static $ident:ident : $dollar ($static:tt)*
+            ) => {
+                $($all)*
+                $dollar (#[$meta])*
+                $vis static $ident : $dollar ($static)*
+            };
+
+            (
+                extern "C" {
+                    #[link_name = $link_name:expr]
+                    $dollar (#[$meta:meta])* $vis:vis static $ident:ident : $ty:ty;
+                }
+            ) => {
+                extern "C" {
+                    #[link_name = $link_name]
+                    $dollar (#[$meta])* $vis static $ident : $ty;
+                }
+            };
+
+            (
+                $dollar ($item:tt)*
+            ) => {
+                $dollar ($item)*
+            };
+        }
+    };
+}
+
+pub(crate) use __add_asan;
+pub(crate) use __add_export_name;
+pub(crate) use __add_used;
+pub(crate) use __generate_macro;

--- a/link-section/src/meta.rs
+++ b/link-section/src/meta.rs
@@ -5,7 +5,7 @@ use crate::{__chain, __perform};
 __perform!((all=() export=()), __chain[
     __add_used,
     __add_asan,
-    __add_export_name,
+    __add_export_name[$],
     __generate_macro[$],
 ]);
 
@@ -39,26 +39,25 @@ macro_rules! __add_asan {
 
 #[cfg(target_os = "aix")]
 macro_rules! __add_export_name {
-    (@entry next=$next:path[$next_args:tt], input=(all=$all:tt export=($($input:tt)*))) => {
-        $next!($next_args, (all=$all export=($($input)* #[export_name = concat!(
-            "_", env!("CARGO_PKG_NAME"), "_",
-            ::core::module_path!(), "_",
-            stringify!($ident),
+    (@entry next=$next:path[$next_args:tt], input=(all=$all:tt export=($($input:tt)*)), args=[$dollar:tt]) => {
+        $next!($next_args, (all=$all export=((
+            "_P", env!("CARGO_PKG_NAME"), 
+            "_M", ::core::module_path!(), 
             "_L", line!(),
             "_C", column!()
-        )])));
+        ))));
     };
 }
 
 #[cfg(not(target_os = "aix"))]
 macro_rules! __add_export_name {
-    (@entry next=$next:path[$next_args:tt], input=$input:tt) => {
+    (@entry next=$next:path[$next_args:tt], input=$input:tt, args=[$dollar:tt]) => {
         $next!($next_args, $input);
     };
 }
 
 macro_rules! __generate_macro {
-    (@entry next=$next:path[$next_args:tt], input=(all=($($all:tt)*) export=($($export:tt)*)), args=[$dollar:tt]) => {
+    (@entry next=$next:path[$next_args:tt], input=(all=($($all:tt)*) export=($(($($export:tt)*))?)), args=[$dollar:tt]) => {
         #[doc(hidden)]
         #[macro_export]
         #[allow(edition_2024_expr_fragment_specifier)]
@@ -68,7 +67,7 @@ macro_rules! __generate_macro {
                 $dollar (#[$meta:meta])* $vis:vis static $ident:ident : $dollar ($static:tt)*
             ) => {
                 $($all)*
-                $($export)*
+                $(#[export_name = concat! (stringify!($ident), $($export)* )])?
                 $dollar (#[$meta])*
                 #[link_section = $link_section]
                 $vis static $ident : $dollar ($static)*
@@ -78,6 +77,7 @@ macro_rules! __generate_macro {
                 #[export_name = $export_name:expr]
                 $dollar (#[$meta:meta])* $vis:vis static $ident:ident : $dollar ($static:tt)*
             ) => {
+                #[export_name = $export_name]
                 $($all)*
                 $dollar (#[$meta])*
                 $vis static $ident : $dollar ($static)*

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -181,26 +181,6 @@ impl<T> Alignment<T> {
 /// Declares the section_name macro.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(feature = "proc_macro")]
-macro_rules! __section_name_string {
-    ($name:ident $($rest:tt)*) => {
-        $crate::$name!((__) $($rest)*)
-    };
-}
-
-/// Declares the section_name macro.
-#[macro_export]
-#[doc(hidden)]
-#[cfg(not(feature = "proc_macro"))]
-macro_rules! __section_name_string {
-    ($name:ident $($rest:tt)*) => {
-        $crate::$name!(raw $($rest)*)
-    };
-}
-
-/// Declares the section_name macro.
-#[macro_export]
-#[doc(hidden)]
 macro_rules! __def_section_name {
     (
         $__name:ident,
@@ -218,35 +198,17 @@ macro_rules! __def_section_name {
         #[doc(hidden)]
         macro_rules! $__name {
             $(
-                (raw item $__section $__type $name:ident) => {
-                    concat!(concat! $__prefix, stringify!($name), concat! $__suffix);
+                (string item $__section $__type $name:ident) => {
+                    $crate::__support::hash!((__) ($__prefix) ($name) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
                 };
-                (raw item $__section $__type $name:ident $aux:ident) => {
-                    concat!(concat! $__prefix, stringify!($name), $__aux_sep, stringify!($aux), concat! $__suffix);
+                (string item $__section $__type $name:ident $aux:ident) => {
+                    $crate::__support::hash!((__) ($__prefix) ($name $__aux_sep $aux) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
                 };
-                (raw backref $__section $__type $name:ident) => {
-                    concat!(concat! $__prefix, stringify!($name), $__refs_sep, concat! $__suffix);
+                (string backref $__section $__type $name:ident) => {
+                    $crate::__support::hash!((__) ($__prefix) ($name $__refs_sep) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
                 };
-                (raw backref $__section $__type $name:ident $aux:ident) => {
-                    concat!(concat! $__prefix, stringify!($name), $__aux_sep, stringify!($aux), $__refs_sep, concat! $__suffix);
-                };
-                (string $ref_or_item:ident $__section $__type $name:ident) => {
-                    $crate::__section_name_string!($__name $ref_or_item $__section $__type $name)
-                };
-                (string $ref_or_item:ident $__section $__type $name:ident $aux:ident) => {
-                    $crate::__section_name_string!($__name $ref_or_item $__section $__type $name $aux)
-                };
-                ($pattern:tt item $__section $__type $name:ident) => {
-                    $crate::__support::hash!($pattern ($__prefix) $name ($__suffix) $__hash_length $__max_length $__valid_section_chars);
-                };
-                ($pattern:tt item $__section $__type $name:ident $aux:ident) => {
-                    $crate::__support::hash!($pattern ($__prefix) ($name $__aux_sep $aux) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
-                };
-                ($pattern:tt backref $__section $__type $name:ident) => {
-                    $crate::__support::hash!($pattern ($__prefix) ($name $__refs_sep) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
-                };
-                ($pattern:tt backref $__section $__type $name:ident $aux:ident) => {
-                    $crate::__support::hash!($pattern ($__prefix) ($name $__aux_sep $aux $__refs_sep) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
+                (string backref $__section $__type $name:ident $aux:ident) => {
+                    $crate::__support::hash!((__) ($__prefix) ($name $__aux_sep $aux $__refs_sep) ($__suffix) $__hash_length $__max_length $__valid_section_chars);
                 };
             )*
             ($pattern:tt $unknown_ref_or_item:ident $unknown_section:ident $unknown_type:ident $name:ident) => {

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -11,6 +11,7 @@ impl FOO {
             let section = {
                 ::link_section::__support::PtrBounds::new(
                     {
+                        #[allow(missing_unsafe_on_extern)]
                         extern "C" {
                             #[link_name = "\u{1}section$start$__DATA$FOO"]
                             static __SYMBOL: u8;
@@ -18,6 +19,7 @@ impl FOO {
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                     {
+                        #[allow(missing_unsafe_on_extern)]
                         extern "C" {
                             #[link_name = "\u{1}section$end$__DATA$FOO"]
                             static __SYMBOL: u8;

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -66,7 +66,7 @@ impl ::core::iter::IntoIterator for FOO {
     }
 }
 fn foo() {
-    const _: fn() = const {
+    const _: fn() = {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -66,7 +66,7 @@ impl ::core::iter::IntoIterator for FOO {
     }
 }
 fn foo() {
-    const _: fn() = {
+    const _: fn() = const {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -13,8 +13,6 @@ impl FOO {
                     {
                         extern "C" {
                             #[link_name = "\u{1}section$start$__DATA$FOO"]
-                            #[allow(unsafe_code)]
-                            #[allow(unsafe_code)]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -22,8 +20,6 @@ impl FOO {
                     {
                         extern "C" {
                             #[link_name = "\u{1}section$end$__DATA$FOO"]
-                            #[allow(unsafe_code)]
-                            #[allow(unsafe_code)]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -71,9 +67,8 @@ fn foo() {
     const _: fn() = const {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
-        #[link_section = "__DATA,FOO,regular,no_dead_strip"]
-        #[allow(unsafe_code)]
         #[used]
+        #[link_section = "__DATA,FOO,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
@@ -75,18 +75,18 @@ impl ::core::iter::IntoIterator for FOO {
     }
 }
 const DRIVER: Driver =
-    const {
-            type __InSecStoredTy =
-                <FOO as ::link_section::__support::SectionItemType>::Item;
-            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
-                Driver::new("driver", || ());
-            ;
-            #[used]
-            #[export_name =
-            "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L22_C1"]
-            #[link_section = "_data_link_section_FOO"]
-            static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
-                __LINK_SECTION_CONST_ITEM_VALUE;
-            __LINK_SECTION_CONST_ITEM_VALUE
-        };
+    {
+        type __InSecStoredTy =
+            <FOO as ::link_section::__support::SectionItemType>::Item;
+        const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
+            Driver::new("driver", || ());
+        ;
+        #[used]
+        #[export_name =
+        "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L22_C1"]
+        #[link_section = "_data_link_section_FOO"]
+        static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
+            __LINK_SECTION_CONST_ITEM_VALUE;
+        __LINK_SECTION_CONST_ITEM_VALUE
+    };
 fn main() {}

--- a/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
@@ -75,18 +75,18 @@ impl ::core::iter::IntoIterator for FOO {
     }
 }
 const DRIVER: Driver =
-    {
-        type __InSecStoredTy =
-            <FOO as ::link_section::__support::SectionItemType>::Item;
-        const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
-            Driver::new("driver", || ());
-        ;
-        #[used]
-        #[export_name =
-        "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L22_C1"]
-        #[link_section = "_data_link_section_FOO"]
-        static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
-            __LINK_SECTION_CONST_ITEM_VALUE;
-        __LINK_SECTION_CONST_ITEM_VALUE
-    };
+    const {
+            type __InSecStoredTy =
+                <FOO as ::link_section::__support::SectionItemType>::Item;
+            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
+                Driver::new("driver", || ());
+            ;
+            #[used]
+            #[export_name =
+            "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L22_C1"]
+            #[link_section = "_data_link_section_FOO"]
+            static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
+                __LINK_SECTION_CONST_ITEM_VALUE;
+            __LINK_SECTION_CONST_ITEM_VALUE
+        };
 fn main() {}

--- a/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
@@ -25,6 +25,7 @@ impl FOO {
                 let section =
                     {
                         ::link_section::__support::PtrBounds::new({
+                                #[allow(missing_unsafe_on_extern)]
                                 extern "C" {
                                     #[link_name = "__start__data_link_section_FOO"]
                                     static __SYMBOL: u8;
@@ -32,6 +33,7 @@ impl FOO {
                                 unsafe { &raw const __SYMBOL as *const () }
                             },
                             {
+                                #[allow(missing_unsafe_on_extern)]
                                 extern "C" {
                                     #[link_name = "__stop__data_link_section_FOO"]
                                     static __SYMBOL: u8;

--- a/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
@@ -80,7 +80,8 @@ const DRIVER: Driver =
                 Driver::new("driver", || ());
             ;
             #[used]
-            #[export_name = "_expand_probe_expand_probe_$ident_L22_C1"]
+            #[export_name =
+            "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L22_C1"]
             #[link_section = "_data_link_section_FOO"]
             static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
                 __LINK_SECTION_CONST_ITEM_VALUE;

--- a/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
@@ -27,7 +27,6 @@ impl FOO {
                         ::link_section::__support::PtrBounds::new({
                                 extern "C" {
                                     #[link_name = "__start__data_link_section_FOO"]
-                                    #[allow(unsafe_code)]
                                     static __SYMBOL: u8;
                                 }
                                 unsafe { &raw const __SYMBOL as *const () }
@@ -35,7 +34,6 @@ impl FOO {
                             {
                                 extern "C" {
                                     #[link_name = "__stop__data_link_section_FOO"]
-                                    #[allow(unsafe_code)]
                                     static __SYMBOL: u8;
                                 }
                                 unsafe { &raw const __SYMBOL as *const () }
@@ -81,10 +79,9 @@ const DRIVER: Driver =
             const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
                 Driver::new("driver", || ());
             ;
-            #[link_section = "_data_link_section_FOO"]
             #[used]
-            #[export_name =
-            "_expand_probe_expand_probe___LINK_SECTION_CONST_ITEM_L22C1"]
+            #[export_name = "_expand_probe_expand_probe_$ident_L22_C1"]
+            #[link_section = "_data_link_section_FOO"]
             static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
                 __LINK_SECTION_CONST_ITEM_VALUE;
             __LINK_SECTION_CONST_ITEM_VALUE

--- a/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
@@ -79,6 +79,7 @@ const DRIVER: Driver =
             #[used]
             #[link_section = ".data.link_section.FOO"]
             static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+            #[allow(missing_unsafe_on_extern)]
             extern "C" {
                 #[link_name = ".data.link_section.FOO.bounds"]
                 static __LINK_SECTION_INFO:

--- a/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
@@ -26,6 +26,7 @@ impl FOO {
                     {
                         static __LINK_SECTION_NAME: &'static str =
                             ".data.link_section.FOO";
+                        #[export_name = ".data.link_section.FOO.bounds"]
                         #[used]
                         #[used]
                         static __LINK_SECTION_INFO:

--- a/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
@@ -71,41 +71,41 @@ impl ::core::iter::IntoIterator for FOO {
     }
 }
 const DRIVER: Driver =
-    const {
-            type __InSecStoredTy =
-                <FOO as ::link_section::__support::SectionItemType>::Item;
-            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
-                Driver::new("driver", || ());
-            #[used]
-            #[link_section = ".data.link_section.FOO"]
-            static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
-            #[allow(missing_unsafe_on_extern)]
-            extern "C" {
-                #[link_name = ".data.link_section.FOO.bounds"]
-                static __LINK_SECTION_INFO:
-                    ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
-            }
-            #[link_section = ".init_array.0"]
-            #[used]
-            #[allow(non_snake_case)]
-            static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
-                {
-                    extern "C" fn __LINK_SECTION_ITEM_FN() {
-                        static DISARMED: ::core::sync::atomic::AtomicBool =
-                            ::core::sync::atomic::AtomicBool::new(false);
-                        if DISARMED.swap(true,
-                                ::core::sync::atomic::Ordering::Relaxed) {
-                            return;
-                        }
-                        unsafe {
-                            let ptr =
-                                ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
-                            ::core::ptr::write(ptr as *mut _,
-                                __LINK_SECTION_CONST_ITEM_VALUE);
-                        }
+    {
+        type __InSecStoredTy =
+            <FOO as ::link_section::__support::SectionItemType>::Item;
+        const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
+            Driver::new("driver", || ());
+        #[used]
+        #[link_section = ".data.link_section.FOO"]
+        static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+        #[allow(missing_unsafe_on_extern)]
+        extern "C" {
+            #[link_name = ".data.link_section.FOO.bounds"]
+            static __LINK_SECTION_INFO:
+                ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
+        }
+        #[link_section = ".init_array.0"]
+        #[used]
+        #[allow(non_snake_case)]
+        static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
+            {
+                extern "C" fn __LINK_SECTION_ITEM_FN() {
+                    static DISARMED: ::core::sync::atomic::AtomicBool =
+                        ::core::sync::atomic::AtomicBool::new(false);
+                    if DISARMED.swap(true,
+                            ::core::sync::atomic::Ordering::Relaxed) {
+                        return;
                     }
-                    __LINK_SECTION_ITEM_FN
-                };
-            __LINK_SECTION_CONST_ITEM_VALUE
-        };
+                    unsafe {
+                        let ptr =
+                            ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
+                        ::core::ptr::write(ptr as *mut _,
+                            __LINK_SECTION_CONST_ITEM_VALUE);
+                    }
+                }
+                __LINK_SECTION_ITEM_FN
+            };
+        __LINK_SECTION_CONST_ITEM_VALUE
+    };
 fn main() {}

--- a/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
@@ -26,7 +26,6 @@ impl FOO {
                     {
                         static __LINK_SECTION_NAME: &'static str =
                             ".data.link_section.FOO";
-                        #[export_name = ".data.link_section.FOO.bounds"]
                         #[used]
                         #[used]
                         static __LINK_SECTION_INFO:
@@ -76,12 +75,11 @@ const DRIVER: Driver =
                 <FOO as ::link_section::__support::SectionItemType>::Item;
             const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
                 Driver::new("driver", || ());
-            #[link_section = ".data.link_section.FOO"]
             #[used]
+            #[link_section = ".data.link_section.FOO"]
             static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
             extern "C" {
                 #[link_name = ".data.link_section.FOO.bounds"]
-                #[allow(unsafe_code)]
                 static __LINK_SECTION_INFO:
                     ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
             }

--- a/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section-const/wasm32-unknown-unknown.rs
@@ -71,41 +71,41 @@ impl ::core::iter::IntoIterator for FOO {
     }
 }
 const DRIVER: Driver =
-    {
-        type __InSecStoredTy =
-            <FOO as ::link_section::__support::SectionItemType>::Item;
-        const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
-            Driver::new("driver", || ());
-        #[used]
-        #[link_section = ".data.link_section.FOO"]
-        static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
-        #[allow(missing_unsafe_on_extern)]
-        extern "C" {
-            #[link_name = ".data.link_section.FOO.bounds"]
-            static __LINK_SECTION_INFO:
-                ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
-        }
-        #[link_section = ".init_array.0"]
-        #[used]
-        #[allow(non_snake_case)]
-        static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
-            {
-                extern "C" fn __LINK_SECTION_ITEM_FN() {
-                    static DISARMED: ::core::sync::atomic::AtomicBool =
-                        ::core::sync::atomic::AtomicBool::new(false);
-                    if DISARMED.swap(true,
-                            ::core::sync::atomic::Ordering::Relaxed) {
-                        return;
+    const {
+            type __InSecStoredTy =
+                <FOO as ::link_section::__support::SectionItemType>::Item;
+            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy =
+                Driver::new("driver", || ());
+            #[used]
+            #[link_section = ".data.link_section.FOO"]
+            static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+            #[allow(missing_unsafe_on_extern)]
+            extern "C" {
+                #[link_name = ".data.link_section.FOO.bounds"]
+                static __LINK_SECTION_INFO:
+                    ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
+            }
+            #[link_section = ".init_array.0"]
+            #[used]
+            #[allow(non_snake_case)]
+            static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
+                {
+                    extern "C" fn __LINK_SECTION_ITEM_FN() {
+                        static DISARMED: ::core::sync::atomic::AtomicBool =
+                            ::core::sync::atomic::AtomicBool::new(false);
+                        if DISARMED.swap(true,
+                                ::core::sync::atomic::Ordering::Relaxed) {
+                            return;
+                        }
+                        unsafe {
+                            let ptr =
+                                ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
+                            ::core::ptr::write(ptr as *mut _,
+                                __LINK_SECTION_CONST_ITEM_VALUE);
+                        }
                     }
-                    unsafe {
-                        let ptr =
-                            ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
-                        ::core::ptr::write(ptr as *mut _,
-                            __LINK_SECTION_CONST_ITEM_VALUE);
-                    }
-                }
-                __LINK_SECTION_ITEM_FN
-            };
-        __LINK_SECTION_CONST_ITEM_VALUE
-    };
+                    __LINK_SECTION_ITEM_FN
+                };
+            __LINK_SECTION_CONST_ITEM_VALUE
+        };
 fn main() {}

--- a/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
@@ -19,7 +19,6 @@ impl FOO {
                         ::link_section::__support::PtrBounds::new({
                                 extern "C" {
                                     #[link_name = "__start__data_link_section_FOO"]
-                                    #[allow(unsafe_code)]
                                     static __SYMBOL: u8;
                                 }
                                 unsafe { &raw const __SYMBOL as *const () }
@@ -27,7 +26,6 @@ impl FOO {
                             {
                                 extern "C" {
                                     #[link_name = "__stop__data_link_section_FOO"]
-                                    #[allow(unsafe_code)]
                                     static __SYMBOL: u8;
                                 }
                                 unsafe { &raw const __SYMBOL as *const () }
@@ -73,10 +71,9 @@ fn foo() {
                     <FOO as ::link_section::__support::SectionItemType>::Item;
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
                 ;
-                #[link_section = "_data_link_section_FOO"]
                 #[used]
-                #[export_name =
-                "_expand_probe_expand_probe___LINK_SECTION_CONST_ITEM_L11C1"]
+                #[export_name = "_expand_probe_expand_probe_$ident_L11_C1"]
+                #[link_section = "_data_link_section_FOO"]
                 static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
                     __LINK_SECTION_CONST_ITEM_VALUE;
                 __LINK_SECTION_CONST_ITEM_VALUE

--- a/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
@@ -72,7 +72,8 @@ fn foo() {
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
                 ;
                 #[used]
-                #[export_name = "_expand_probe_expand_probe_$ident_L11_C1"]
+                #[export_name =
+                "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L11_C1"]
                 #[link_section = "_data_link_section_FOO"]
                 static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
                     __LINK_SECTION_CONST_ITEM_VALUE;

--- a/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
@@ -17,6 +17,7 @@ impl FOO {
                 let section =
                     {
                         ::link_section::__support::PtrBounds::new({
+                                #[allow(missing_unsafe_on_extern)]
                                 extern "C" {
                                     #[link_name = "__start__data_link_section_FOO"]
                                     static __SYMBOL: u8;
@@ -24,6 +25,7 @@ impl FOO {
                                 unsafe { &raw const __SYMBOL as *const () }
                             },
                             {
+                                #[allow(missing_unsafe_on_extern)]
                                 extern "C" {
                                     #[link_name = "__stop__data_link_section_FOO"]
                                     static __SYMBOL: u8;

--- a/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
@@ -68,18 +68,18 @@ impl ::core::iter::IntoIterator for FOO {
 }
 fn foo() {
     const _: fn() =
-        const {
-                type __InSecStoredTy =
-                    <FOO as ::link_section::__support::SectionItemType>::Item;
-                const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
-                ;
-                #[used]
-                #[export_name =
-                "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L11_C1"]
-                #[link_section = "_data_link_section_FOO"]
-                static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
-                    __LINK_SECTION_CONST_ITEM_VALUE;
-                __LINK_SECTION_CONST_ITEM_VALUE
-            };
+        {
+            type __InSecStoredTy =
+                <FOO as ::link_section::__support::SectionItemType>::Item;
+            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
+            ;
+            #[used]
+            #[export_name =
+            "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L11_C1"]
+            #[link_section = "_data_link_section_FOO"]
+            static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
+                __LINK_SECTION_CONST_ITEM_VALUE;
+            __LINK_SECTION_CONST_ITEM_VALUE
+        };
 }
 fn main() {}

--- a/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
@@ -68,18 +68,18 @@ impl ::core::iter::IntoIterator for FOO {
 }
 fn foo() {
     const _: fn() =
-        {
-            type __InSecStoredTy =
-                <FOO as ::link_section::__support::SectionItemType>::Item;
-            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
-            ;
-            #[used]
-            #[export_name =
-            "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L11_C1"]
-            #[link_section = "_data_link_section_FOO"]
-            static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
-                __LINK_SECTION_CONST_ITEM_VALUE;
-            __LINK_SECTION_CONST_ITEM_VALUE
-        };
+        const {
+                type __InSecStoredTy =
+                    <FOO as ::link_section::__support::SectionItemType>::Item;
+                const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
+                ;
+                #[used]
+                #[export_name =
+                "__LINK_SECTION_CONST_ITEM_Pexpand_probe_Mexpand_probe_L11_C1"]
+                #[link_section = "_data_link_section_FOO"]
+                static __LINK_SECTION_CONST_ITEM: __InSecStoredTy =
+                    __LINK_SECTION_CONST_ITEM_VALUE;
+                __LINK_SECTION_CONST_ITEM_VALUE
+            };
 }
 fn main() {}

--- a/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
@@ -64,41 +64,41 @@ impl ::core::iter::IntoIterator for FOO {
 }
 fn foo() {
     const _: fn() =
-        {
-            type __InSecStoredTy =
-                <FOO as ::link_section::__support::SectionItemType>::Item;
-            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
-            #[used]
-            #[link_section = ".data.link_section.FOO"]
-            static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
-            #[allow(missing_unsafe_on_extern)]
-            extern "C" {
-                #[link_name = ".data.link_section.FOO.bounds"]
-                static __LINK_SECTION_INFO:
-                    ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
-            }
-            #[link_section = ".init_array.0"]
-            #[used]
-            #[allow(non_snake_case)]
-            static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
-                {
-                    extern "C" fn __LINK_SECTION_ITEM_FN() {
-                        static DISARMED: ::core::sync::atomic::AtomicBool =
-                            ::core::sync::atomic::AtomicBool::new(false);
-                        if DISARMED.swap(true,
-                                ::core::sync::atomic::Ordering::Relaxed) {
-                            return;
+        const {
+                type __InSecStoredTy =
+                    <FOO as ::link_section::__support::SectionItemType>::Item;
+                const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
+                #[used]
+                #[link_section = ".data.link_section.FOO"]
+                static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+                #[allow(missing_unsafe_on_extern)]
+                extern "C" {
+                    #[link_name = ".data.link_section.FOO.bounds"]
+                    static __LINK_SECTION_INFO:
+                        ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
+                }
+                #[link_section = ".init_array.0"]
+                #[used]
+                #[allow(non_snake_case)]
+                static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
+                    {
+                        extern "C" fn __LINK_SECTION_ITEM_FN() {
+                            static DISARMED: ::core::sync::atomic::AtomicBool =
+                                ::core::sync::atomic::AtomicBool::new(false);
+                            if DISARMED.swap(true,
+                                    ::core::sync::atomic::Ordering::Relaxed) {
+                                return;
+                            }
+                            unsafe {
+                                let ptr =
+                                    ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
+                                ::core::ptr::write(ptr as *mut _,
+                                    __LINK_SECTION_CONST_ITEM_VALUE);
+                            }
                         }
-                        unsafe {
-                            let ptr =
-                                ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
-                            ::core::ptr::write(ptr as *mut _,
-                                __LINK_SECTION_CONST_ITEM_VALUE);
-                        }
-                    }
-                    __LINK_SECTION_ITEM_FN
-                };
-            __LINK_SECTION_CONST_ITEM_VALUE
-        };
+                        __LINK_SECTION_ITEM_FN
+                    };
+                __LINK_SECTION_CONST_ITEM_VALUE
+            };
 }
 fn main() {}

--- a/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
@@ -18,6 +18,7 @@ impl FOO {
                     {
                         static __LINK_SECTION_NAME: &'static str =
                             ".data.link_section.FOO";
+                        #[export_name = ".data.link_section.FOO.bounds"]
                         #[used]
                         #[used]
                         static __LINK_SECTION_INFO:

--- a/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
@@ -71,6 +71,7 @@ fn foo() {
                 #[used]
                 #[link_section = ".data.link_section.FOO"]
                 static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+                #[allow(missing_unsafe_on_extern)]
                 extern "C" {
                     #[link_name = ".data.link_section.FOO.bounds"]
                     static __LINK_SECTION_INFO:

--- a/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
@@ -18,7 +18,6 @@ impl FOO {
                     {
                         static __LINK_SECTION_NAME: &'static str =
                             ".data.link_section.FOO";
-                        #[export_name = ".data.link_section.FOO.bounds"]
                         #[used]
                         #[used]
                         static __LINK_SECTION_INFO:
@@ -68,12 +67,11 @@ fn foo() {
                 type __InSecStoredTy =
                     <FOO as ::link_section::__support::SectionItemType>::Item;
                 const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
-                #[link_section = ".data.link_section.FOO"]
                 #[used]
+                #[link_section = ".data.link_section.FOO"]
                 static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
                 extern "C" {
                     #[link_name = ".data.link_section.FOO.bounds"]
-                    #[allow(unsafe_code)]
                     static __LINK_SECTION_INFO:
                         ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
                 }

--- a/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section/wasm32-unknown-unknown.rs
@@ -64,41 +64,41 @@ impl ::core::iter::IntoIterator for FOO {
 }
 fn foo() {
     const _: fn() =
-        const {
-                type __InSecStoredTy =
-                    <FOO as ::link_section::__support::SectionItemType>::Item;
-                const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
-                #[used]
-                #[link_section = ".data.link_section.FOO"]
-                static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
-                #[allow(missing_unsafe_on_extern)]
-                extern "C" {
-                    #[link_name = ".data.link_section.FOO.bounds"]
-                    static __LINK_SECTION_INFO:
-                        ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
-                }
-                #[link_section = ".init_array.0"]
-                #[used]
-                #[allow(non_snake_case)]
-                static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
-                    {
-                        extern "C" fn __LINK_SECTION_ITEM_FN() {
-                            static DISARMED: ::core::sync::atomic::AtomicBool =
-                                ::core::sync::atomic::AtomicBool::new(false);
-                            if DISARMED.swap(true,
-                                    ::core::sync::atomic::Ordering::Relaxed) {
-                                return;
-                            }
-                            unsafe {
-                                let ptr =
-                                    ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
-                                ::core::ptr::write(ptr as *mut _,
-                                    __LINK_SECTION_CONST_ITEM_VALUE);
-                            }
+        {
+            type __InSecStoredTy =
+                <FOO as ::link_section::__support::SectionItemType>::Item;
+            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
+            #[used]
+            #[link_section = ".data.link_section.FOO"]
+            static __LINK_SECTION_COUNTING_ITEM: u8 = 0;
+            #[allow(missing_unsafe_on_extern)]
+            extern "C" {
+                #[link_name = ".data.link_section.FOO.bounds"]
+                static __LINK_SECTION_INFO:
+                    ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
+            }
+            #[link_section = ".init_array.0"]
+            #[used]
+            #[allow(non_snake_case)]
+            static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
+                {
+                    extern "C" fn __LINK_SECTION_ITEM_FN() {
+                        static DISARMED: ::core::sync::atomic::AtomicBool =
+                            ::core::sync::atomic::AtomicBool::new(false);
+                        if DISARMED.swap(true,
+                                ::core::sync::atomic::Ordering::Relaxed) {
+                            return;
                         }
-                        __LINK_SECTION_ITEM_FN
-                    };
-                __LINK_SECTION_CONST_ITEM_VALUE
-            };
+                        unsafe {
+                            let ptr =
+                                ::link_section::__support::wasm::register_wasm_link_section_item(&raw const __LINK_SECTION_INFO);
+                            ::core::ptr::write(ptr as *mut _,
+                                __LINK_SECTION_CONST_ITEM_VALUE);
+                        }
+                    }
+                    __LINK_SECTION_ITEM_FN
+                };
+            __LINK_SECTION_CONST_ITEM_VALUE
+        };
 }
 fn main() {}

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -107,7 +107,7 @@ macro_rules! __sorted_referenced_slice {
             );
         }
 
-        $vis static $name: $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice<$ty> = unsafe {
+        $vis static $name: $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice<$ty> = unsafe /*const*/ {
             $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice::new(self::$name::$name.const_deref())
         };
     };

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -107,9 +107,9 @@ macro_rules! __sorted_referenced_slice {
             );
         }
 
-        $vis static $name: $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice<$ty> = unsafe /*const*/ {
+        $vis static $name: $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice<$ty> = const {unsafe {
             $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice::new(self::$name::$name.const_deref())
-        };
+        } };
     };
     (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
         $collection ! (( $collection => $vis $name: $ty = $expr ));


### PR DESCRIPTION
Cleans up a bunch of cruft that accumulated in the link-section macros - hash was slightly more complex than it needed to be.