### PR TITLE
Prepare crates for initial `scattered-collect` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "libc-print",
  "linktime-proc-macro",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "linktime"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ctor",
  "dtor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,9 @@ repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.6", default-features = false }
-dtor = { path = "dtor", version = "1.0.2", default-features = false }
+dtor = { path = "dtor", version = "1.0.3", default-features = false }
 link-section = { path = "link-section", version = "0.17.0", default-features = false }
+linktime = { path = "linktime", version = "0.16.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.6] - Unreleased
+## [1.0.6] - 2026-05-16
 
 ### Changed
 
 - Bump `link-section` dependency to 0.17.0.
+
+### Fixed
+
+- `#[ctor]` requires significantly less macro recursion.
 
 ## [1.0.5] - 2026-05-11
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `link-section` dependency to 0.17.0.
+- MSRV bumped to 1.85.0 (if `priority` feature is enabled), otherwise remains at
+  1.60.0.
 
 ### Fixed
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `link-section` dependency to 0.17.0.
 - MSRV bumped to 1.85.0 (if `priority` feature is enabled), otherwise remains at
   1.60.0.
+  - To restore MSRV to 1.60.0, use `ctor = { version = "1.0.6", default-features
+    = false, features = ["proc_macro", "std"] }` in your Cargo.toml.
 
 ### Fixed
 

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-05-16
+
+### Fixed
+
+- `#[dtor]` requires significantly less macro recursion.
+
 ## [1.0.2] - 2026-05-08
 
 ### Added

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtor"
-version = "1.0.2"
+version = "1.0.3"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible destructors for all platforms that run after main (like C/C++ __attribute__((destructor)))"

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0] - Unreleased
+## [0.17.0] - 2026-05-16
 
 ### Added
 

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 readme = "README.md"
 categories = ["development-tools::build-utils", "no-std", "no-std::no-alloc", "embedded", "development-tools::procedural-macro-helpers"]
+rust-version = "1.85"
 
 [features]
 default = ["proc_macro", "std"]

--- a/linktime/Cargo.toml
+++ b/linktime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linktime"
-version = "0.15.0"
+version = "0.16.0"
 authors.workspace = true
 edition = "2021"
 description = "Link-time registration patterns for Rust (ctors, dtors, link-time slices and sections)"

--- a/scattered-collect-proc-macro/Cargo.toml
+++ b/scattered-collect-proc-macro/Cargo.toml
@@ -2,10 +2,10 @@
 name = "scattered-collect-proc-macro"
 version = "0.1.0"
 edition = "2021"
-authors = ["Matt Mastracci <matthew@mastracci.com>"]
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "proc-macro support for scattered-collect (link-time collections)"
-license = "Apache-2.0 OR MIT"
-repository = "https://github.com/mmastrac/scattered-collect"
 categories = ["development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 
 [lib]

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Link-time collections for Rust (distributed slices, registries)"
 categories = ["data-structures", "development-tools::build-utils", "no-std"]
+rust-version = "1.85"
 
 [dependencies]
 link-section = { workspace = true, features = ["proc_macro"] }

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures", "development-tools::build-utils", "no-std"]
 [dependencies]
 link-section = { workspace = true, features = ["proc_macro"] }
 ctor = { workspace = true, features = ["proc_macro", "priority", "std"] }
-scattered-collect-proc-macro = { path = "../scattered-collect-proc-macro" }
+scattered-collect-proc-macro.workspace = true
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "const_xxh3"] }
 wide = "1.3"
 

--- a/tests/ctor/edition-2018/Cargo.toml
+++ b/tests/ctor/edition-2018/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 [features]
 
 [dependencies]
-ctor = { path = "../../../ctor" }
+# When we bump the MSRV, can probably re-add priority feature.
+ctor = { path = "../../../ctor", default-features = false, features = ["proc_macro", "std"] }
 libc-print = "0.3"
 
 [workspace]

--- a/tests/ctor/edition-2021/Cargo.toml
+++ b/tests/ctor/edition-2021/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 [features]
 
 [dependencies]
-ctor = { path = "../../../ctor" }
+# When we bump the MSRV, can probably re-add priority feature.
+ctor = { path = "../../../ctor", default-features = false, features = ["proc_macro", "std"] }
 libc-print = "0.3"
 
 [workspace]


### PR DESCRIPTION
`link-section`: 0.17.0
`ctor`: minor bump
`dtor`: minor bump
