### PR TITLE
Improve scattered-collect macros

### DIFF
--- a/.github/jobs/build-minimal.sh
+++ b/.github/jobs/build-minimal.sh
@@ -10,6 +10,8 @@ minimal_crates=(
   tests/ctor/edition-2018
   tests/ctor/edition-2021
   tests/dtor/link-section
+  tests/dtor/no-default-features
+  
   tests/link_section/basic
   tests/link_section/interior_mut
   tests/link_section/mut

--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -11,6 +11,7 @@ sanitize_runs=(
   "link-section:link-section-ref"
   "link-section:link-section-mut"
   "link-section:link-section-movable"
+  "link-section:link-section-movable-no-macro"
 )
 
 for spec in "${sanitize_runs[@]}"; do

--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -14,6 +14,11 @@ sanitize_runs=(
   "link-section:link-section-movable"
   "link-section:link-section-movable-no-macro"
   "link-section:link-section-ref"
+  "scattered-collect:scattered-collect-intern-strings"
+  "scattered-collect:scattered-collect-slice"
+  "scattered-collect:scattered-collect-sorted-slice"
+  "scattered-collect:scattered-collect-referenced-slice"
+  "scattered-collect:scattered-collect-sorted-referenced-slice"
 )
 
 for spec in "${sanitize_runs[@]}"; do

--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -7,11 +7,13 @@ set -xeuo pipefail
 sanitize_runs=(
   "ctor:ctor-example"
   "ctor:ctor-advanced"
+  "link-section:link-section-dyn"
   "link-section:link-section-example"
-  "link-section:link-section-ref"
   "link-section:link-section-mut"
+  "link-section:link-section-mut-no-macro"
   "link-section:link-section-movable"
   "link-section:link-section-movable-no-macro"
+  "link-section:link-section-ref"
 )
 
 for spec in "${sanitize_runs[@]}"; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "linktime-proc-macro",
  "macrotest",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ctor",
  "link-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ repository = "https://github.com/mmastrac/linktime"
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.6", default-features = false }
 dtor = { path = "dtor", version = "1.0.3", default-features = false }
-link-section = { path = "link-section", version = "0.17.0", default-features = false }
+link-section = { path = "link-section", version = "0.17.1", default-features = false }
 linktime = { path = "linktime", version = "0.16.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-05-17
+
+### Added
+
+- `MovableRef` and `Ref` implement `Debug` and `Display` if the referenced type does.
+
 ## [0.17.0] - 2026-05-16
 
 ### Added

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `MovableRef` and `Ref` implement `Debug` and `Display` if the referenced type does.
 
+### Changed
+
+- Deprecated `reference` module in favor of `Ref` from the crate root.
+
 ## [0.17.0] - 2026-05-16
 
 ### Added

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.17.0"
+version = "0.17.1"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -55,5 +55,9 @@ name = "link-section-mut"
 path = "examples/mut.rs"
 
 [[example]]
+name = "link-section-mut-no-macro"
+path = "examples/mut-no-macro.rs"
+
+[[example]]
 name = "link-section-ref"
 path = "examples/ref.rs"

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -47,6 +47,10 @@ name = "link-section-movable"
 path = "examples/movable.rs"
 
 [[example]]
+name = "link-section-movable-no-macro"
+path = "examples/movable-no-macro.rs"
+
+[[example]]
 name = "link-section-mut"
 path = "examples/mut.rs"
 

--- a/link-section/examples/movable-no-macro.rs
+++ b/link-section/examples/movable-no-macro.rs
@@ -1,0 +1,73 @@
+//! Reference-section example for `link-section`.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+#![warn(missing_docs)]
+
+use link_section::section;
+
+/// Operations.
+#[section(movable, no_macro)]
+static OPERATIONS: link_section::TypedMovableSection<Operation>;
+
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd)]
+struct Operation(u32);
+
+pub(crate) mod operations {
+    use super::Operation;
+    use link_section::in_section;
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_A: Operation = Operation(1);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_B: Operation = Operation(3);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_C: Operation = Operation(6);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_D: Operation = Operation(10);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_E: Operation = Operation(8);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_F: Operation = Operation(2);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_G: Operation = Operation(4);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_H: Operation = Operation(5);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_I: Operation = Operation(9);
+
+    #[in_section(unsafe, name = OPERATIONS, type = movable)]
+    pub static OPERATION_J: Operation = Operation(7);
+}
+
+#[allow(unsafe_code)]
+fn sort_operations() {
+    unsafe { OPERATIONS.sort_unstable() };
+}
+
+fn main() {
+    // This should normally be done in a `ctor`, but for this example we know
+    // there are no other live threads and we do it here.
+    sort_operations();
+
+    for op in OPERATIONS {
+        println!("Operation: {op:?}");
+    }
+
+    println!("OPERATION_A: {:?}", *operations::OPERATION_A);
+    println!("OPERATION_B: {:?}", *operations::OPERATION_B);
+    println!("OPERATION_C: {:?}", *operations::OPERATION_C);
+    println!("OPERATION_D: {:?}", *operations::OPERATION_D);
+    println!("OPERATION_E: {:?}", *operations::OPERATION_E);
+    println!("OPERATION_F: {:?}", *operations::OPERATION_F);
+    println!("OPERATION_G: {:?}", *operations::OPERATION_G);
+    println!("OPERATION_H: {:?}", *operations::OPERATION_H);
+    println!("OPERATION_I: {:?}", *operations::OPERATION_I);
+    println!("OPERATION_J: {:?}", *operations::OPERATION_J);
+}

--- a/link-section/examples/mut-no-macro.rs
+++ b/link-section/examples/mut-no-macro.rs
@@ -1,0 +1,36 @@
+//! Reference-section example for `link-section`.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+#![warn(missing_docs)]
+
+use link_section::section;
+
+/// Operations.
+#[section(mutable, no_macro)]
+pub static OPERATIONS: link_section::TypedMutableSection<&'static str>;
+
+mod operations {
+    use link_section::in_section;
+
+    #[in_section(unsafe, name = OPERATIONS, type = mutable)]
+    const OPERATION_1: &'static str = "operation_1";
+
+    #[in_section(unsafe, name = OPERATIONS, type = mutable)]
+    const OPERATION_2: &'static str = "operation_2";
+
+    #[in_section(unsafe, name = OPERATIONS, type = mutable)]
+    const OPERATION_3: &'static str = "operation_3";
+}
+
+#[allow(unsafe_code)]
+fn main() {
+    // This should normally be done in a `ctor`, but for this example we know
+    // there are no other live threads and we do it here.
+    {
+        let ops = unsafe { OPERATIONS.as_mut_slice() };
+        ops.sort_unstable();
+    }
+
+    for op in OPERATIONS {
+        println!("Operation: {}", op);
+    }
+}

--- a/link-section/src/item.rs
+++ b/link-section/src/item.rs
@@ -1,5 +1,25 @@
 //! Item handling.
 
+use core::ops::Deref;
+
+/// Argument to [`crate::TypedSection::offset_of`] and related section lookup APIs.
+///
+/// Implemented for any [`Deref`] target, including `&T`, [`crate::Ref`], and
+/// [`crate::MovableRef`].
+pub trait SectionItemLocation<T: ?Sized> {
+    /// Address of the item's storage in the link section (not the wrapper).
+    fn item_ptr(&self) -> *const T;
+}
+
+impl<P, T: ?Sized> SectionItemLocation<T> for P
+where
+    P: Deref<Target = T>,
+{
+    fn item_ptr(&self) -> *const T {
+        self.deref() as *const T
+    }
+}
+
 /// Element type for this section handle ([`crate::TypedSection`], etc.).
 pub trait SectionItemType {
     /// Item type stored or referenced in the section.

--- a/link-section/src/item.rs
+++ b/link-section/src/item.rs
@@ -14,13 +14,13 @@ impl<T: ?Sized> SectionItemLocation<T> for &T {
     }
 }
 
-impl<T> SectionItemLocation<T> for Ref<T> {
+impl<T> SectionItemLocation<T> for &Ref<T> {
     fn item_ptr(&self) -> *const T {
         Ref::as_ptr(self)
     }
 }
 
-impl<T> SectionItemLocation<T> for MovableRef<T> {
+impl<T> SectionItemLocation<T> for &MovableRef<T> {
     fn item_ptr(&self) -> *const T {
         MovableRef::as_ptr(self)
     }

--- a/link-section/src/item.rs
+++ b/link-section/src/item.rs
@@ -1,6 +1,6 @@
 //! Item handling.
 
-use core::ops::Deref;
+use crate::{MovableRef, Ref};
 
 /// Argument to [`crate::TypedSection::offset_of`] and related section lookup APIs.
 ///
@@ -11,12 +11,21 @@ pub trait SectionItemLocation<T: ?Sized> {
     fn item_ptr(&self) -> *const T;
 }
 
-impl<P, T: ?Sized> SectionItemLocation<T> for P
-where
-    P: Deref<Target = T>,
-{
+impl<'a, T: ?Sized> SectionItemLocation<T> for &'a T {
     fn item_ptr(&self) -> *const T {
-        self.deref() as *const T
+        *self as *const T
+    }
+}
+
+impl<'a, T> SectionItemLocation<T> for &'a Ref<T> {
+    fn item_ptr(&self) -> *const T {
+        Ref::as_ptr(self)
+    }
+}
+
+impl<'a, T> SectionItemLocation<T> for &'a MovableRef<T> {
+    fn item_ptr(&self) -> *const T {
+        MovableRef::as_ptr(self)
     }
 }
 

--- a/link-section/src/item.rs
+++ b/link-section/src/item.rs
@@ -3,27 +3,24 @@
 use crate::{MovableRef, Ref};
 
 /// Argument to [`crate::TypedSection::offset_of`] and related section lookup APIs.
-///
-/// Implemented for any [`Deref`] target, including `&T`, [`crate::Ref`], and
-/// [`crate::MovableRef`].
 pub trait SectionItemLocation<T: ?Sized> {
     /// Address of the item's storage in the link section (not the wrapper).
     fn item_ptr(&self) -> *const T;
 }
 
-impl<'a, T: ?Sized> SectionItemLocation<T> for &'a T {
+impl<T: ?Sized> SectionItemLocation<T> for &T {
     fn item_ptr(&self) -> *const T {
         *self as *const T
     }
 }
 
-impl<'a, T> SectionItemLocation<T> for &'a Ref<T> {
+impl<T> SectionItemLocation<T> for Ref<T> {
     fn item_ptr(&self) -> *const T {
         Ref::as_ptr(self)
     }
 }
 
-impl<'a, T> SectionItemLocation<T> for &'a MovableRef<T> {
+impl<T> SectionItemLocation<T> for MovableRef<T> {
     fn item_ptr(&self) -> *const T {
         MovableRef::as_ptr(self)
     }

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -15,6 +15,7 @@ mod platform;
 mod section_parse;
 mod sections;
 
+pub use item::SectionItemLocation;
 pub use sections::{
     MovableBackref, MovableRef, Ref, Section, TypedMovableSection, TypedMutableSection,
     TypedReferenceSection, TypedSection,

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -16,11 +16,12 @@ mod section_parse;
 mod sections;
 
 pub use sections::{
-    MovableBackref, MovableRef, Section, TypedMovableSection, TypedMutableSection,
+    MovableBackref, MovableRef, Ref, Section, TypedMovableSection, TypedMutableSection,
     TypedReferenceSection, TypedSection,
 };
 
 /// Types for [`TypedReferenceSection`].
+#[deprecated(since = "0.17.1", note = "Use [`Ref`] from the crate root instead.")]
 pub mod reference {
     pub use crate::sections::Ref;
 }

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -140,8 +140,8 @@ macro_rules! impl_bounds_fns {
         ///
         /// This is O(1), as it performs direct pointer arithmetic.
         #[inline]
-        pub fn offset_of(&self, item: impl ::core::ops::Deref<Target = T>) -> Option<usize> {
-            let ptr = item.deref() as *const T;
+        pub fn offset_of(&self, item: impl $crate::SectionItemLocation<T>) -> Option<usize> {
+            let ptr = item.item_ptr();
             if ptr < self.start_ptr() || ptr >= self.end_ptr() {
                 None
             } else {

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -135,6 +135,19 @@ macro_rules! impl_bounds_fns {
                 unsafe { ::core::slice::from_raw_parts(self.start_ptr(), self.len()) }
             }
         }
+
+        /// The offset of the item in the section, if it is in the section.
+        ///
+        /// This is O(1), as it performs direct pointer arithmetic.
+        #[inline]
+        pub fn offset_of(&self, item: impl ::core::ops::Deref<Target = T>) -> Option<usize> {
+            let ptr = item.deref() as *const T;
+            if ptr < self.start_ptr() || ptr >= self.end_ptr() {
+                None
+            } else {
+                Some(unsafe { ptr.offset_from(self.start_ptr()) as usize })
+            }
+        }
     };
 }
 
@@ -199,17 +212,6 @@ pub struct TypedSection<T: 'static> {
 impl<T: 'static> TypedSection<T> {
     impl_section_new!(T);
     impl_bounds_fns!(T);
-
-    /// The offset of the item in the section, if it is in the section.
-    #[inline]
-    pub fn offset_of(&self, item: &T) -> Option<usize> {
-        let ptr = item as *const T;
-        if ptr < self.start_ptr() || ptr >= self.end_ptr() {
-            None
-        } else {
-            Some(unsafe { ptr.offset_from(self.start_ptr()) as usize })
-        }
-    }
 }
 
 impl_bounds_traits!(TypedSection<T>);
@@ -232,17 +234,6 @@ pub struct TypedMutableSection<T: 'static> {
 impl<T: 'static> TypedMutableSection<T> {
     impl_section_new!(T);
     impl_bounds_fns!(T);
-
-    /// The offset of the item in the section, if it is in the section.
-    #[inline]
-    pub fn offset_of(&self, item: &T) -> Option<usize> {
-        let ptr = item as *const T;
-        if ptr < self.start_ptr() || ptr >= self.end_ptr() {
-            None
-        } else {
-            Some(unsafe { ptr.offset_from(self.start_ptr()) as usize })
-        }
-    }
 
     /// The start address of the section.
     #[inline]
@@ -317,17 +308,6 @@ impl<T: 'static> TypedMovableSection<T> {
     }
 
     impl_bounds_fns!(T);
-
-    /// The offset of the item in the section, if it is in the section.
-    #[inline]
-    pub fn offset_of(&self, item: &T) -> Option<usize> {
-        let ptr = item as *const T;
-        if ptr < self.start_ptr() || ptr >= self.end_ptr() {
-            None
-        } else {
-            Some(unsafe { ptr.offset_from(self.start_ptr()) as usize })
-        }
-    }
 
     /// The section as a mutable slice.
     ///
@@ -497,7 +477,7 @@ impl<T> MovableRef<T> {
     }
 
     /// Raw pointer to the value currently referenced by this slot.
-    pub fn as_ptr(&self) -> *const T {
+    pub const fn as_ptr(&self) -> *const T {
         unsafe { *self.slot.get() }
     }
 }
@@ -577,17 +557,6 @@ pub struct TypedReferenceSection<T: 'static> {
 impl<T: 'static> TypedReferenceSection<T> {
     impl_section_new!(T);
     impl_bounds_fns!(T);
-
-    /// The offset of the item in the section, if it is in the section.
-    #[inline]
-    pub fn offset_of(&self, item: &Ref<T>) -> Option<usize> {
-        let ptr = item.as_ptr();
-        if ptr < self.start_ptr() || ptr >= self.end_ptr() {
-            None
-        } else {
-            Some(unsafe { ptr.offset_from(self.start_ptr()) as usize })
-        }
-    }
 }
 
 impl_bounds_traits!(TypedReferenceSection<T>);

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -509,6 +509,24 @@ impl<T> ::core::ops::Deref for MovableRef<T> {
     }
 }
 
+impl<T> ::core::fmt::Debug for MovableRef<T>
+where
+    T: ::core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<T> ::core::fmt::Display for MovableRef<T>
+where
+    T: ::core::fmt::Display,
+{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
 unsafe impl<T> Send for MovableRef<T> where T: Send {}
 unsafe impl<T> Sync for MovableRef<T> where T: Sync {}
 
@@ -635,6 +653,24 @@ impl<T> ::core::ops::Deref for Ref<T> {
         }
         #[cfg(not(target_family = "wasm"))]
         &self.t
+    }
+}
+
+impl<T> ::core::fmt::Debug for Ref<T>
+where
+    T: ::core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<T> ::core::fmt::Display for Ref<T>
+where
+    T: ::core::fmt::Display,
+{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        (**self).fmt(f)
     }
 }
 

--- a/linktime/src/lib.rs
+++ b/linktime/src/lib.rs
@@ -25,7 +25,7 @@ pub mod link_section {
 
     #[doc(inline)]
     pub use link_section::{
-        reference, MovableBackref, MovableRef, Section, TypedMovableSection, TypedMutableSection,
+        MovableBackref, MovableRef, Ref, Section, TypedMovableSection, TypedMutableSection,
         TypedReferenceSection, TypedSection,
     };
 

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -18,19 +18,23 @@ xxhash-rust = { version = "0.8.15", features = ["xxh3", "const_xxh3"] }
 wide = "1.3"
 
 [[example]]
-name = "slice"
+name = "scattered-collect-intern-strings"
+path = "examples/intern_strings.rs"
+
+[[example]]
+name = "scattered-collect-slice"
 path = "examples/slice.rs"
 
 [[example]]
-name = "sorted_slice"
+name = "scattered-collect-sorted-slice"
 path = "examples/sorted_slice.rs"
 
 [[example]]
-name = "referenced_slice"
+name = "scattered-collect-referenced-slice"
 path = "examples/referenced_slice.rs"
 
 [[example]]
-name = "sorted_referenced_slice"
+name = "scattered-collect-sorted-referenced-slice"
 path = "examples/sorted_referenced_slice.rs"
 
 [lints.rust]

--- a/scattered-collect/examples/intern_strings.rs
+++ b/scattered-collect/examples/intern_strings.rs
@@ -1,3 +1,6 @@
+//! Example for `ScatteredSortedReferencedSlice`.
+#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
+
 use std::{
     cmp::Ordering,
     fmt::{self, Debug, Display},
@@ -20,7 +23,7 @@ impl Str {
         INTERNED_STRINGS
             .binary_search(&Str::Static(s))
             .ok()
-            .map(|i| Str::Interned(i))
+            .map(Str::Interned)
     }
 }
 

--- a/scattered-collect/examples/intern_strings.rs
+++ b/scattered-collect/examples/intern_strings.rs
@@ -1,0 +1,93 @@
+use std::{
+    cmp::Ordering,
+    fmt::{self, Debug, Display},
+    ops::Deref,
+};
+
+use scattered_collect::{
+    ScatteredSortedReferencedSlice, gather, scatter, sorted_referenced_slice::Ref,
+};
+
+// A string type that allows interning in `O(log N)` time (where `N` is the
+// number of interned strings).
+enum Str {
+    Static(&'static str),
+    Interned(usize),
+}
+
+impl Str {
+    fn try_intern(s: &'static str) -> Option<Self> {
+        INTERNED_STRINGS
+            .binary_search(&Str::Static(s))
+            .ok()
+            .map(|i| Str::Interned(i))
+    }
+}
+
+impl Display for Str {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self.deref(), f)
+    }
+}
+
+impl Debug for Str {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self.deref(), f)
+    }
+}
+
+impl Deref for Str {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Str::Static(s) => s,
+            Str::Interned(i) => INTERNED_STRINGS[*i].deref(),
+        }
+    }
+}
+
+impl Eq for Str {}
+impl PartialEq for Str {
+    fn eq(&self, other: &Self) -> bool {
+        self.deref() == other.deref()
+    }
+}
+impl PartialEq<Ref<Str>> for Str {
+    fn eq(&self, other: &Ref<Str>) -> bool {
+        self.deref() == &***other
+    }
+}
+
+impl PartialOrd for Str {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Str {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.deref().cmp(other.deref())
+    }
+}
+
+#[gather]
+static INTERNED_STRINGS: ScatteredSortedReferencedSlice<Str>;
+
+macro_rules! intern_string {
+    ($name:ident, $string:literal) => {
+        #[scatter(INTERNED_STRINGS)]
+        static $name: Str = Str::Static($string);
+    };
+}
+
+intern_string!(HELLO, "hello");
+intern_string!(WORLD, "world");
+
+fn main() {
+    let hello = Str::try_intern("hello").unwrap();
+    let world = Str::try_intern("world").unwrap();
+    assert!(Str::try_intern("none").is_none());
+    assert_eq!(hello, HELLO);
+    assert_eq!(world, WORLD);
+    println!("{hello} {world}!");
+}

--- a/scattered-collect/examples/referenced_slice.rs
+++ b/scattered-collect/examples/referenced_slice.rs
@@ -3,20 +3,23 @@
 
 use scattered_collect::{gather, referenced_slice::ScatteredReferencedSlice, scatter};
 
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct MyId(u32);
+
 /// A scattered referenced slice of `u32`.
 #[gather]
-static COLLECTION: ScatteredReferencedSlice<u32>;
+static COLLECTION: ScatteredReferencedSlice<MyId>;
 
 #[scatter(COLLECTION)]
-static ITEM_ONE: u32 = 1;
+static ITEM_ONE: MyId = MyId(1);
 
 #[scatter(COLLECTION)]
-static ITEM_TWO: u32 = 2;
+static ITEM_TWO: MyId = MyId(2);
 
 #[scatter(COLLECTION)]
-static ITEM_THREE: u32 = 3;
+static ITEM_THREE: MyId = MyId(3);
 
 fn main() {
     println!("COLLECTION: {:?}", &*COLLECTION);
-    println!("ITEM_ONE: {}", *ITEM_ONE);
+    println!("ITEM_ONE: {:?}", ITEM_ONE);
 }

--- a/scattered-collect/examples/slice.rs
+++ b/scattered-collect/examples/slice.rs
@@ -3,18 +3,21 @@
 
 use scattered_collect::{gather, scatter, slice::ScatteredSlice};
 
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct MyId(u32);
+
 /// A scattered slice of `u32`.
 #[gather]
-pub static COLLECTION: ScatteredSlice<u32>;
+static COLLECTION: ScatteredSlice<MyId>;
 
 #[scatter(COLLECTION)]
-const _: u32 = 1;
+const _: MyId = MyId(1);
 
 #[scatter(COLLECTION)]
-const _: u32 = 2;
+const _: MyId = MyId(2);
 
 #[scatter(COLLECTION)]
-const _: u32 = 3;
+const _: MyId = MyId(3);
 
 fn main() {
     println!("COLLECTION: {:?}", &*COLLECTION);

--- a/scattered-collect/examples/sorted_slice.rs
+++ b/scattered-collect/examples/sorted_slice.rs
@@ -3,18 +3,21 @@
 
 use scattered_collect::{gather, scatter, sorted_slice::ScatteredSortedSlice};
 
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct MyId(u32);
+
 /// A scattered sorted slice of `u32`.
 #[gather]
-pub static COLLECTION: ScatteredSortedSlice<u32>;
+static COLLECTION: ScatteredSortedSlice<MyId>;
 
 #[scatter(COLLECTION)]
-const _: u32 = 1;
+const _: MyId = MyId(1);
 
 #[scatter(COLLECTION)]
-const _: u32 = 2;
+const _: MyId = MyId(2);
 
 #[scatter(COLLECTION)]
-const _: u32 = 3;
+const _: MyId = MyId(3);
 
 fn main() {
     println!("COLLECTION: {:?}", &*COLLECTION);

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -23,7 +23,7 @@
 
 use link_section::TypedReferenceSection;
 
-pub use link_section::reference::Ref;
+pub use link_section::Ref;
 
 /// A collection of sized items available both as a slice over the gathered
 /// section and as `static` handles at each declaration site.

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -56,7 +56,10 @@ impl<T: 'static> ScatteredReferencedSlice<T> {
     /// The offset of the item in the slice, if it is from this slice.
     ///
     /// This is O(1), as it performs direct pointer arithmetic.
-    pub fn offset_of(this: &Self, item: impl ::core::ops::Deref<Target = T>) -> Option<usize> {
+    pub fn offset_of(
+        this: &Self,
+        item: impl link_section::SectionItemLocation<T>,
+    ) -> Option<usize> {
         TypedReferenceSection::offset_of(this.section, item)
     }
 }

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -56,8 +56,8 @@ impl<T: 'static> ScatteredReferencedSlice<T> {
     /// The offset of the item in the slice, if it is from this slice.
     ///
     /// This is O(1), as it performs direct pointer arithmetic.
-    pub fn offset_of(&self, item: &Ref<T>) -> Option<usize> {
-        TypedReferenceSection::offset_of(self.section, item)
+    pub fn offset_of(this: &Self, item: impl ::core::ops::Deref<Target = T>) -> Option<usize> {
+        TypedReferenceSection::offset_of(this.section, item)
     }
 }
 

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -52,6 +52,13 @@ impl<T: 'static> ScatteredReferencedSlice<T> {
     pub fn is_empty(&self) -> bool {
         self.section.is_empty()
     }
+
+    /// The offset of the item in the slice, if it is from this slice.
+    ///
+    /// This is O(1), as it performs direct pointer arithmetic.
+    pub fn offset_of(&self, item: &Ref<T>) -> Option<usize> {
+        TypedReferenceSection::offset_of(self.section, item)
+    }
 }
 
 impl<T: 'static> ::core::ops::Deref for ScatteredReferencedSlice<T> {
@@ -77,21 +84,16 @@ macro_rules! __referenced_slice {
 
         $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __referenced_slice_private_macro__) (as $name;));
 
-        #[allow(unused)]
-        #[allow(non_snake_case)]
-        #[doc(hidden)]
-        $vis mod $name {
-            $crate::__support::link_section::declarative::section!(
-                #[section(reference)]
-                pub static $name: $crate::__support::link_section::TypedReferenceSection<$ty>;
-            );
-        }
-
         $(#[$meta])*
         $vis static $name: $collection<$ty> = {
+            $crate::__support::link_section::declarative::section!(
+                #[section(reference, no_macro)]
+                static $name: $crate::__support::link_section::TypedReferenceSection<$ty>;
+            );
+
             unsafe {
                 $crate::referenced_slice::ScatteredReferencedSlice::new(
-                    self::$name::$name.const_deref(),
+                    $name.const_deref(),
                 )
             }
         };
@@ -108,14 +110,14 @@ macro_rules! __referenced_slice {
     };
     (@scatter [$collection:ident] $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section($collection::$collection)]
+            #[in_section(unsafe, name = $collection, type = reference)]
             $(#[$imeta])*
             $vis static $name: $ty = $expr;
         );
     };
     (@scatter ($collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr)) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section($collection::$collection)]
+            #[in_section(unsafe, name = $collection, type = reference)]
             $vis static $name: $ty = $expr;
         );
     };

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -52,27 +52,22 @@ macro_rules! __slice {
         #[allow(unused)]
         $vis use $crate::__slice as $name;
 
-        #[allow(unused)]
-        #[allow(non_snake_case)]
-        #[doc(hidden)]
-        $vis mod $name {
-            $crate::__support::link_section::declarative::section!(
-                #[section(typed)]
-                pub static $name: $crate::__support::link_section::TypedSection<$ty>;
-            );
-        }
-
         $(#[$meta])*
         $vis static $name: $collection<$ty> = {
+            $crate::__support::link_section::declarative::section!(
+                #[section(typed)]
+                static $name: $crate::__support::link_section::TypedSection<$ty>;
+            );
+
             unsafe { $crate::slice::ScatteredSlice::new(
-                self::$name::$name.const_deref()
+                $name.const_deref()
             ) }
         };
     };
 
     (@scatter [$($meta:tt)*] $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section($($meta)*::$($meta)*)]
+            #[in_section(unsafe, name = $($meta)*, type = typed)]
             $(#[$imeta])*
             $vis $type $name: $ty = $expr;
         );

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -8,10 +8,10 @@
 //! static SLICE_PLUGINS: ScatteredSlice<&'static str>;
 //!
 //! #[scatter(SLICE_PLUGINS)]
-//! const _: &str = "json";
+//! const _: &'static str = "json";
 //!
 //! #[scatter(SLICE_PLUGINS)]
-//! const _: &str = "yaml";
+//! const _: &'static str = "yaml";
 //!
 //! fn main() {
 //! # if cfg!(miri) { return; }

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -68,7 +68,7 @@ impl<T: Ord + 'static> ScatteredSortedReferencedSlice<T> {
     ///
     /// This is O(1), as it performs direct pointer arithmetic.
     pub fn offset_of(&self, item: &Ref<T>) -> Option<usize> {
-        TypedMovableSection::offset_of(self.data, &*item)
+        TypedMovableSection::offset_of(self.data, item)
     }
 }
 

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -63,6 +63,13 @@ impl<T: Ord + 'static> ScatteredSortedReferencedSlice<T> {
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
+
+    /// The offset of the item in the slice, if it is from this slice.
+    ///
+    /// This is O(1), as it performs direct pointer arithmetic.
+    pub fn offset_of(&self, item: &Ref<T>) -> Option<usize> {
+        TypedMovableSection::offset_of(self.data, &*item)
+    }
 }
 
 impl<T: Ord + 'static> ::core::ops::Deref for ScatteredSortedReferencedSlice<T> {
@@ -93,7 +100,7 @@ macro_rules! __sorted_referenced_slice_decl_rslot {
         $expr:expr
     ) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section($collection::$collection)]
+            #[in_section(unsafe, name = $collection, type = movable)]
             $(#[$imeta])*
             $vis static $name: $ty = $expr;
         );
@@ -115,12 +122,11 @@ macro_rules! __sorted_referenced_slice {
 
         $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __sorted_referenced_slice_private_macro__) (as $name;));
 
-        #[allow(unused, non_snake_case, unsafe_code)]
-        #[doc(hidden)]
-        $vis mod $name {
+        $(#[$meta])*
+        $vis static $name: $collection<$ty> = const {
             $crate::__support::link_section::declarative::section!(
-                #[section(movable)]
-                pub static $name: $crate::__support::link_section::TypedMovableSection<$ty>;
+                #[section(movable, no_macro)]
+                static $name: $crate::__support::link_section::TypedMovableSection<$ty>;
             );
 
             $crate::__support::ctor::declarative::ctor!(
@@ -131,12 +137,11 @@ macro_rules! __sorted_referenced_slice {
                     }
                 }
             );
-        }
 
-        $(#[$meta])*
-        $vis static $name: $collection<$ty> = const {unsafe {
-            $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice::new(self::$name::$name.const_deref())
-        } };
+            unsafe {
+                $crate::sorted_referenced_slice::ScatteredSortedReferencedSlice::new($name.const_deref())
+            }
+        };
     };
     (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
         $collection ! (( $collection => $vis $name: $ty = $expr ));
@@ -172,7 +177,7 @@ macro_rules! __sorted_referenced_slice {
 
 #[cfg(all(test, not(miri)))]
 mod tests {
-    use crate::sorted_referenced_slice::ScatteredSortedReferencedSlice;
+    use crate::sorted_referenced_slice::{Ref, ScatteredSortedReferencedSlice};
 
     __sorted_referenced_slice!(gather pub TEST_SORT_REF: u32);
     __sorted_referenced_slice!(scatter TEST_SORT_REF => pub SORT_REF_ITEM_A: u32 = 1);
@@ -183,7 +188,8 @@ mod tests {
     fn test_scattered_sorted_referenced_slice() {
         assert_eq!(TEST_SORT_REF.len(), 3);
         assert_eq!(&*TEST_SORT_REF, [1, 2, 3].as_slice());
-        assert_eq!(*SORT_REF_ITEM_A, 1);
+        let a: &Ref<u32> = &SORT_REF_ITEM_A;
+        assert_eq!(**a, 1);
         assert_eq!(*SORT_REF_ITEM_B, 3);
         assert_eq!(*SORT_REF_ITEM_C, 2);
     }

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -67,7 +67,10 @@ impl<T: Ord + 'static> ScatteredSortedReferencedSlice<T> {
     /// The offset of the item in the slice, if it is from this slice.
     ///
     /// This is O(1), as it performs direct pointer arithmetic.
-    pub fn offset_of(this: &Self, item: impl ::core::ops::Deref<Target = T>) -> Option<usize> {
+    pub fn offset_of(
+        this: &Self,
+        item: impl link_section::SectionItemLocation<T>,
+    ) -> Option<usize> {
         TypedMovableSection::offset_of(this.data, item)
     }
 }

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -67,8 +67,8 @@ impl<T: Ord + 'static> ScatteredSortedReferencedSlice<T> {
     /// The offset of the item in the slice, if it is from this slice.
     ///
     /// This is O(1), as it performs direct pointer arithmetic.
-    pub fn offset_of(&self, item: &Ref<T>) -> Option<usize> {
-        TypedMovableSection::offset_of(self.data, item)
+    pub fn offset_of(this: &Self, item: impl ::core::ops::Deref<Target = T>) -> Option<usize> {
+        TypedMovableSection::offset_of(this.data, item)
     }
 }
 

--- a/scattered-collect/src/sorted_slice.rs
+++ b/scattered-collect/src/sorted_slice.rs
@@ -87,35 +87,30 @@ macro_rules! __sorted_slice {
         #[allow(unused)]
         $vis use $crate::__slice as $name;
 
-        #[allow(unused)]
-        #[allow(non_snake_case)]
-        #[doc(hidden)]
-        $vis mod $name {
-            $crate::__support::link_section::declarative::section!(
-                #[section(mutable)]
-                pub static $name: $crate::__support::link_section::TypedMutableSection<$ty>;
-            );
-        }
-
         $(#[$meta])*
         $vis static $name: $collection<$ty> = {
+            $crate::__support::link_section::declarative::section!(
+                #[section(mutable, no_macro)]
+                static $name: $crate::__support::link_section::TypedMutableSection<$ty>;
+            );
+
+            $crate::__support::ctor::declarative::ctor!(
+                // Run as soon as possible, before any other constructors.
+                #[ctor(unsafe, anonymous, priority = 0)]
+                fn initialize_scattered_sorted_slice() {
+                    unsafe { $crate::sorted_slice::initialize_scattered_sorted_slice($name.as_mut_slice()) };
+                }
+            );
+
             unsafe { $crate::sorted_slice::ScatteredSortedSlice::new(
-                self::$name::$name.const_deref()
+                $name.const_deref()
             ) }
         };
-
-        $crate::__support::ctor::declarative::ctor!(
-            // Run as soon as possible, before any other constructors.
-            #[ctor(unsafe, anonymous, priority = 0)]
-            fn initialize_scattered_sorted_slice() {
-                unsafe { $crate::sorted_slice::initialize_scattered_sorted_slice(self::$name::$name.as_mut_slice()) };
-            }
-        );
     };
 
     (@scatter [$($meta:tt)*] $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section($($meta)*::$($meta)*)]
+            #[in_section(unsafe, name = $($meta)*, type = mutable)]
             $(#[$imeta])*
             $vis $type $name: $ty = $expr;
         );

--- a/scattered-collect/src/sorted_slice.rs
+++ b/scattered-collect/src/sorted_slice.rs
@@ -85,7 +85,7 @@ macro_rules! __sorted_slice {
     (@gather $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
         #[doc(hidden)]
         #[allow(unused)]
-        $vis use $crate::__slice as $name;
+        $vis use $crate::__sorted_slice as $name;
 
         $(#[$meta])*
         $vis static $name: $collection<$ty> = {

--- a/tests/wasm/rust/src/lib.rs
+++ b/tests/wasm/rust/src/lib.rs
@@ -93,7 +93,7 @@ mod link_section {
         libc_println!("test_link_section");
         libc_println!("DRIVER: {}", reference::DRIVER.name);
         (reference::DRIVER.f)();
-        assert!(reference::DRIVERS.offset_of(reference::DRIVER) == Some(0));
+        assert!(reference::DRIVERS.offset_of(&reference::DRIVER) == Some(0));
     }
 }
 

--- a/tests/wasm/rust/src/lib.rs
+++ b/tests/wasm/rust/src/lib.rs
@@ -93,7 +93,7 @@ mod link_section {
         libc_println!("test_link_section");
         libc_println!("DRIVER: {}", reference::DRIVER.name);
         (reference::DRIVER.f)();
-        assert!(reference::DRIVERS.offset_of(&reference::DRIVER) == Some(0));
+        assert!(reference::DRIVERS.offset_of(reference::DRIVER) == Some(0));
     }
 }
 


### PR DESCRIPTION
The macros were using a hidden module, but that didn't work well with types that aren't in the prelude. We don't need them, however.