### PR TITLE
Remove `feature(used_with_args)` from all examples

### DIFF
--- a/.github/jobs/test-used-linker.sh
+++ b/.github/jobs/test-used-linker.sh
@@ -3,7 +3,10 @@ set -xeuo pipefail
 
 . $(dirname "$0")/_init.sh
 
-export RUSTDOCFLAGS='--cfg linktime_used_linker'
+export RUSTDOCFLAGS="--cfg linktime_used_linker \
+    -Z crate-attr=feature(used_with_arg) \
+    -Z crate-attr=allow(unused_features) \
+    -Z crate-attr=allow(duplicate_features)"
 export RUSTFLAGS="-D warnings --cfg linktime_used_linker \
     -Z crate-attr=feature(used_with_arg) \
     -Z crate-attr=allow(unused_features) \

--- a/ctor/examples/ctor-advanced.rs
+++ b/ctor/examples/ctor-advanced.rs
@@ -1,7 +1,5 @@
 //! Constructors beyond `ctor-basic` / `ctor-example`: anonymous `#[ctor]`, priorities, nested modules,
 //! inherent `#[ctor]` methods on generic `impl`s, and ctors under a module-level `const`.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
-
 use ctor::ctor;
 use libc_print::*;
 use std::collections::HashMap;

--- a/ctor/examples/ctor-basic.rs
+++ b/ctor/examples/ctor-basic.rs
@@ -1,6 +1,4 @@
 //! Matches the `ctor` README introduction (`cargo run --example ctor-basic`).
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
-
 use ctor::ctor;
 use libc_print::*;
 

--- a/ctor/examples/ctor-dynamic.rs
+++ b/ctor/examples/ctor-dynamic.rs
@@ -1,5 +1,4 @@
 //! Demonstrate dynamic `#[ctor]`s.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![allow(clippy::incompatible_msrv)]
 
 use ctor::ctor;

--- a/ctor/examples/ctor-example.rs
+++ b/ctor/examples/ctor-example.rs
@@ -1,5 +1,4 @@
 //! Examples from the `README`.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 // Ensure we don't blow a low recursion limit.
 #![recursion_limit = "61"]
 

--- a/ctor/examples/ctor-priority.rs
+++ b/ctor/examples/ctor-priority.rs
@@ -1,5 +1,4 @@
 #![allow(unexpected_cfgs)]
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 //! Edition 2024 test.
 
 use ctor::ctor;

--- a/ctor/examples/ctor-statics.rs
+++ b/ctor/examples/ctor-statics.rs
@@ -1,6 +1,4 @@
 //! Demonstrate various forms of `#[ctor]` statics.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
-
 use std::mem::MaybeUninit;
 
 use ctor::ctor;

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -10,7 +10,6 @@
     feature(used_with_arg)
 )]
 #![cfg_attr(all(target_vendor = "apple", linktime_asan), feature(sanitize))]
-#![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/dtor/src/example.rs
+++ b/dtor/src/example.rs
@@ -1,8 +1,6 @@
 //! This example demonstrates the various types of ctor/dtor in an executable
 //! context.
-#![recursion_limit = "90"]
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
-
+#![recursion_limit = "60"]
 use dtor::dtor;
 use libc_print::*;
 

--- a/dtor/src/lib.rs
+++ b/dtor/src/lib.rs
@@ -4,7 +4,6 @@
 //! # dtor
 #![doc = include_str!("../docs/PREAMBLE.md")]
 #![doc = include_str!("../docs/GENERATED.md")]
-#![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/link-section/examples/const.rs
+++ b/link-section/examples/const.rs
@@ -1,5 +1,4 @@
 //! Example usage of the `link-section` crate.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 use link_section::{in_section, section};

--- a/link-section/examples/dyn.rs
+++ b/link-section/examples/dyn.rs
@@ -1,5 +1,4 @@
 //! Example usage of the `link-section` crate.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 use link_section::{in_section, section};

--- a/link-section/examples/example.rs
+++ b/link-section/examples/example.rs
@@ -1,5 +1,4 @@
 //! Example usage of the `link-section` crate.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 use link_section::{in_section, section};

--- a/link-section/examples/movable-no-macro.rs
+++ b/link-section/examples/movable-no-macro.rs
@@ -1,5 +1,4 @@
 //! Reference-section example for `link-section`.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 use link_section::section;

--- a/link-section/examples/movable.rs
+++ b/link-section/examples/movable.rs
@@ -1,5 +1,4 @@
 //! Reference-section example for `link-section`.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 use link_section::section;

--- a/link-section/examples/mut-no-macro.rs
+++ b/link-section/examples/mut-no-macro.rs
@@ -1,5 +1,4 @@
 //! Reference-section example for `link-section`.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 use link_section::section;

--- a/link-section/examples/mut.rs
+++ b/link-section/examples/mut.rs
@@ -1,5 +1,4 @@
 //! Reference-section example for `link-section`.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 use link_section::section;

--- a/link-section/examples/ref.rs
+++ b/link-section/examples/ref.rs
@@ -1,5 +1,4 @@
 //! Reference-section example for `link-section`.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![warn(missing_docs)]
 
 mod operations {

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -2,7 +2,6 @@
 //! # link-section
 #![doc = include_str!("../docs/PREAMBLE.md")]
 #![allow(unsafe_code)]
-#![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 #![no_std]
 
 #[doc = include_str!("../docs/LIFE_BEFORE_MAIN.md")]

--- a/linktime/src/lib.rs
+++ b/linktime/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 
 /// Define an initializer function that runs before `main`. See [ctor][ctor].
 ///

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -22,7 +22,7 @@ wide = "1.3"
 
 [dev-dependencies]
 divan = "0.1.21"
-scattered-collect = { path = ".", version = "*", features = ["__internal"] }
+scattered-collect = { path = ".", features = ["__internal"] }
 
 [[example]]
 name = "scattered-collect-intern-strings"

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -1,7 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(linktime_used_linker, allow(unused_features))]
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
-#![cfg_attr(linktime_used_linker, doc(test(attr(feature(used_with_arg)))))]
 
 pub mod hash;
 pub mod map;

--- a/tests/ctor/crt-static/src/main.rs
+++ b/tests/ctor/crt-static/src/main.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 //! `+crt-static` test.
 
 use ctor::ctor;

--- a/tests/ctor/edition-2018/src/main.rs
+++ b/tests/ctor/edition-2018/src/main.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 //! Edition 2018 test.
 
 use ctor::ctor;

--- a/tests/ctor/edition-2021/src/main.rs
+++ b/tests/ctor/edition-2021/src/main.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 //! Edition 2021 test.
 
 use ctor::ctor;

--- a/tests/ctor/edition-2024/src/main.rs
+++ b/tests/ctor/edition-2024/src/main.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 //! Edition 2024 test.
 
 use ctor::ctor;

--- a/tests/ctor/priority/src/main.rs
+++ b/tests/ctor/priority/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(unexpected_cfgs)]
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 //! Edition 2024 test.
 
 use ctor::ctor;

--- a/tests/ctor/system/src/dylib.rs
+++ b/tests/ctor/system/src/dylib.rs
@@ -1,6 +1,5 @@
 //! Tests for ctor in dylibs.
 #![allow(dead_code, unused_imports, unused_features, unsafe_code)]
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 
 use ctor::ctor;
 use dtor::dtor;

--- a/tests/ctor/system/src/dylib_load.rs
+++ b/tests/ctor/system/src/dylib_load.rs
@@ -1,5 +1,4 @@
 //! Tests for ctor in an executable that loads a dylib.
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 #![allow(unused_imports)]
 
 use ctor::ctor;

--- a/tests/ctor/system/src/lib.rs
+++ b/tests/ctor/system/src/lib.rs
@@ -1,7 +1,6 @@
 //! Tests for various configurations of the crate.
 
 #![allow(unused_features)]
-#![cfg_attr(linktime_used_linker, feature(used_with_arg))]
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
We can pass this via `RUSTFLAGS` now.