### PR TITLE
Improve macro collection path resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ctor",
  "divan",

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/README.md
+++ b/scattered-collect/README.md
@@ -42,3 +42,38 @@ whatsoever.
   (auto-wrapped as [`sorted_referenced_slice::Ref`]).
 - [`ScatteredMap`]: A collection of key-value pairs that are available via
   slice, as well as indexed by key.
+
+## Scatter/Gather syntax
+
+The collections are defined as a single scatter call with multiple gather calls
+that submit items to the collection.
+
+```rust
+# use scattered_collect::{gather, scatter, slice::ScatteredSlice};
+# struct DatabaseDriver(&'static str);
+#[gather]
+static COLLECTION: ScatteredSlice<DatabaseDriver>;
+```
+
+... and then elsewhere in your crate:
+
+```rust
+# mod root { // doctests have weird scope for macros...
+# use scattered_collect::{gather, scatter, slice::ScatteredSlice};
+# struct DatabaseDriver(&'static str);
+# #[gather] static COLLECTION: ScatteredSlice<DatabaseDriver>;
+
+mod postgres {
+    # use super::*;
+    #[scatter(COLLECTION)]
+    static POSTGRES_DRIVER: DatabaseDriver = DatabaseDriver("postgres" /*, ...*/);
+}
+
+mod mysql {
+    # use super::*;
+    # struct DatabaseDriver(&'static str);
+    #[scatter(COLLECTION)]
+    static MYSQL_DRIVER: DatabaseDriver = DatabaseDriver("mysql" /*, ...*/);
+}
+# }
+```

--- a/scattered-collect/examples/intern_strings.rs
+++ b/scattered-collect/examples/intern_strings.rs
@@ -18,7 +18,7 @@ enum Str {
 
 impl Str {
     fn try_intern(s: &'static str) -> Option<Self> {
-        INTERNED_STRINGS
+        intern::INTERNED_STRINGS
             .binary_search(&Str::Static(s))
             .ok()
             .map(Str::Interned)
@@ -42,7 +42,7 @@ impl Deref for Str {
     fn deref(&self) -> &Self::Target {
         match self {
             Str::Static(s) => s,
-            Str::Interned(i) => INTERNED_STRINGS[*i].deref(),
+            Str::Interned(i) => crate::intern::INTERNED_STRINGS[*i].deref(),
         }
     }
 }
@@ -71,24 +71,39 @@ impl Ord for Str {
     }
 }
 
-#[gather]
-static INTERNED_STRINGS: ScatteredSortedReferencedSlice<Str>;
+mod intern {
+    use crate::{ScatteredSortedReferencedSlice, Str, gather};
 
-macro_rules! intern_string {
-    ($name:ident, $string:literal) => {
-        #[scatter(INTERNED_STRINGS)]
-        static $name: Str = Str::Static($string);
-    };
+    #[gather]
+    pub(crate) static INTERNED_STRINGS: ScatteredSortedReferencedSlice<Str>;
+
+    macro_rules! intern_string {
+        ($name:ident, $string:literal) => {
+            #[$crate::scatter($crate::intern::INTERNED_STRINGS)]
+            static $name: $crate::Str = $crate::Str::Static($string);
+        };
+    }
+    pub(crate) use intern_string;
 }
 
-intern_string!(HELLO, "hello");
-intern_string!(WORLD, "world");
+use crate::intern::intern_string;
+
+mod another_mod {
+    use crate::intern::intern_string;
+    intern_string!(CUSTOM, "custom");
+}
 
 fn main() {
+    intern_string!(HELLO, "hello");
+    intern_string!(WORLD, "world");
+
     let hello = Str::try_intern("hello").unwrap();
     let world = Str::try_intern("world").unwrap();
     assert!(Str::try_intern("none").is_none());
     assert_eq!(hello, HELLO);
     assert_eq!(world, WORLD);
     println!("{hello} {world}!");
+
+    // Interning works from everywhere.
+    Str::try_intern("custom").expect("custom");
 }

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -216,7 +216,7 @@ macro_rules! __iterable {
     (@gather $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
         $crate::__support::ident_concat!((#[doc(hidden)] #[macro_export] macro_rules!) (__ $name __iterable_private_macro__) ({
             ($passthru:tt) => {
-                $crate::__iterable!(@scatter $passthru);
+                $crate::__iterable!(@scatter [$name] $passthru);
             };
         }));
 
@@ -229,17 +229,14 @@ macro_rules! __iterable {
             $crate::iterable::ScatteredIterable::new(&$crate::__iterable_state!($name))
         };
     };
-    (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
-        $collection ! (( $collection => $vis static $name: $ty = $expr; ));
-    };
-    (@scatter ($collection:ident => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
         $(#[$imeta])*
         $vis static $name: $crate::iterable::Ref<$ty> = $crate::iterable::Ref::new($expr);
 
         $crate::__support::ctor::declarative::ctor!(
             #[ctor(unsafe, anonymous, priority = 0)]
             fn __iterable_submit() {
-                $crate::iterable::submit(&$crate::__iterable_state!($collection), &$name);
+                $crate::iterable::submit(&$crate::__iterable_state!($($meta)*), &$name);
             }
         );
     };
@@ -250,9 +247,9 @@ mod tests {
     use crate::iterable::{Ref, ScatteredIterable};
 
     __iterable!(gather pub TEST_ITERABLE: u32);
-    __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_A: u32 = 1);
-    __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_B: u32 = 3);
-    __iterable!(scatter TEST_ITERABLE => pub ITERABLE_ITEM_C: u32 = 2);
+    __iterable!(@scatter [TEST_ITERABLE] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_A: u32 = 1;));
+    __iterable!(@scatter [TEST_ITERABLE] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_B: u32 = 3;));
+    __iterable!(@scatter [TEST_ITERABLE] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_C: u32 = 2;));
 
     fn offset_for_value(value: u32) -> usize {
         match value {

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -21,7 +21,7 @@ macro_rules! __scatter_parse {
     // Send the #[scatter]'d item into the collection's private macro.
     (#[scatter ($($meta:tt)*)] $(#[$imeta:meta])* $($item:tt)*) => {
         $($meta)* ! (
-            ($($meta)* =>
+            ([$($meta)*] =>
             $(#[$imeta])*
             $($item)*
             )

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -249,7 +249,7 @@ macro_rules! __map {
             __ $name __map_scatter__
         ) ({
             ($passthru:tt) => {
-                $crate::__map!(@scatter [$key] [$value] $passthru);
+                $crate::__map!(@scatter [$name] [$key] [$value] $passthru);
             };
         }));
 
@@ -259,12 +259,12 @@ macro_rules! __map {
             (as $name;)
         );
     };
-    (scatter $collection:ident => [$key:ty] [$value:ty] $vis:vis $name:ident: $ty:ty = ($key_expr:expr, $value_expr:expr)) => {
-        $collection ! (( $collection => $vis static $name: $ty = ($key_expr, $value_expr); ));
+    (scatter [$collection:ident] => [$key:ty] [$value:ty] $vis:vis $name:ident: $ty:ty = ($key_expr:expr, $value_expr:expr)) => {
+        $collection ! (( [$collection] => $vis static $name: $ty = ($key_expr, $value_expr); ));
     };
-    (@scatter [$key:ty] [$value:ty] ($collection:ident => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = ($key_expr:expr, $value_expr:expr);)) => {
+    (@scatter [$collection_name:ident] [$key:ty] [$value:ty] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = ($key_expr:expr, $value_expr:expr);)) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section(unsafe, name = $collection, type = typed)]
+            #[in_section(unsafe, name = $collection_name, type = typed)]
             $(#[$imeta])*
             $vis $kind $name: $crate::map::MapRecord<$key, $value> = $crate::map::MapRecord::new(
                 $key_expr,
@@ -273,7 +273,7 @@ macro_rules! __map {
             );
         );
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section(unsafe, name = MAP_META, aux(main = $collection), type = mutable)]
+            #[in_section(unsafe, name = MAP_META, aux(main = $collection_name), type = mutable)]
             const _: $crate::map::MapMetadataChunk = $crate::map::MAP_METADATA_CHUNK_ZERO;
         );
     };
@@ -284,8 +284,8 @@ mod link_tests {
     use crate::ScatteredMap;
 
     __map!(@gather pub static TEST_MAP: ScatteredMap<&'static str, u32>;);
-    __map!(scatter TEST_MAP => [&'static str] [u32] APPLE: (&'static str, u32) = ("apple", 1));
-    __map!(scatter TEST_MAP => [&'static str] [u32] BANANA: (&'static str, u32) = ("banana", 2));
+    __map!(scatter [TEST_MAP] => [&'static str] [u32] APPLE: (&'static str, u32) = ("apple", 1));
+    __map!(scatter [TEST_MAP] => [&'static str] [u32] BANANA: (&'static str, u32) = ("banana", 2));
 
     #[test]
     fn scattered_map_gather_scatter_find() {
@@ -316,7 +316,7 @@ mod link_tests {
     macro_rules! make_test {
         ($($name:ident)*) => {
             $(
-            __map!(scatter TEST_MAP_2 => [&'static str] [Record]
+            __map!(scatter [TEST_MAP_2] => [&'static str] [Record]
                 $name: (&'static str, Record) = (
                     stringify!($name),
                     Record::new(stringify!($name), |_key| println!(stringify!($name)))

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -66,7 +66,7 @@ macro_rules! __referenced_slice {
     (@gather $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
         $crate::__support::ident_concat!((#[doc(hidden)] #[macro_export] macro_rules!) (__ $name __referenced_slice_private_macro__) ({
             ($passthru:tt) => {
-                $crate::__referenced_slice!(@scatter $passthru);
+                $crate::__referenced_slice!(@scatter [$name] $passthru);
             };
         }));
 
@@ -86,12 +86,9 @@ macro_rules! __referenced_slice {
             }
         };
     };
-    (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
-        $collection ! (( $collection => $vis static $name: $ty = $expr; ));
-    };
-    (@scatter ($collection:ident => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section(unsafe, name = $collection, type = reference)]
+            #[in_section(unsafe, name = $collection_name, type = reference)]
             $vis static $name: $ty = $expr;
         );
     };
@@ -102,9 +99,9 @@ mod tests {
     use crate::referenced_slice::ScatteredReferencedSlice;
 
     __referenced_slice!(gather pub TEST_REF_SLICE: u32);
-    __referenced_slice!(scatter TEST_REF_SLICE => pub REF_SLICE_ITEM_A: u32 = 1);
-    __referenced_slice!(scatter TEST_REF_SLICE => pub REF_SLICE_ITEM_B: u32 = 3);
-    __referenced_slice!(scatter TEST_REF_SLICE => pub REF_SLICE_ITEM_C: u32 = 2);
+    __referenced_slice!(@scatter [TEST_REF_SLICE] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_A: u32 = 1;));
+    __referenced_slice!(@scatter [TEST_REF_SLICE] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_B: u32 = 3;));
+    __referenced_slice!(@scatter [TEST_REF_SLICE] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_C: u32 = 2;));
 
     #[test]
     fn test_scattered_referenced_slice() {

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -34,9 +34,13 @@ impl<T> ::core::ops::Deref for ScatteredSlice<T> {
 #[doc(hidden)]
 macro_rules! __slice {
     (@gather $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
-        #[doc(hidden)]
-        #[allow(unused)]
-        $vis use $crate::__slice as $name;
+        $crate::__support::ident_concat!((#[doc(hidden)] #[macro_export] macro_rules!) (__ $name __slice_private_macro__) ({
+            ($passthru:tt) => {
+                $crate::__slice!(@scatter [$name] $passthru);
+            };
+        }));
+
+        $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __slice_private_macro__) (as $name;));
 
         $(#[$meta])*
         $vis static $name: $collection<$ty> = {
@@ -51,16 +55,9 @@ macro_rules! __slice {
         };
     };
 
-    (@scatter [$($meta:tt)*] $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;) => {
+    (@scatter [$collection_name:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section(unsafe, name = $($meta)*, type = typed)]
-            $(#[$imeta])*
-            $vis $type $name: $ty = $expr;
-        );
-    };
-    (($collection:ident => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
-        $crate::__slice!(
-            @scatter [$collection]
+            #[in_section(unsafe, name = $collection_name, type = typed)]
             $(#[$imeta])*
             $vis $type $name: $ty = $expr;
         );
@@ -72,9 +69,9 @@ mod tests {
     pub use super::ScatteredSlice;
 
     __slice!(@gather pub static TEST_SLICE: ScatteredSlice<u32>;);
-    __slice!(@scatter [TEST_SLICE] const _: u32 = 1;);
-    __slice!(@scatter [TEST_SLICE] const _: u32 = 3;);
-    __slice!(@scatter [TEST_SLICE] const _: u32 = 2;);
+    __slice!(@scatter [TEST_SLICE] ([TEST_SLICE] => const _: u32 = 1;));
+    __slice!(@scatter [TEST_SLICE] ([TEST_SLICE] => const _: u32 = 3;));
+    __slice!(@scatter [TEST_SLICE] ([TEST_SLICE] => const _: u32 = 2;));
 
     #[test]
     fn test_scattered_slice() {

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -83,7 +83,7 @@ macro_rules! __sorted_referenced_slice {
     (@gather $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
         $crate::__support::ident_concat!((#[doc(hidden)] #[macro_export] macro_rules!) (__ $name __sorted_referenced_slice_private_macro__) ({
             ($passthru:tt) => {
-                $crate::__sorted_referenced_slice!(@scatter $passthru);
+                $crate::__sorted_referenced_slice!(@scatter [$name] $passthru);
             };
         }));
 
@@ -110,12 +110,9 @@ macro_rules! __sorted_referenced_slice {
             }
         };
     };
-    (scatter $collection:ident => $vis:vis $name:ident: $ty:ty = $expr:expr) => {
-        $collection ! (( $collection => $vis static $name: $ty = $expr; ));
-    };
-    (@scatter ($collection:ident => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
-            #[in_section(unsafe, name = $collection, type = movable)]
+            #[in_section(unsafe, name = $collection_name, type = movable)]
             $(#[$imeta])*
             $vis static $name: $ty = $expr;
         );
@@ -127,9 +124,9 @@ mod tests {
     use crate::sorted_referenced_slice::{Ref, ScatteredSortedReferencedSlice};
 
     __sorted_referenced_slice!(gather pub TEST_SORT_REF: u32);
-    __sorted_referenced_slice!(scatter TEST_SORT_REF => pub SORT_REF_ITEM_A: u32 = 1);
-    __sorted_referenced_slice!(scatter TEST_SORT_REF => pub SORT_REF_ITEM_B: u32 = 3);
-    __sorted_referenced_slice!(scatter TEST_SORT_REF => pub SORT_REF_ITEM_C: u32 = 2);
+    __sorted_referenced_slice!(@scatter [TEST_SORT_REF] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_A: u32 = 1;));
+    __sorted_referenced_slice!(@scatter [TEST_SORT_REF] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_B: u32 = 3;));
+    __sorted_referenced_slice!(@scatter [TEST_SORT_REF] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_C: u32 = 2;));
 
     #[test]
     fn test_scattered_sorted_referenced_slice() {

--- a/scattered-collect/src/sorted_slice.rs
+++ b/scattered-collect/src/sorted_slice.rs
@@ -69,9 +69,13 @@ pub fn initialize_scattered_sorted_slice<T: Ord>(main: &mut [T]) {
 #[macro_export]
 macro_rules! __sorted_slice {
     (@gather $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
-        #[doc(hidden)]
-        #[allow(unused)]
-        $vis use $crate::__sorted_slice as $name;
+        $crate::__support::ident_concat!((#[doc(hidden)] #[macro_export] macro_rules!) (__ $name __sorted_slice_private_macro__) ({
+            ($passthru:tt) => {
+                $crate::__sorted_slice!(@scatter [$name] $passthru);
+            };
+        }));
+
+        $crate::__support::ident_concat!((#[doc(hidden)] $vis use) (__ $name __sorted_slice_private_macro__) (as $name;));
 
         $(#[$meta])*
         $vis static $name: $collection<$ty> = {
@@ -94,16 +98,9 @@ macro_rules! __sorted_slice {
         };
     };
 
-    (@scatter [$($meta:tt)*] $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;) => {
+    (@scatter [$collection_name:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
             #[in_section(unsafe, name = $($meta)*, type = mutable)]
-            $(#[$imeta])*
-            $vis $type $name: $ty = $expr;
-        );
-    };
-    (($collection:ident => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
-        $crate::__sorted_slice!(
-            @scatter [$collection]
             $(#[$imeta])*
             $vis $type $name: $ty = $expr;
         );
@@ -115,12 +112,12 @@ mod tests {
     pub use super::ScatteredSortedSlice;
 
     __sorted_slice!(@gather pub static TEST_SORTED_SLICE: ScatteredSortedSlice<u32>;);
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE] const _: u32 = 6;);
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE] const _: u32 = 3;);
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE] const _: u32 = 2;);
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE] const _: u32 = 4;);
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE] const _: u32 = 5;);
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE] const _: u32 = 1;);
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE] ([TEST_SORTED_SLICE] => const _: u32 = 6;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE] ([TEST_SORTED_SLICE] => const _: u32 = 3;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE] ([TEST_SORTED_SLICE] => const _: u32 = 2;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE] ([TEST_SORTED_SLICE] => const _: u32 = 4;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE] ([TEST_SORTED_SLICE] => const _: u32 = 5;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE] ([TEST_SORTED_SLICE] => const _: u32 = 1;));
 
     #[test]
     fn test_scattered_sorted_slice() {


### PR DESCRIPTION
The scatter/gather macros were a little inconsistent in how they resolved the collection macro -- this updates them all to use a nearly identical style so that paths work as you'd expect.
