### PR TITLE
Add a new combine! macro to replace hash/ident_concat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ dtor = { path = "dtor", version = "1.0.3", default-features = false }
 link-section = { path = "link-section", version = "0.17.2", default-features = false }
 linktime = { path = "linktime", version = "0.16.0", default-features = false }
 
-linktime-proc-macro = { path = "linktime-proc-macro", version = "0.1.0" }
+linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }
 
 scattered-collect = { path = "scattered-collect", version = "0.3.0" }
 scattered-collect-proc-macro = { path = "scattered-collect-proc-macro", version = "0.1.0" }

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -124,9 +124,69 @@ pub mod __support {
     pub use crate::{item::*, platform::*};
 
     #[cfg(feature = "proc_macro")]
-    pub use linktime_proc_macro::hash;
+    pub use linktime_proc_macro::combine;
+
     #[cfg(feature = "proc_macro")]
-    pub use linktime_proc_macro::ident_concat;
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __ident_concat {
+        (($($prefix:tt)*) ($($name:tt)*) ($($suffix:tt)*)) => {
+            $crate::__support::combine!(
+                output=ident
+                prefix=($($prefix)*)
+                input=($($name)*)
+                suffix=($($suffix)*)
+            );
+        };
+    }
+
+    #[cfg(feature = "proc_macro")]
+    pub use crate::__ident_concat as ident_concat;
+
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __hash_proc_macro {
+        // Matches the former `linktime_proc_macro::hash` proc macro.
+        ((__) (($($__prefix:literal $(,)?)*)) ($($name:tt)*) (($($__suffix:literal $(,)?)*)) $__hash_length:literal $__max_length:literal $__valid_section_chars:literal) => {
+            $crate::__support::combine!(output=string input=(
+                __IF__(
+                    test=(
+                        __AND__(
+                            a=(__LT__(
+                                a=(__LENGTH__(string=(__RAW__(input=($($name)*)))))
+                                b=$__max_length
+                            ))
+                            b=(__EQ__(
+                                a=(__LENGTH__(string=(__REPLACE__(
+                                    input=(__RAW__(input=($($name)*)))
+                                    pattern=[$__valid_section_chars]
+                                    replacement=""
+                                ))))
+                                b=0
+                            ))
+                        )
+                    )
+                    then=(
+                        $($__prefix)*
+                        __RAW__(input=($($name)*))
+                        $($__suffix)*
+                    )
+                    else=(
+                        $($__prefix)*
+                        __SUBSTRING__(input=(
+                            __SUBSTRING__(input=(
+                                __TOIDENT__(input=(__RAW__(input=($($name)*))))
+                            ) end=(__SUB__(a=$__max_length b=$__hash_length)))
+                            __SUBSTRING__(input=(
+                                __HASH__(string=(__RAW__(input=($($name)*))) alphabet=[$__valid_section_chars])
+                            ) length=$__hash_length)
+                        ) length=$__max_length)
+                        $($__suffix)*
+                    )
+                )
+            ));
+        };
+    }
 
     #[doc(hidden)]
     #[macro_export]
@@ -135,8 +195,11 @@ pub mod __support {
             concat!($($__prefix,)* $(stringify!($name)),* $(,$__suffix)*);
         };
     }
+
     #[cfg(not(feature = "proc_macro"))]
     pub use __hash_no_proc_macro as hash;
+    #[cfg(feature = "proc_macro")]
+    pub use __hash_proc_macro as hash;
 
     #[cfg(miri)]
     #[doc(hidden)]

--- a/linktime-proc-macro/Cargo.toml
+++ b/linktime-proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linktime-proc-macro"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition = "2021"
 description = "proc-macro helpers for linktime crates (ctors, dtors, linker sections)"
@@ -14,6 +14,7 @@ default = []
 ctor = []
 dtor = []
 link_section = []
+scattered_collect = []
 
 [lib]
 proc-macro = true

--- a/linktime-proc-macro/src/combine/args.rs
+++ b/linktime-proc-macro/src/combine/args.rs
@@ -1,0 +1,391 @@
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+
+use proc_macro::{Delimiter, Span, TokenStream, TokenTree};
+
+use super::parse_stream;
+
+pub(super) trait Argument {
+    type Arg;
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>>;
+}
+pub(super) trait ArgumentIdent {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum OutputType {
+    Ident,
+    String,
+    ISize,
+    RawString,
+}
+
+impl FromStr for OutputType {
+    type Err = Cow<'static, str>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ident" => Ok(OutputType::Ident),
+            "string" => Ok(OutputType::String),
+            "isize" => Ok(OutputType::ISize),
+            _ => Err(Cow::Borrowed(
+                "Invalid output type (expected ident, string, or isize)",
+            )),
+        }
+    }
+}
+impl ArgumentIdent for OutputType {}
+
+impl<T: ArgumentIdent + FromStr<Err = Cow<'static, str>>> Argument for T {
+    type Arg = T;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        if let TokenTree::Ident(ident) = token {
+            Ok(T::from_str(ident.to_string().as_str())?)
+        } else {
+            Err(Cow::Borrowed("Expected an ident"))
+        }
+    }
+}
+
+impl Argument for TokenStream {
+    type Arg = TokenStream;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        match token {
+            TokenTree::Group(group) => Ok(group.stream()),
+            TokenTree::Literal(literal) => {
+                Ok(TokenStream::from_iter([TokenTree::Literal(literal)]))
+            }
+            TokenTree::Ident(ident) => Ok(TokenStream::from_iter([TokenTree::Ident(ident)])),
+            TokenTree::Punct(punct) => Ok(TokenStream::from_iter([TokenTree::Punct(punct)])),
+        }
+    }
+}
+
+impl Argument for Span {
+    type Arg = Span;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        match token {
+            TokenTree::Group(group) => Ok(group
+                .stream()
+                .into_iter()
+                .next()
+                .expect("Expected a non-empty group")
+                .span()),
+            TokenTree::Literal(literal) => Ok(literal.span()),
+            TokenTree::Ident(ident) => Ok(ident.span()),
+            TokenTree::Punct(punct) => Ok(punct.span()),
+        }
+    }
+}
+
+impl Argument for TokenTree {
+    type Arg = TokenTree;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        Ok(token)
+    }
+}
+
+impl Argument for String {
+    type Arg = String;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        let stream = <TokenStream as Argument>::from_token_tree(token)?;
+        let mut s = String::with_capacity(32);
+        parse_stream(&mut s, "input", OutputType::String, stream);
+        Ok(s)
+    }
+}
+
+impl Argument for usize {
+    type Arg = usize;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        let s = <String as Argument>::from_token_tree(token)?;
+        let (radix, s) = radix(&s);
+        let s = s.replace('_', "");
+        Ok(usize::from_str_radix(&s, radix)
+            .map_err(|e| format!("Expected a numeric literal, got `{}`", e))?)
+    }
+}
+
+impl Argument for isize {
+    type Arg = isize;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        let s = <String as Argument>::from_token_tree(token)?;
+        if s.strip_prefix('-').is_some() {
+            let (radix, s) = radix(&s);
+            let s = s.replace('_', "");
+            Ok(isize::from_str_radix(&s, radix)
+                .map_err(|e| format!("Expected a numeric literal, got `{}`", e))?
+                .checked_neg()
+                .expect("Expected a valid isize"))
+        } else {
+            let (radix, s) = radix(&s);
+            let s = s.replace('_', "");
+            Ok(isize::from_str_radix(&s, radix)
+                .map_err(|e| format!("Expected a numeric literal, got `{}`", e))?)
+        }
+    }
+}
+
+fn radix(s: &str) -> (u32, &str) {
+    if let Some(s) = s.strip_prefix("0x") {
+        (16, s)
+    } else if let Some(s) = s.strip_prefix("0o") {
+        (8, s)
+    } else if let Some(s) = s.strip_prefix("0b") {
+        (2, s)
+    } else {
+        (10, s)
+    }
+}
+
+#[derive(Default)]
+pub(super) struct TranslateString {
+    chars: Vec<(char, Option<char>)>,
+    len: usize,
+}
+
+impl TranslateString {
+    fn new(chars: Vec<(char, Option<char>)>) -> Self {
+        let len = chars
+            .iter()
+            .map(|(from, to)| {
+                let range = *from..=to.unwrap_or(*from);
+                *range.end() as u32 - *range.start() as u32 + 1
+            })
+            .sum::<u32>() as usize;
+        Self { chars, len }
+    }
+
+    /// Find the index of the character, including within ranges.
+    pub(super) fn find(&self, c: char) -> Option<usize> {
+        let mut i = 0;
+        for (from, to) in &self.chars {
+            let range = *from..=to.unwrap_or(*from);
+            let range_len = *range.end() as u32 - *range.start() as u32 + 1;
+            if range.contains(&c) {
+                return Some(i + (c as usize - *from as usize));
+            }
+            i += range_len as usize;
+        }
+        None
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.chars.is_empty()
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(super) fn char(&self, index: usize) -> char {
+        let mut i = index as u32;
+        let mut last_char = ' ';
+        for (from, to) in &self.chars {
+            let range = *from..=to.unwrap_or(*from);
+            last_char = *range.end();
+            let range_len = *range.end() as u32 - *range.start() as u32 + 1;
+            if i < range_len {
+                return char::from_u32(*range.start() as u32 + i).unwrap();
+            }
+            i -= range_len;
+        }
+        last_char
+    }
+}
+
+pub(super) enum PatternString {
+    Range(PatternRange),
+    String(String),
+}
+
+pub(super) struct PatternRange {
+    negated: bool,
+    chars: HashSet<char>,
+    ranges: Vec<(char, char)>,
+}
+
+impl PatternRange {
+    pub(super) fn is_match(&self, c: char) -> bool {
+        if self.negated {
+            !self.chars.contains(&c)
+                && !self
+                    .ranges
+                    .iter()
+                    .any(|(start, end)| c >= *start && c <= *end)
+        } else {
+            self.chars.contains(&c)
+                || self
+                    .ranges
+                    .iter()
+                    .any(|(start, end)| c >= *start && c <= *end)
+        }
+    }
+}
+
+impl Argument for PatternString {
+    type Arg = PatternString;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        match token {
+            TokenTree::Group(group) if group.delimiter() == Delimiter::Bracket => {
+                // Parse as regex-group-lite
+                let mut s = String::with_capacity(32);
+                parse_stream(&mut s, "input", OutputType::RawString, group.stream());
+
+                let mut chars = HashSet::new();
+                let mut ranges = Vec::new();
+                let mut it = s.chars();
+                let mut last_char = it.next();
+                let negated = if last_char == Some('^') {
+                    last_char = None;
+                    true
+                } else {
+                    false
+                };
+                while let Some(c) = it.next() {
+                    match (c, last_char.take()) {
+                        ('-', Some(last_char)) => {
+                            let next = it.next();
+                            if let Some(next) = next {
+                                ranges.push((last_char, next));
+                            } else {
+                                chars.insert(last_char);
+                                chars.insert('-');
+                            }
+                        }
+                        (c, None) => {
+                            last_char = Some(c);
+                        }
+                        (c, Some(last)) => {
+                            chars.insert(last);
+                            last_char = Some(c);
+                        }
+                    }
+                }
+                if let Some(last_char) = last_char {
+                    chars.insert(last_char);
+                }
+                Ok(PatternString::Range(PatternRange {
+                    negated,
+                    chars,
+                    ranges,
+                }))
+            }
+            _ => {
+                let s = <String as Argument>::from_token_tree(token)?;
+                Ok(PatternString::String(s))
+            }
+        }
+    }
+}
+
+impl Argument for TranslateString {
+    type Arg = TranslateString;
+
+    fn from_token_tree(token: TokenTree) -> Result<Self::Arg, Cow<'static, str>> {
+        let s = <String as Argument>::from_token_tree(token)?;
+
+        let mut it = s.chars();
+        let mut last_char = it.next();
+        let mut chars = Vec::new();
+        while let Some(c) = it.next() {
+            match (c, last_char.take()) {
+                ('-', Some(last)) => {
+                    let next = it.next();
+                    if let Some(next) = next {
+                        chars.push((last, Some(next)));
+                    } else {
+                        chars.push((last, None));
+                    }
+                }
+                (c, Some(last)) => {
+                    chars.push((last, None));
+                    last_char = Some(c);
+                }
+                (c, None) => {
+                    last_char = Some(c);
+                }
+            }
+        }
+        if let Some(last_char) = last_char {
+            chars.push((last_char, None));
+        }
+        Ok(TranslateString::new(chars))
+    }
+}
+
+/// Parse arguments from inside of a group: `(key=value, key2=value2, ...)`. Each value is a token tree
+/// (a group, literal, ident, or punctuation).
+///
+/// Keys must be idents.
+#[allow(unknown_lints, tail_expr_drop_order)]
+pub(super) fn parse_arguments(item: TokenStream, func: &str) -> HashMap<String, TokenTree> {
+    let mut args = HashMap::new();
+    let mut item = item.into_iter();
+    loop {
+        match item.next() {
+            Some(TokenTree::Ident(ident)) => match item.next() {
+                Some(TokenTree::Punct(punct)) if punct.as_char() == '=' => {
+                    args.insert(
+                        ident.to_string(),
+                        item.next()
+                            .unwrap_or_else(|| panic!("{func}: Expected a value after =")),
+                    );
+                }
+                Some(token) => {
+                    panic!("{func}: Expected a key=value pair, got {:?}", token);
+                }
+                None => {
+                    panic!("{func}: Expected = after key");
+                }
+            },
+            None => {
+                return args;
+            }
+            Some(token) => {
+                panic!(
+                    "{func}: Expected a sequence of key=value pairs, got {:?}",
+                    token
+                );
+            }
+        }
+    }
+}
+
+pub(super) fn pop_argument<T: Argument>(
+    args: &mut HashMap<String, TokenTree>,
+    func: &str,
+    key: &str,
+) -> T::Arg {
+    let Some(token) = args.remove(key) else {
+        panic!("{func}: Missing required argument '{key}'");
+    };
+    match T::from_token_tree(token) {
+        Ok(arg) => arg,
+        Err(e) => {
+            panic!("{func}: Invalid argument '{key}': {e}");
+        }
+    }
+}
+
+pub(super) fn pop_optional_argument<T: Argument>(
+    args: &mut HashMap<String, TokenTree>,
+    func: &str,
+    key: &str,
+) -> Option<T::Arg> {
+    let token = args.remove(key)?;
+    match T::from_token_tree(token) {
+        Ok(arg) => Some(arg),
+        Err(e) => {
+            panic!("{func}: Invalid argument '{key}': {e}");
+        }
+    }
+}

--- a/linktime-proc-macro/src/combine/mod.rs
+++ b/linktime-proc-macro/src/combine/mod.rs
@@ -1,0 +1,467 @@
+mod args;
+
+use std::borrow::Cow;
+
+use proc_macro::{Group, Ident, Literal, Span, TokenStream, TokenTree};
+
+use self::args::{
+    parse_arguments, pop_argument, pop_optional_argument, OutputType, PatternString,
+    TranslateString,
+};
+
+pub(crate) fn combine(item: TokenStream) -> TokenStream {
+    let mut args = parse_arguments(item, "combine!");
+    let output = pop_argument::<OutputType>(&mut args, "combine!", "output");
+    let input = pop_argument::<TokenStream>(&mut args, "combine!", "input");
+    let prefix = pop_optional_argument::<TokenStream>(&mut args, "combine!", "prefix");
+    let suffix = pop_optional_argument::<TokenStream>(&mut args, "combine!", "suffix");
+    let paren = pop_optional_argument::<TokenTree>(&mut args, "combine!", "paren");
+    let paren_prefix = pop_optional_argument::<TokenStream>(&mut args, "combine!", "paren_prefix");
+    let paren_suffix = pop_optional_argument::<TokenStream>(&mut args, "combine!", "paren_suffix");
+    let span = pop_optional_argument::<Span>(&mut args, "combine!", "span");
+
+    let mut s = String::with_capacity(32);
+
+    parse_stream(&mut s, "input", output, input);
+
+    let span = span.unwrap_or_else(Span::call_site);
+
+    let output_token = match output {
+        OutputType::Ident => TokenTree::Ident(Ident::new(to_ident(&s).as_ref(), span)),
+        OutputType::String => TokenTree::Literal(Literal::string(s.as_str())),
+        OutputType::ISize => {
+            let s = s.replace(|c: char| c != '+' && c != '-' && !c.is_ascii_digit(), "");
+            TokenTree::Literal(Literal::isize_suffixed(
+                s.parse::<isize>().expect("input: Expected a valid isize"),
+            ))
+        }
+        OutputType::RawString => unreachable!(),
+    };
+
+    let mut stream = TokenStream::new();
+    if let Some(prefix) = prefix {
+        stream.extend(prefix);
+    }
+    if let Some(paren) = paren {
+        let TokenTree::Group(group) = paren else {
+            panic!("combine!: Expected an empty group in paren");
+        };
+        let mut paren_stream = TokenStream::new();
+        if let Some(paren_prefix) = paren_prefix {
+            paren_stream.extend(paren_prefix);
+        }
+        paren_stream.extend([output_token]);
+        if let Some(paren_suffix) = paren_suffix {
+            paren_stream.extend(paren_suffix);
+        }
+        let group = Group::new(group.delimiter(), paren_stream);
+        stream.extend([TokenTree::Group(group)]);
+    } else {
+        stream.extend([output_token]);
+    }
+    if let Some(suffix) = suffix {
+        stream.extend(suffix);
+    }
+    stream
+}
+
+#[allow(unknown_lints, tail_expr_drop_order)]
+fn parse_stream(s: &mut String, arg: &str, output: OutputType, input: TokenStream) {
+    let mut input = input.into_iter();
+    while let Some(token) = input.next() {
+        match token {
+            TokenTree::Literal(literal) => {
+                let literal = literal.to_string();
+                if literal.starts_with('"') && literal.ends_with('"') {
+                    decode_literal_string(
+                        s,
+                        arg,
+                        literal
+                            .strip_prefix('"')
+                            .unwrap()
+                            .strip_suffix('"')
+                            .unwrap(),
+                    );
+                } else if literal.starts_with('\'') && literal.ends_with('\'') {
+                    decode_literal_string(
+                        s,
+                        arg,
+                        literal
+                            .strip_prefix('\'')
+                            .unwrap()
+                            .strip_suffix('\'')
+                            .unwrap(),
+                    );
+                } else if literal.starts_with(|c: char| c.is_ascii_digit()) {
+                    s.push_str(&literal);
+                } else {
+                    panic!(
+                        "{arg}: Expected a literal string or numeric literal, got `{literal:?}`"
+                    );
+                }
+            }
+            TokenTree::Ident(ident) => {
+                let ident = ident.to_string();
+                if output != OutputType::RawString
+                    && ident.len() > 2
+                    && ident.starts_with("__")
+                    && ident.ends_with("__")
+                {
+                    parse_function(s, arg, &mut input, &ident);
+                } else {
+                    s.push_str(&ident);
+                }
+            }
+            TokenTree::Group(group) => parse_stream(s, arg, output, group.stream()),
+            TokenTree::Punct(punct) => s.push(punct.as_char()),
+        }
+    }
+}
+
+fn parse_function(
+    s: &mut String,
+    arg: &str,
+    input: &mut proc_macro::token_stream::IntoIter,
+    ident: &String,
+) {
+    let func = &ident[2..ident.len() - 2];
+    let Some(TokenTree::Group(group)) = input.next() else {
+        panic!("Expected arguments after {ident:?}");
+    };
+    let mut args = parse_arguments(group.stream(), ident);
+    match func {
+        "FILE" => {
+            let of = pop_optional_argument::<Span>(&mut args, ident, "of")
+                .unwrap_or_else(Span::call_site);
+            let file = crate::fallback::file(&of);
+            s.push_str(&file);
+        }
+        "LINE" => {
+            let of = pop_optional_argument::<Span>(&mut args, ident, "of")
+                .unwrap_or_else(Span::call_site);
+            let line = crate::fallback::line(&of);
+            s.push_str(&line.to_string());
+        }
+        "COLUMN" => {
+            let of = pop_optional_argument::<Span>(&mut args, ident, "of")
+                .unwrap_or_else(Span::call_site);
+            let column = crate::fallback::column(&of);
+            s.push_str(&column.to_string());
+        }
+        "SOURCE" => {
+            let of = pop_argument::<TokenStream>(&mut args, ident, "of");
+            for (i, token) in of.into_iter().enumerate() {
+                if i > 0 {
+                    s.push(' ');
+                }
+                s.push_str(
+                    crate::fallback::source_text(&token.span())
+                        .unwrap_or_default()
+                        .as_ref(),
+                );
+            }
+        }
+        "DEBUG" => {
+            let of = pop_argument::<TokenTree>(&mut args, ident, "of");
+            s.push_str(&format!("{:?}", of));
+        }
+        "HASH" => {
+            let input = pop_argument::<String>(&mut args, ident, "string");
+            let alphabet = pop_optional_argument::<TranslateString>(&mut args, ident, "alphabet");
+            let mut hash = crate::hash::xx3::xx3hash(&input);
+            if let Some(alphabet) = alphabet {
+                if hash == 0 {
+                    s.push(alphabet.char(0));
+                } else {
+                    let mut hash_str = String::with_capacity(32);
+                    while hash > 0 {
+                        hash_str.push(alphabet.char(hash as usize % alphabet.len()));
+                        hash /= alphabet.len() as u64;
+                    }
+                    s.extend(hash_str.chars().rev());
+                }
+            } else {
+                s.push_str(&format!("{:016x}", hash));
+            }
+        }
+        "LOCATIONHASH" => {
+            let input = pop_argument::<TokenStream>(&mut args, ident, "of");
+            let alphabet = pop_optional_argument::<TranslateString>(&mut args, ident, "alphabet");
+            let mut hash = crate::hash::location_hash(input);
+            if let Some(alphabet) = alphabet {
+                if hash == 0 {
+                    s.push(alphabet.char(0));
+                } else {
+                    let mut hash_str = String::with_capacity(32);
+                    while hash > 0 {
+                        hash_str.push(alphabet.char(hash as usize % alphabet.len()));
+                        hash /= alphabet.len() as u64;
+                    }
+                    s.extend(hash_str.chars().rev());
+                }
+            } else {
+                s.push_str(&format!("{:016x}", hash));
+            }
+        }
+        "LENGTH" => {
+            let input = pop_argument::<String>(&mut args, ident, "string");
+            s.push_str(&input.len().to_string());
+        }
+        "REPLACE" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            let pattern = pop_argument::<PatternString>(&mut args, ident, "pattern");
+            let replacement = pop_argument::<String>(&mut args, ident, "replacement");
+
+            match pattern {
+                PatternString::Range(range) => {
+                    s.push_str(&input.replace(|c: char| range.is_match(c), &replacement));
+                }
+                PatternString::String(string) => {
+                    s.push_str(&input.replace(&string, &replacement));
+                }
+            }
+        }
+        "TRANSLATE" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            let pattern = pop_argument::<TranslateString>(&mut args, ident, "pattern");
+            let replacement =
+                pop_optional_argument::<TranslateString>(&mut args, ident, "replacement")
+                    .unwrap_or_default();
+            for c in input.chars() {
+                if let Some(index) = pattern.find(c) {
+                    if !replacement.is_empty() {
+                        s.push(replacement.char(index));
+                    }
+                } else {
+                    s.push(c);
+                }
+            }
+        }
+        "TRIM" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            let left = pop_argument::<PatternString>(&mut args, ident, "left");
+            let right = pop_argument::<PatternString>(&mut args, ident, "right");
+            let input = match left {
+                PatternString::Range(range) => {
+                    input.trim_start_matches(|c: char| range.is_match(c))
+                }
+                PatternString::String(string) => input.trim_start_matches(&string),
+            };
+            let input = match right {
+                PatternString::Range(range) => input.trim_end_matches(|c: char| range.is_match(c)),
+                PatternString::String(string) => input.trim_end_matches(&string),
+            };
+            s.push_str(input);
+        }
+        "CONTAINS" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            let pattern = pop_argument::<PatternString>(&mut args, ident, "pattern");
+            let sucesss = match pattern {
+                PatternString::Range(range) => input.contains(|c: char| range.is_match(c)),
+                PatternString::String(string) => input.contains(&string),
+            };
+            s.push_str(if sucesss { "1" } else { "0" });
+        }
+        "STREQ" => {
+            let a = pop_argument::<String>(&mut args, ident, "a");
+            let b = pop_argument::<String>(&mut args, ident, "b");
+            s.push_str(if a == b { "1" } else { "0" });
+        }
+        "SUBSTRING" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            let start = pop_optional_argument::<usize>(&mut args, ident, "start").unwrap_or(0);
+            let end = pop_optional_argument::<usize>(&mut args, ident, "end");
+            let length = pop_optional_argument::<usize>(&mut args, ident, "length");
+
+            let end = end.or(length.map(|l| start + l)).unwrap_or(usize::MAX);
+            let end = end.min(input.len());
+
+            s.push_str(&input[start..end]);
+        }
+        "PAD" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            let length = pop_argument::<usize>(&mut args, ident, "length");
+            let left =
+                pop_optional_argument::<String>(&mut args, ident, "left").unwrap_or_default();
+            let right =
+                pop_optional_argument::<String>(&mut args, ident, "right").unwrap_or_default();
+            if !left.is_empty() && !right.is_empty() {
+                panic!("{arg}: Expected a left xor right padding, got both");
+            }
+
+            let mut len = input.len();
+            if !left.is_empty() {
+                while len < length {
+                    s.push_str(&left);
+                    len += left.len();
+                }
+            }
+            s.push_str(&input);
+            if !right.is_empty() {
+                while len < length {
+                    s.push_str(&right);
+                    len += right.len();
+                }
+            }
+        }
+        "IF" => {
+            let a = pop_argument::<isize>(&mut args, ident, "test");
+            let then_tree = pop_argument::<String>(&mut args, ident, "then");
+            let else_tree =
+                pop_optional_argument::<String>(&mut args, ident, "else").unwrap_or_default();
+
+            if a != 0 {
+                s.push_str(&then_tree);
+            } else {
+                s.push_str(&else_tree);
+            }
+        }
+        "ADD" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&(a + b).to_string());
+        }
+        "SUB" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&(a - b).to_string());
+        }
+        "MUL" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&(a * b).to_string());
+        }
+        "DIV" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&(a / b).to_string());
+        }
+        "AND" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&(a & b).to_string());
+        }
+        "OR" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&(a | b).to_string());
+        }
+        "NE" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&((a != b) as u8).to_string());
+        }
+        "EQ" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&((a == b) as u8).to_string());
+        }
+        "GE" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&((a >= b) as u8).to_string());
+        }
+        "GT" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&((a > b) as u8).to_string());
+        }
+        "LE" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&((a <= b) as u8).to_string());
+        }
+        "LT" => {
+            let a = pop_argument::<isize>(&mut args, ident, "a");
+            let b = pop_argument::<isize>(&mut args, ident, "b");
+            s.push_str(&((a < b) as u8).to_string());
+        }
+        "RAW" => {
+            let input = pop_argument::<TokenStream>(&mut args, ident, "input");
+            let mut raw = String::with_capacity(32);
+            parse_stream(&mut raw, ident, OutputType::RawString, input);
+            s.push_str(&raw);
+        }
+        "TOSTRING" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            s.push_str(&input);
+        }
+        "TOIDENT" => {
+            let input = pop_argument::<String>(&mut args, ident, "input");
+            s.push_str(to_ident(&input).as_ref());
+        }
+        "TONUMBER" => {
+            let input = pop_argument::<isize>(&mut args, ident, "input");
+            s.push_str(&input.to_string());
+        }
+        _ => {
+            panic!("Unknown function: {func}");
+        }
+    }
+}
+
+pub(crate) fn decode_literal_string(s: &mut String, name: &str, literal: &str) {
+    if !literal.contains('\\') {
+        s.push_str(literal);
+    } else {
+        let mut iter = literal.chars();
+        while let Some(c) = iter.next() {
+            if c == '\\' {
+                match iter.next() {
+                    Some('n') => s.push('\n'),
+                    Some('r') => s.push('\r'),
+                    Some('t') => s.push('\t'),
+                    Some('\\') => s.push('\\'),
+                    Some('"') => s.push('"'),
+                    Some('\'') => s.push('\''),
+                    Some('0') => s.push('\0'),
+                    Some('x') => {
+                        let Some(c) = iter.next() else {
+                            panic!("{}: Expected a hexadecimal character", name);
+                        };
+                        let Some(c2) = iter.next() else {
+                            panic!("{}: Expected a hexadecimal character", name);
+                        };
+                        let Ok(c) = format!("{}{}", c, c2).parse::<u8>() else {
+                            panic!("{}: Expected a hexadecimal character", name);
+                        };
+                        s.push(char::from(c));
+                    }
+                    Some(_) => panic!("{name}: Expected a valid escape sequence (got {c:?})"),
+                    None => break,
+                }
+            } else {
+                s.push(c);
+            }
+        }
+    }
+}
+
+fn to_ident(input: &str) -> Cow<'_, str> {
+    // Idents must be XID_Start + XID_Continue*, but we just use
+    // is_alphabetic and is_alphanumeric as an approximation.
+    let mut s = input;
+    while !s.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+        if s.is_empty() {
+            panic!("No valid ident characters found in `{input}`");
+        }
+        s = &s[1..];
+    }
+
+    // If we detect any invalid chars, filter them one-by-one.
+    if s[1..].contains(|c: char| !c.is_alphanumeric() && c != '_') {
+        let mut output = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        // We know there's always at least one
+        output.push(chars.next().unwrap());
+        for c in chars {
+            if c.is_alphanumeric() || c == '_' {
+                output.push(c);
+            }
+        }
+        Cow::Owned(output)
+    } else {
+        // Fast path: all valid chars are alphanumeric or underscore.
+        Cow::Borrowed(s)
+    }
+}

--- a/linktime-proc-macro/src/fallback.rs
+++ b/linktime-proc-macro/src/fallback.rs
@@ -1,0 +1,72 @@
+#![allow(unstable_name_collisions)] // Intentional!
+
+use proc_macro::Span;
+use std::path::Path;
+
+/// Trait providing a fallback method for `Span` methods.
+#[allow(unused)]
+pub(crate) trait FallbackSpan {
+    fn line(&self) -> usize;
+    fn column(&self) -> usize;
+    fn file(&self) -> String;
+    fn source_text(&self) -> Option<String>;
+}
+
+/// Implement it for references of Span using autoref, giving it lower priority
+/// than inherent methods.
+impl FallbackSpan for &Span {
+    #[inline(always)]
+    fn line(&self) -> usize {
+        0
+    }
+    #[inline(always)]
+    fn column(&self) -> usize {
+        0
+    }
+    #[inline(always)]
+    fn file(&self) -> String {
+        String::new()
+    }
+    #[inline(always)]
+    fn source_text(&self) -> Option<String> {
+        None
+    }
+}
+
+#[allow(unused, clippy::needless_borrow)]
+pub(crate) fn has_1_88_span_methods(span: Span) -> bool {
+    let line_val = (&span).line();
+
+    // If it returns 0, we are on an older compiler.
+    line_val != 0
+}
+
+#[inline(always)]
+pub(crate) fn file(span: &Span) -> String {
+    // cargo expand may return a full path here.
+    let file = span.file();
+    let path = Path::new(&file);
+    if Path::new(&file).is_absolute() {
+        path.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string()
+    } else {
+        file
+    }
+}
+
+#[inline(always)]
+pub(crate) fn line(span: &Span) -> usize {
+    span.line()
+}
+
+#[inline(always)]
+pub(crate) fn column(span: &Span) -> usize {
+    span.column()
+}
+
+#[inline(always)]
+pub(crate) fn source_text(span: &Span) -> Option<String> {
+    span.source_text()
+}

--- a/linktime-proc-macro/src/generate.rs
+++ b/linktime-proc-macro/src/generate.rs
@@ -6,7 +6,7 @@ use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, Tok
 /// ::ctor::__support::ctor_parse!(#[ctor] fn foo() { ... });
 /// ::dtor::__support::dtor_parse!(#[dtor] fn foo() { ... });
 /// ```
-#[allow(unknown_lints, tail_expr_drop_order)]
+#[allow(unknown_lints, tail_expr_drop_order, unused)]
 pub(crate) fn generate(
     macro_crate: &str,
     macro_type: &str,

--- a/linktime-proc-macro/src/hash/mod.rs
+++ b/linktime-proc-macro/src/hash/mod.rs
@@ -1,136 +1,59 @@
-use proc_macro::{Delimiter, Group, Ident, Literal, Span, TokenStream, TokenTree};
+use proc_macro::{Span, TokenStream, TokenTree};
 
-use crate::tokens::{
-    decode_literal_string, decode_literal_strings, expect_literal, expect_numeric_literal,
-};
+pub(crate) mod xx3;
 
-mod xx3;
-
-/// Concatenate two identifiers.
-pub(crate) fn ident_concat(item: TokenStream) -> TokenStream {
-    let mut item = item.into_iter();
-    let Some(TokenTree::Group(pre_group)) = item.next() else {
-        panic!("pre_group: Expected a group");
-    };
-    let Some(TokenTree::Group(name_group)) = item.next() else {
-        panic!("name_group: Expected a group");
-    };
-    let Some(TokenTree::Group(post_group)) = item.next() else {
-        panic!("post_group: Expected a group");
-    };
-
-    let mut item = name_group.stream().into_iter();
-    let mut name = String::new();
-    while let Some(TokenTree::Ident(ident)) = item.next() {
-        name.push_str(&ident.to_string());
-    }
-
-    let mut output = pre_group.stream();
-    output.extend([TokenTree::Ident(Ident::new(&name, Span::call_site()))]);
-    output.extend(post_group.stream());
-    output
+struct TokenTreeDeepIterator {
+    stack: Vec<proc_macro::token_stream::IntoIter>,
 }
 
-/// If the input string is longer than the max length, replace the tail end of
-/// the string with the hash of the string.
-///
-/// hash!(output (prefix) (name) (suffix) hash_length max_length valid_section_chars)
-pub(crate) fn hash(item: TokenStream) -> TokenStream {
-    let mut item = item.into_iter();
+impl Iterator for TokenTreeDeepIterator {
+    type Item = Span;
 
-    let Some(TokenTree::Group(group)) = item.next() else {
-        panic!("output: Expected a group");
-    };
-    let group = group.stream();
-
-    let Some(prefix_group) = item.next() else {
-        panic!("prefix: Expected a group");
-    };
-    let prefix = decode_literal_strings("prefix", prefix_group);
-
-    let Some(input_group) = item.next() else {
-        panic!("input: Expected an identifier");
-    };
-    let literal = decode_literal_strings("input", input_group);
-
-    let Some(suffix_group) = item.next() else {
-        panic!("suffix: Expected a group");
-    };
-    let suffix = decode_literal_strings("suffix", suffix_group);
-
-    let hash_length = expect_numeric_literal(
-        "hash_length",
-        item.next().expect("hash_length: Missing argument"),
-    );
-    let max_length = expect_numeric_literal(
-        "max_length",
-        item.next().expect("max_length: Missing argument"),
-    );
-
-    let valid_section_chars = expect_literal(
-        "valid_section_chars",
-        item.next().expect("valid_section_chars: Missing argument"),
-    );
-    let valid_section_chars =
-        decode_literal_string("valid_section_chars", valid_section_chars).into_bytes();
-
-    // If the string is valid as-is, return it
-    let output = if literal.len() < max_length
-        && !literal
-            .to_string()
-            .contains(|c| c > '\u{007f}' || !valid_section_chars.contains(&(c as u8)))
-    {
-        format!("{prefix}{literal}{suffix}")
-    } else {
-        // Not valid, so we need to hash the string
-        let mut output = String::with_capacity(max_length + prefix.len() + suffix.len());
-        output.push_str(&prefix.to_string());
-        let mut next = literal.chars();
-        while output.len() < max_length - hash_length + prefix.len() {
-            let Some(c) = next.next() else {
-                break;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let mut iter = self.stack.pop()?;
+            let Some(token) = iter.next() else {
+                continue;
             };
-            if c <= '\u{007f}' && valid_section_chars.contains(&(c as u8)) {
-                output.push(c);
+            self.stack.push(iter);
+            match token {
+                TokenTree::Group(group) => {
+                    self.stack.push(group.stream().into_iter());
+                    return Some(group.span());
+                }
+                _ => return Some(token.span()),
             }
         }
+    }
+}
 
-        let mut hash = xx3::xx3hash(&literal);
-        while output.len() < max_length + prefix.len() {
-            let c = valid_section_chars[hash as usize % valid_section_chars.len()];
-            output.push(c as char);
-            hash /= valid_section_chars.len() as u64;
-        }
-        output.push_str(&suffix);
-        output
+pub(crate) fn location_hash(tokens: TokenStream) -> u64 {
+    let iterator = TokenTreeDeepIterator {
+        stack: vec![tokens.into_iter()],
     };
 
-    fn emit(tree: TokenStream, output: &str, found: &mut bool) -> TokenStream {
-        if *found {
-            return tree;
+    // TODO: Can we avoid doing multiple hashes?
+    let mut buffer = [0_u8; 1024];
+    let mut last_hash = 0_u64;
+    for span in iterator {
+        let hash = last_hash.to_be_bytes();
+        let line = crate::fallback::line(&span).to_be_bytes();
+        let column = crate::fallback::column(&span).to_be_bytes();
+        let file = crate::fallback::file(&span);
+        let mut len = 0;
+
+        for buf in [
+            hash.as_slice(),
+            line.as_slice(),
+            column.as_slice(),
+            file.as_bytes(),
+        ] {
+            buffer[len..len + buf.len()].copy_from_slice(buf);
+            len += buf.len();
         }
-        let mut stream = TokenStream::new();
-        for input in tree.into_iter() {
-            match input {
-                _ if *found => stream.extend([input]),
-                TokenTree::Ident(ident) if ident.to_string() == "__" => {
-                    stream.extend([TokenTree::Literal(Literal::string(output))]);
-                    *found = true;
-                }
-                TokenTree::Group(group) => stream.extend([TokenTree::Group(Group::new(
-                    group.delimiter(),
-                    emit(group.stream(), output, found),
-                ))]),
-                _ => stream.extend([input]),
-            }
-        }
-        stream
+
+        last_hash = crate::hash::xx3::xx3hash_bytes(&buffer[..len]);
     }
 
-    let mut found = false;
-    let stream = emit(group, &output, &mut found);
-    if !found {
-        panic!("output: Expected to find __");
-    }
-    TokenStream::from_iter([TokenTree::Group(Group::new(Delimiter::None, stream))])
+    last_hash
 }

--- a/linktime-proc-macro/src/hash/xx3.rs
+++ b/linktime-proc-macro/src/hash/xx3.rs
@@ -276,3 +276,8 @@ fn xxh3_64(data: &[u8]) -> u64 {
 pub(crate) fn xx3hash(s: &str) -> u64 {
     xxh3_64(s.as_bytes())
 }
+
+#[inline]
+pub(crate) fn xx3hash_bytes(s: &[u8]) -> u64 {
+    xxh3_64(s)
+}

--- a/linktime-proc-macro/src/lib.rs
+++ b/linktime-proc-macro/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 
+mod combine;
+mod fallback;
 mod generate;
 mod hash;
-mod tokens;
 
 use proc_macro::TokenStream;
 
@@ -34,16 +35,337 @@ generators! {
     (ctor/"ctor": ctor/ctor_linktime)
     (dtor/"dtor": dtor/dtor_linktime)
     (link_section/"link_section": in_section/in_section_linktime, section/section_linktime)
+    (scattered_collect/"scattered_collect": scatter/scatter_linktime, gather/gather_linktime)
 }
 
-#[doc(hidden)]
+/// Combines idents and strings into a single ident or string.
+///
+/// Both idents and strings are decoded as literal strings. Punctuation is
+/// ignored when building `ident` output.
+///
+/// Arguments are specified via named arguments:
+///
+/// - `output`: The type of the combined value. Must be either `ident`, `string`
+///   or `isize`.
+/// - `input`: The input tokens to combine.
+/// - `prefix`: The prefix tokens to emit before the combined value.
+/// - `suffix`: The suffix tokens to emit after the combined value.
+/// - `paren`: The group to emit around the combined value.
+/// - `paren_prefix`: The prefix tokens to emit before the value inside the
+///   group.
+/// - `paren_suffix`: The suffix tokens to emit after the value inside the
+///   group.
+/// - `span`: The span of the combined value. If not specified, the call-site's
+///   span is used.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// // Idents, strings and numeric literals are combined as-is.
+/// let str = combine!(output=string input=(prefix _ "NAME" _ suffix));
+/// assert_eq!(str, "prefix_NAME_suffix");
+/// let str = combine!(output=string input=(prefix _ NAME _ 1 _ suffix));
+/// assert_eq!(str, "prefix_NAME_1_suffix");
+///
+/// // Resolves to `let prefix_NAME_suffix = 1;`
+/// combine!(output=ident input=(prefix _ "NAME" _ suffix) prefix=(let ) suffix=(= 1;));
+/// assert_eq!(prefix_NAME_suffix, 1);
+///
+/// // Set the span of the combined value to one of a specific token (useful for macros)
+/// combine!(output=ident input=(prefix _ "NAME" _ suffix) span=token);
+/// ```
+///
+/// ## Token handling
+///
+/// The macro will ignore grouping tokens. For ident output, the macro will also
+/// ignore punctuation tokens and will strip any non-ident-compatible
+/// characters.
+///
+/// ## Functions
+///
+/// The macro also supports a number of special function tokens which are
+/// resolved recursively and can be nested arbitrarily deep.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// macro_rules! make_name_max_length {
+///     ($prefix:ident $name:ident $suffix:ident) => {
+///       // Ensure user calls are not expanded recursively
+///       /* $crate:: */ make_name_max_length!(@internal (__RAW__(input=($prefix))) (__RAW__(input=($name))) (__RAW__(input=($suffix))))
+///     };
+///     (@internal $prefix:tt $name:tt $suffix:tt) => {
+///         combine!(output=string input=(
+///             __IF__(
+///               test=(__GT__(a=(__LENGTH__(string=($prefix _ $name _ $suffix))) b=20))
+///               then=(
+///                 __SUBSTRING__(input=($prefix _ $name _ $suffix) start=0 end=10)
+///                 _ $
+///                 // uppercase hash
+///                 __TRANSLATE__(
+///                   input=(__SUBSTRING__(input=(__HASH__(string=($prefix _ $name _ $suffix))) length=10))
+///                   pattern=[a-f] replacement=[A-F]
+///                 )
+///               )
+///               else=(
+///                 $prefix _ $name _ $suffix _ __LENGTH__(string=($name))
+///               )
+///             )
+///         ))
+///     };
+/// }
+/// assert_eq!(make_name_max_length!(prefix NAME suffix), "prefix_NAME_suffix_4");
+/// assert_eq!(make_name_max_length!(prefix LONG_NAME suffix), "prefix_LON_$64470473B5");
+/// ```
+///
+/// ## Source span functions
+///
+///  - `__FILE__(of=token)`: The file name of the file containing the `token`.
+///    Supported on Rust 1.88+, returns "" otherwise.
+///  - `__LINE__(of=token)`: The line number of the `token`. Supported on Rust
+///    1.88+, returns 0 otherwise.
+///  - `__COLUMN__(of=token)`: The column number of the `token`. Supported on
+///    Rust 1.88+, returns 0 otherwise.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let file = combine!(output=string input=("file:" __FILE__(of=token) ":" __LINE__(of=token) ":" __COLUMN__(of=token)));
+/// assert_eq!(file, "file:linktime-proc-macro/src/lib.rs:6:110");
+/// ```
+///
+///  - `__LOCATIONHASH__(of=token, alphabet=[chars...])`: Returns a hash of
+///    location information for all tokens within the tree of `token`. If
+///    `alphabet` is specified, the hash is converted to a string using the
+///    characters in the `alphabet`. No zero padding is applied in this case.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let location_hash = combine!(output=string input=("location_hash:" __LOCATIONHASH__(of=(a bunch of tokens) alphabet=[a-z])));
+/// assert_eq!(location_hash, "location_hash:dwsrxapjetrwwu");
+/// ```
+///
+///  - `__SOURCE__(of=token)`: The source text content of the `token`.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// macro_rules! source_of {
+///     ($token:item) => {
+///         combine!(output=string input=("source" "(@" __LINE__(of=$token) "):" __SOURCE__(of=$token)))
+///     };
+/// }
+/// // Use a macro to get the line and source text of a token
+/// assert_eq!(source_of!(fn foo() {}), "source(@12):fn foo () {}");
+/// assert_eq!(source_of!(static X: u32 = 1;), "source(@13):static X : u32 = 1 ;");
+///
+/// let source = combine!(output=string input=("source:" __SOURCE__(of=(my token))));
+/// assert_eq!(source, "source:my token");
+/// ```
+///
+/// ## String functions
+///
+///  - `__HASH__(string=(tokens...) [alphabet=[chars...]])`: The hash of the
+///    `tokens` when converted to a string, by default as a zero-padding
+///    lowercase hexadecimal string. `tokens` may contain nested function calls.
+///    If `alphabet` is specified, the hash is converted to a string using the
+///    characters in the `alphabet`. No zero padding is applied in this case.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let hash = combine!(output=string input=("hash:" __HASH__(string=(__LENGTH__(string="a")))));
+/// assert_eq!(hash, "hash:65cd25028f98f158");
+/// let hash = combine!(output=string input=("hash:" __HASH__(string=(1))));
+/// assert_eq!(hash, "hash:65cd25028f98f158");
+/// let hash = combine!(output=string input=("hash:" __HASH__(string=(1) alphabet=[0-9a-f])));
+/// assert_eq!(hash, "hash:65cd25028f98f158");
+/// let hash = combine!(output=string input=("hash:" __HASH__(string=(1) alphabet=[a-z])));
+/// assert_eq!(hash, "hash:cywprjlaqhbdie");
+/// ```
+///
+///  - `__LENGTH__(string=(tokens...))`: The length of the `tokens` when
+///    converted to a string.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let length = combine!(output=string input=("length:" __LENGTH__(string="a")));
+/// assert_eq!(length, "length:1");
+/// ```
+///
+///  - `__SUBSTRING__(input=(input) start=start end=end length=length)`: The
+///    substring of the `input` from the `start` to the `end` index (exclusive)
+///    or `length` characters from the `start` index. If `end` or `length` would
+///    exceed the length of the input, the substring is truncated to the end of
+///    the input. If `end` or `length` are missing, the substring is the entire
+///    input from `start` to the end of the input.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let substring = combine!(output=string input=("substring:" __SUBSTRING__(input="abc" start=1 end=2)));
+/// assert_eq!(substring, "substring:b");
+/// let substring = combine!(output=string input=("substring:" __SUBSTRING__(input="abc" start=1 length=2)));
+/// assert_eq!(substring, "substring:bc");
+/// ```
+///
+///  - `__PAD__(input=(input) length=length left=(padding...)
+///    right=(padding...))`: Pad the `input` to the `length` with the
+///    `padding...` (converted to a string).
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let pad = combine!(output=string input=("pad:" __PAD__(input=123 length=5 left=0)));
+/// assert_eq!(pad, "pad:00123");
+/// ```
+///
+/// ## Pattern functions
+///
+///  - `__REPLACE__(input=(input) pattern=(pattern...)|[chars...]
+///    replacement=(replacement))`: Replace all occurrences of the `pattern...`
+///    (converted to a string) in the `input` with the `replacement`. If
+///    `replacement` is missing or empty, the pattern is removed.
+///
+/// Note: `pattern` may be specified as a regex-like character group. Use square
+/// brackets to specify a character group.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let replace = combine!(output=string input=("replace:" __REPLACE__(input=(a b c) pattern=(b) replacement=(x))));
+/// assert_eq!(replace, "replace:axc");
+///
+/// // Remove non-alnum characters
+/// let translate = combine!(output=string input=("replace:" __REPLACE__(input="⚠️ thx 1138" pattern=[^a-zA-Z0-9] replacement="")));
+/// assert_eq!(translate, "replace:thx1138");
+/// ```
+///
+///  - `__TRANSLATE__(input=(input) pattern=(pattern...)|[chars...]
+///    replacement=(replacement)|[chars...])`: Replace all occurrences of the
+///    `pattern...` (converted to a string) characters in the `input` with the
+///    `replacement` characters. If replacement is missing or empty, the
+///    character is removed. Otherwise, the replacement character is selected
+///    from the replacement string in order (repeating the last character if
+///    necessary).
+///
+/// Note: `pattern` and `replacement` may be specified as regex-like character
+/// groups. Use square brackets to specify a character group.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// // Deletes all digits
+/// let translate = combine!(output=string input=("translate:" __TRANSLATE__(input=(thx 1138) pattern=(0 1 2 3 4 5 6 7 8 9))));
+/// assert_eq!(translate, "translate:thx");
+/// // Uppercase all ASCII letters
+/// let translate = combine!(output=string input=("translate:" __TRANSLATE__(input=(thx 1138) pattern=[a-z] replacement=[A-Z])));
+/// assert_eq!(translate, "translate:THX1138");
+/// ```
+///
+///  - `__TRIM__(input=(input) left=(padding...)|[chars...]
+///    right=(padding...)|[chars...])`: Trim the
+///    `input` of the `left` and `right` patterns.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// // Note: because we are using escaped characters, we need to put them in a string
+/// let trim = combine!(output=string input=("trim:" __TRIM__(input="  thx 1138  " left=[" \n\t"] right=[" \n\t"])));
+/// assert_eq!(trim, "trim:thx 1138");
+/// let trim = combine!(output=string input=("trim:" __TRIM__(input="  thx 1138  " left=[' '] right=[' '])));
+/// assert_eq!(trim, "trim:thx 1138");
+/// ```
+///
+///  - `__CONTAINS__(input=(input) pattern=(pattern...)|[chars...])`: Check if
+///    the `input` contains the `pattern...`. If so, returns `1`, otherwise `0`.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let contains = combine!(output=isize input=("contains:" __CONTAINS__(input="thx 1138" pattern=[0-9])));
+/// assert_eq!(contains, 1);
+/// let contains = combine!(output=isize input=("contains:" __CONTAINS__(input="thx 1138" pattern=[aeiou])));
+/// assert_eq!(contains, 0);
+/// let contains = combine!(output=isize input=("contains:" __CONTAINS__(input="thx 1138" pattern="1138")));
+/// assert_eq!(contains, 1);
+/// ```
+///
+///  - `__STREQ__(a=(tokens...) b=(tokens...))`: Compare `a` and `b` as strings.
+///    Returns `1` if equal, `0` otherwise.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let eq = combine!(output=isize input=("eq:" __STREQ__(a="thx 1138" b="thx 1138")));
+/// assert_eq!(eq, 1);
+/// let eq = combine!(output=isize input=("eq:" __STREQ__(a="thx 1138" b="thx 1139")));
+/// assert_eq!(eq, 0);
+/// ```
+///
+/// ## Comparison functions
+///
+///  - `__IF__(test=(tokens...) then=(tokens...) else=(tokens...))`: If test is
+///    non-zero, emit the `then` tokens, otherwise emit the `else` tokens.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// // Outputs true or false idents
+/// assert!(combine!(output=ident input=(__IF__(test=1 then="true" else="false"))));
+/// assert!(combine!(output=ident input=(__IF__(test=(__CONTAINS__(input="thx 1138" pattern="1138")) then="true" else="false"))));
+/// ```
+///
+/// - `__LT__(a=(tokens...) b=(tokens...))`: Compare `a` < `b` as numbers.
+/// - `__GT__(a=(tokens...) b=(tokens...))`: Compare `a` > `b` as numbers.
+/// - `__LE__(a=(tokens...) b=(tokens...))`: Compare `a` <= `b` as numbers.
+/// - `__GE__(a=(tokens...) b=(tokens...))`: Compare `a` >= `b` as numbers.
+/// - `__EQ__(a=(tokens...) b=(tokens...))`: Compare `a` == `b` as numbers.
+/// - `__NE__(a=(tokens...) b=(tokens...))`: Compare `a` != `b` as numbers.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let lt = combine!(output=isize input=(__LT__(a=1 b=2)));
+/// assert_eq!(lt, 1);
+/// let gt = combine!(output=isize input=(__GT__(a=1 b=2)));
+/// assert_eq!(gt, 0);
+/// ```
+///
+/// ## Math functions
+///
+///  - `__ADD__(a=(tokens...) b=(tokens...))`: Add the `a` and `b` tokens.
+///  - `__SUB__(a=(tokens...) b=(tokens...))`: Subtract the `b` from `a`.
+///  - `__MUL__(a=(tokens...) b=(tokens...))`: Multiply the `a` and `b` tokens.
+///  - `__DIV__(a=(tokens...) b=(tokens...))`: Divide the `a` by `b`.
+///  - `__AND__(a=(tokens...) b=(tokens...))`: Bitwise AND the `a` and `b`
+///    tokens.
+///  - `__OR__(a=(tokens...) b=(tokens...))`: Bitwise OR the `a` and `b` tokens.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// assert_eq!(combine!(output=isize input=("add:" __ADD__(a=1 b=2))), 3);
+/// assert_eq!(combine!(output=isize input=("sub:" __SUB__(a=1 b=2))), -1);
+/// assert_eq!(combine!(output=isize input=("mul:" __MUL__(a=1 b=2))), 2);
+/// assert_eq!(combine!(output=isize input=("div:" __DIV__(a=1 b=2))), 0);
+/// assert_eq!(combine!(output=isize input=("and:" __AND__(a=1 b=2))), 0);
+/// assert_eq!(combine!(output=isize input=("or:" __OR__(a=1 b=2))), 3);
+/// ```
+///
+/// ## Conversion functions
+///
+///  - `__TOSTRING__(input=(tokens...))`: Convert the `tokens` to a string
+///    literal.
+///  - `__RAW__(input=(tokens...))`: Convert the `tokens` to a string, ignoring
+///    nested function calls (recommended for user input).
+///  - `__TOIDENT__(input=(tokens...))`: Convert the `tokens` to an ident,
+///    stripping invalid characters.
+///  - `__TONUMBER__(input=(tokens...))`: Convert the `tokens` to a numeric
+///    literal.
+///
+/// ```rust
+/// # use linktime_proc_macro::combine;
+/// let string = combine!(output=string input=("string:" __TOSTRING__(input=(a b c))));
+/// assert_eq!(string, "string:abc");
+///
+/// let number = combine!(output=isize input=("number:" __TONUMBER__(input=(1 2 3))));
+/// assert_eq!(number, 123);
+/// let number = combine!(output=isize input=("number:" __TONUMBER__(input=("0x" 123 _ 456))));
+/// assert_eq!(number, 0x123456);
+///
+/// let ident = combine!(output=string input=("ident:" __TOIDENT__(input=(a $ b _ c))));
+/// assert_eq!(ident, "ident:ab_c");
+///
+/// let raw = combine!(output=string input=("raw:" __RAW__(input=(__TOSTRING__(input=(a b c))))));
+/// assert_eq!(raw, "raw:__TOSTRING__input=abc");
+/// ```
 #[proc_macro]
-pub fn ident_concat(item: TokenStream) -> TokenStream {
-    hash::ident_concat(item)
-}
-
-#[doc(hidden)]
-#[proc_macro]
-pub fn hash(item: TokenStream) -> TokenStream {
-    hash::hash(item)
+pub fn combine(item: TokenStream) -> TokenStream {
+    combine::combine(item)
 }


### PR DESCRIPTION
Implements a new umbrella macro `combine!` that handles string and ident concatenation for various things we need. Replaces the old macros with compat stubs for now - we'll be reworking things in the future. 

This is like a version of `concat!` and `stringify!` on steroids. It mostly performs string concatenation, but callers may embed `__FUNCTION__(...)` calls internally which are evaluated before being appending to the ident or string.

Extracted from #469 


