### PR TITLE
Support Rust 1.96 changes in WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libc-print"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4fb34ccfede7d939c50cf24b65e228fa2af1d3b49f6efd44b080dd3dcf2f1e"
+checksum = "a52163ef340f2845a3973431341ec3afb9a9c3efedc28bce7c93a5eb35c44b3b"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "linktime-proc-macro",
  "macrotest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "libc-print",
  "linktime-proc-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.7", default-features = false }
-dtor = { path = "dtor", version = "1.0.4", default-features = false }
-link-section = { path = "link-section", version = "0.18.0", default-features = false }
+dtor = { path = "dtor", version = "1.0.5", default-features = false }
+link-section = { path = "link-section", version = "0.18.1", default-features = false }
 linktime = { path = "linktime", version = "0.17.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -35,7 +35,7 @@ linktime-proc-macro = { workspace = true, optional = true, features = ["ctor"] }
 link-section = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
-libc-print = "0.3"
+libc-print = "0.5"
 macrotest = "1"
 trybuild = "1"
 walkdir = "2"

--- a/dtor/CHANGELOG.md
+++ b/dtor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-05-30
+
+### Changed
+
+- Bump `link-section` dependency to 0.18.1.
+- Fixed WASM import module for `atexit` to support Rust 1.96.
+
 ## [1.0.4] - 2026-05-28
 
 ### Changed

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtor"
-version = "1.0.4"
+version = "1.0.5"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible destructors for all platforms that run after main (like C/C++ __attribute__((destructor)))"

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -21,7 +21,7 @@ proc_macro = ["dep:linktime-proc-macro"]
 linktime-proc-macro = { workspace = true, optional = true, features = ["dtor"] }
 
 [dev-dependencies]
-libc-print = "0.3"
+libc-print = "0.5"
 macrotest = "1"
 trybuild = "1"
 walkdir = "2"

--- a/dtor/src/native.rs
+++ b/dtor/src/native.rs
@@ -68,6 +68,7 @@ unsafe fn _run_atexit(cb: unsafe extern "C" fn()) {
 #[inline(always)]
 unsafe fn _run_atexit(cb: unsafe extern "C" fn()) {
     #[allow(missing_unsafe_on_extern)] // MSRV
+    #[cfg_attr(target_os = "unknown", link(wasm_import_module = "env"))]
     extern "C" {
         fn atexit(cb: unsafe extern "C" fn()) -> i32;
     }

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-05-30
+
+### Changed
+
+- Fixed WASM import module for `read_custom_section` and `atexit`.
+
 ## [0.18.0] - 2026-05-28
 
 ### Changed

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.18.0"
+version = "0.18.1"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -153,6 +153,8 @@ macro_rules! __register_wasm_item {
 
 #[cfg(target_family = "wasm")]
 #[allow(missing_unsafe_on_extern)] // MSRV
+#[cfg_attr(target_os = "unknown", link(wasm_import_module = "env"))]
+#[cfg_attr(target_env = "p1", link(wasm_import_module = "env"))]
 extern "C" {
     /// Read custom section with name/name_length as a UTF8 string
     pub(crate) fn read_custom_section(

--- a/linktime/Cargo.toml
+++ b/linktime/Cargo.toml
@@ -29,7 +29,7 @@ dtor = { workspace = true, optional = true }
 link-section = { workspace = true, optional = true }
 
 [dev-dependencies]
-libc-print = "0.3"
+libc-print = "0.5"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dev-dependencies]
 clitest-lib = { version = "0.6.0", default-features = false, features = ["fancy-regex"] }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [lib]
 path = "test.rs"

--- a/tests/ctor/crt-static/Cargo.toml
+++ b/tests/ctor/crt-static/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 ctor = { path = "../../../ctor" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]
 

--- a/tests/ctor/doctest/Cargo.toml
+++ b/tests/ctor/doctest/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 ctor = { path = "../../../ctor" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/ctor/edition-2018/Cargo.toml
+++ b/tests/ctor/edition-2018/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 # When we bump the MSRV, can probably re-add priority feature.
 ctor = { path = "../../../ctor", default-features = false, features = ["proc_macro", "std"] }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]
 

--- a/tests/ctor/edition-2021/Cargo.toml
+++ b/tests/ctor/edition-2021/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 # When we bump the MSRV, can probably re-add priority feature.
 ctor = { path = "../../../ctor", default-features = false, features = ["proc_macro", "std"] }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]
 

--- a/tests/ctor/edition-2024/Cargo.toml
+++ b/tests/ctor/edition-2024/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 
 [dependencies]
 ctor = { path = "../../../ctor" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]
 

--- a/tests/ctor/no-default-features/Cargo.toml
+++ b/tests/ctor/no-default-features/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 ctor = { path = "../../../ctor", default-features = false }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/ctor/priority/Cargo.toml
+++ b/tests/ctor/priority/Cargo.toml
@@ -9,6 +9,6 @@ rust-version = "1.85"
 
 [dependencies]
 ctor = { path = "../../../ctor" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/ctor/system/Cargo.toml
+++ b/tests/ctor/system/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 ctor = { path = "../../../ctor" }
 dtor = { path = "../../../dtor" }
 dlopen = "0.1.8"
-libc-print = "0.3"
+libc-print = "0.5"
 libc = { version = "0.2.96", default-features = false }
 
 [[example]]

--- a/tests/ctor/warn-unsafe/Cargo.toml
+++ b/tests/ctor/warn-unsafe/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 
 [dependencies]
 ctor = { path = "../../../ctor", default-features = false, features = ["proc_macro", "std"] }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [features]
 

--- a/tests/ctor/wasm/Cargo.toml
+++ b/tests/ctor/wasm/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ctor = { path = "../../../ctor" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/dtor/link-section/Cargo.toml
+++ b/tests/dtor/link-section/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 dtor = { path = "../../../dtor" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/dtor/no-default-features/Cargo.toml
+++ b/tests/dtor/no-default-features/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 dtor = { path = "../../../dtor", default-features = false }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/dtor/wasm/Cargo.toml
+++ b/tests/dtor/wasm/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 dtor = { path = "../../../dtor" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/link_section/basic/Cargo.toml
+++ b/tests/link_section/basic/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 ctor = { path = "../../../ctor" }
 link-section = { path = "../../../link-section" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/link_section/interior_mut/Cargo.toml
+++ b/tests/link_section/interior_mut/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 ctor = { path = "../../../ctor" }
 link-section = { path = "../../../link-section" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/link_section/mut/Cargo.toml
+++ b/tests/link_section/mut/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 ctor = { path = "../../../ctor" }
 link-section = { path = "../../../link-section" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/link_section/no-default-features/Cargo.toml
+++ b/tests/link_section/no-default-features/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 link-section = { path = "../../../link-section", default-features = false }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]

--- a/tests/wasm/rust/Cargo.toml
+++ b/tests/wasm/rust/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 linktime = { path = "../../../linktime" }
-libc-print = "0.3"
+libc-print = "0.5"
 
 [workspace]
 


### PR DESCRIPTION
The Rust changelog added a note re: unknown WASM imports. We now need an explicit `link(wasm_import_module = "env")`. 