### PR TITLE
Fix linker error with empty scatter/gather collections on ELF

### DIFF
--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -11,6 +11,7 @@ zig_examples=(
   ctor-advanced
   link-section-const
   link-section-dyn
+  link-section-empty
   link-section-example
   link-section-mut
 )

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.2] - 2026-06-06
+
+### Changed
+
+- Empty sections are now automatically supported on all platforms other than AIX.
+
 ## [0.18.1] - 2026-05-30
 
 ### Changed

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -39,6 +39,10 @@ name = "link-section-dyn"
 path = "examples/dyn.rs"
 
 [[example]]
+name = "link-section-empty"
+path = "examples/empty.rs"
+
+[[example]]
 name = "link-section-example"
 path = "examples/example.rs"
 

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -228,11 +228,10 @@ pre-main construction functions to copy each entry into a contiguous section
 allocated at startup. The number of items in a link-section is computed by
 generating a custom data section containing one byte per item.
 
-The WASM support expects a function in the module's environment with the
-following signature and functionality. The wasm import only passes the four
-`usize` / pointer parameters; the embedder should close over
-`WebAssembly.Module` and `WebAssembly.Memory` from compile/instantiate when
-installing the import.
+The WASM support expects a function named `read_custom_section` in the module's
+environment with four `usize` / pointer parameters; the embedder should close
+over `WebAssembly.Module` and `WebAssembly.Memory` from compile/instantiate when
+installing the import and pass them to the function below:
 
 ```js
 /**

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -151,7 +151,7 @@ pub fn callback() {
 | macOS                    | ✅ Fully supported                              |
 | Windows                  | ✅ Fully supported                              |
 | WASM                     | ✅ Fully supported, via emulation (§2) (§3)     |
-| AIX                      | ✅ Supported (§4)                               |
+| AIX                      | ✅ Supported (§4) (§5)                          |
 | Other LLVM/GCC platforms | ✅ Supported, uses orphan section handling (§1) |
 
 (§1) Orphan section handling is a feature of the linker that allows sections to
@@ -166,6 +166,9 @@ function) is required to register each section with the runtime.
 
 (§4) AIX requires `-C link-arg=-bdbg:namedsects:ss` which enables functionality
 similar to LLVM/GCC's orphan section handling.
+
+(§5) Empty sections are not currently supported: ensure every section has at least
+one item, or pass the `-C link-arg=-berok` linker flag to ignore errors.
 
 ## Platform Details
 
@@ -291,6 +294,10 @@ found:
         ld: 0711-317 ERROR: Undefined symbol: __stop__data_link_section_DATABASES
         ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
 ```
+
+In addition, the linker may report the same errors if a section is empty. It is
+recommended that you either (1) provide a sentinel item for AIX that can be skipped
+in the slice, or (2) pass the `-C link-arg=-berok` linker flag to ignore the error.
 
 For debugging AIX link-section issues, `-C link-arg=-bmap:[path]/linker.out` and
 `-C link-arg=-bnoquiet` may also be useful.

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -151,7 +151,7 @@ pub fn callback() {
 | macOS                    | ✅ Fully supported                              |
 | Windows                  | ✅ Fully supported                              |
 | WASM                     | ✅ Fully supported, via emulation (§2) (§3)     |
-| AIX                      | ✅ Supported (§4)                               |
+| AIX                      | ✅ Supported (§4) (§5)                          |
 | Other LLVM/GCC platforms | ✅ Supported, uses orphan section handling (§1) |
 
 (§1) Orphan section handling is a feature of the linker that allows sections to
@@ -166,6 +166,9 @@ function) is required to register each section with the runtime.
 
 (§4) AIX requires `-C link-arg=-bdbg:namedsects:ss` which enables functionality
 similar to LLVM/GCC's orphan section handling.
+
+(§5) Empty sections are not currently supported: ensure every section has at least
+one item, or pass the `-C link-arg=-berok` linker flag to ignore errors.
 
 ## Platform Details
 
@@ -225,11 +228,10 @@ pre-main construction functions to copy each entry into a contiguous section
 allocated at startup. The number of items in a link-section is computed by
 generating a custom data section containing one byte per item.
 
-The WASM support expects a function in the module's environment with the
-following signature and functionality. The wasm import only passes the four
-`usize` / pointer parameters; the embedder should close over
-`WebAssembly.Module` and `WebAssembly.Memory` from compile/instantiate when
-installing the import.
+The WASM support expects a function named `read_custom_section` in the module's
+environment with four `usize` / pointer parameters; the embedder should close
+over `WebAssembly.Module` and `WebAssembly.Memory` from compile/instantiate when
+installing the import and pass them to the function below:
 
 ```js
 /**
@@ -291,6 +293,10 @@ found:
         ld: 0711-317 ERROR: Undefined symbol: __stop__data_link_section_DATABASES
         ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
 ```
+
+In addition, the linker may report the same errors if a section is empty. It is
+recommended that you either (1) provide a sentinel item for AIX that can be skipped
+in the slice, or (2) pass the `-C link-arg=-berok` linker flag to ignore the error.
 
 For debugging AIX link-section issues, `-C link-arg=-bmap:[path]/linker.out` and
 `-C link-arg=-bnoquiet` may also be useful.

--- a/link-section/examples/empty.rs
+++ b/link-section/examples/empty.rs
@@ -3,6 +3,7 @@
 //!
 //! Each section kind that routes through `get_section!` is exercised empty.
 #![warn(missing_docs)]
+#![allow(unsafe_code)]
 
 use link_section::{
     section, Ref, TypedMovableSection, TypedMutableSection, TypedReferenceSection, TypedSection,

--- a/link-section/examples/empty.rs
+++ b/link-section/examples/empty.rs
@@ -1,0 +1,52 @@
+//! Regression test: sections with no `#[in_section]` items must still link.
+//!
+//! On ELF targets the linker only synthesizes the `__start_`/`__stop_`
+//! encapsulation symbols for sections that are actually emitted. A section with
+//! no submitted items is never emitted, so without the weak-symbol workaround
+//! (see `__weak_section_symbols!` in the standard platform) the `extern`
+//! references would be undefined and the link would fail:
+//!
+//! ```text
+//! ld.lld: error: undefined symbol: __start__data_link_section_...
+//! ```
+//!
+//! Each section kind that routes through `get_section!` is exercised empty.
+#![warn(missing_docs)]
+
+use link_section::{
+    Ref, TypedMovableSection, TypedMutableSection, TypedReferenceSection, TypedSection, section,
+};
+
+/// An empty typed section.
+#[section(typed)]
+pub static EMPTY_TYPED: TypedSection<u32>;
+
+/// An empty mutable section.
+#[section(mutable)]
+pub static EMPTY_MUTABLE: TypedMutableSection<u32>;
+
+/// An empty movable section (exercises the value *and* backref symbols).
+#[section(movable)]
+pub static EMPTY_MOVABLE: TypedMovableSection<u32>;
+
+/// An empty reference section.
+#[section(reference)]
+pub static EMPTY_REFERENCE: TypedReferenceSection<Ref<u32>>;
+
+/// Asserts every empty section links and reports zero items.
+pub fn main() {
+    assert!(EMPTY_TYPED.is_empty(), "typed");
+    assert_eq!(EMPTY_TYPED.as_slice(), &[] as &[u32]);
+
+    assert!(EMPTY_MUTABLE.is_empty(), "mutable");
+
+    assert!(EMPTY_MOVABLE.is_empty(), "movable");
+    // Sorting an empty movable section must also be a no-op rather than touching
+    // the (null) backref bounds.
+    unsafe { EMPTY_MOVABLE.sort_unstable() };
+    assert!(EMPTY_MOVABLE.is_empty(), "movable after sort");
+
+    assert!(EMPTY_REFERENCE.is_empty(), "reference");
+
+    eprintln!("OK: all empty sections linked and report empty");
+}

--- a/link-section/examples/empty.rs
+++ b/link-section/examples/empty.rs
@@ -1,20 +1,11 @@
 //! Regression test: sections with no `#[in_section]` items must still link.
 //!
-//! On ELF targets the linker only synthesizes the `__start_`/`__stop_`
-//! encapsulation symbols for sections that are actually emitted. A section with
-//! no submitted items is never emitted, so without the weak-symbol workaround
-//! (see `__weak_section_symbols!` in the standard platform) the `extern`
-//! references would be undefined and the link would fail:
-//!
-//! ```text
-//! ld.lld: error: undefined symbol: __start__data_link_section_...
-//! ```
 //!
 //! Each section kind that routes through `get_section!` is exercised empty.
 #![warn(missing_docs)]
 
 use link_section::{
-    Ref, TypedMovableSection, TypedMutableSection, TypedReferenceSection, TypedSection, section,
+    section, Ref, TypedMovableSection, TypedMutableSection, TypedReferenceSection, TypedSection,
 };
 
 /// An empty typed section.

--- a/link-section/src/platform/standard.rs
+++ b/link-section/src/platform/standard.rs
@@ -7,6 +7,8 @@
 macro_rules! __get_section_standard {
     (movable, name=$name:tt, type=$generic_ty:ty) => {
         {
+            $crate::__weak_section_symbols!(item data $name);
+            $crate::__weak_section_symbols!(backref data $name);
             $crate::__support::MovableBounds::new(
                 $crate::__support::PtrBounds::new(
                     $crate::__address_of_symbol!(item data start $name),
@@ -21,12 +23,37 @@ macro_rules! __get_section_standard {
     };
     ($section_type:ident, name=$name:tt, type=$generic_ty:ty) => {
         {
+            $crate::__weak_section_symbols!(item data $name);
             $crate::__support::PtrBounds::new(
                 $crate::__address_of_symbol!(item data start $name),
                 $crate::__address_of_symbol!(item data end $name),
             )
         }
     }
+}
+
+/// Declare a section's `__start_`/`__stop_` encapsulation symbols as weak.
+///
+/// This ensures we can reference them even if the section is empty
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __weak_section_symbols {
+    // `$ref_or_item` is `item` or `backref`; it both selects the symbol names
+    // (via `section_name!`) and names the wrapper module, so the value- and
+    // backref-symbol invocations in the `movable` arm don't collide.
+    ($ref_or_item:ident $section:ident $name:tt) => {
+        #[cfg(not(miri))]
+        mod $ref_or_item {
+            ::core::arch::global_asm!(::core::concat!(
+                ".weak ",
+                $crate::__support::section_name!(string $ref_or_item $section start $name),
+                "\n",
+                ".weak ",
+                $crate::__support::section_name!(string $ref_or_item $section end $name),
+                "\n",
+            ));
+        }
+    };
 }
 
 pub use crate::__get_section_standard as get_section;

--- a/link-section/src/platform/standard.rs
+++ b/link-section/src/platform/standard.rs
@@ -37,12 +37,12 @@ macro_rules! __get_section_standard {
 /// This ensures we can reference them even if the section is empty
 #[doc(hidden)]
 #[macro_export]
+#[cfg(all(not(miri), not(target_os = "aix"), not(target_family = "wasm")))]
 macro_rules! __weak_section_symbols {
     // `$ref_or_item` is `item` or `backref`; it both selects the symbol names
     // (via `section_name!`) and names the wrapper module, so the value- and
     // backref-symbol invocations in the `movable` arm don't collide.
     ($ref_or_item:ident $section:ident $name:tt) => {
-        #[cfg(not(miri))]
         mod $ref_or_item {
             ::core::arch::global_asm!(::core::concat!(
                 ".weak ",
@@ -54,6 +54,16 @@ macro_rules! __weak_section_symbols {
             ));
         }
     };
+}
+
+/// Declare a section's `__start_`/`__stop_` encapsulation symbols as weak.
+///
+/// This ensures we can reference them even if the section is empty
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(all(not(miri), not(target_os = "aix"), not(target_family = "wasm"))))]
+macro_rules! __weak_section_symbols {
+    ($($args:tt)*) => {};
 }
 
 pub use crate::__get_section_standard as get_section;

--- a/link-section/tests/expand-linux/link_section.expanded.rs
+++ b/link-section/tests/expand-linux/link_section.expanded.rs
@@ -15,6 +15,7 @@ impl FOO {
     pub const fn const_deref(&self) -> &'static TypedSection<fn()> {
         static SECTION: TypedSection<fn()> = {
             let section = {
+                mod item {}
                 ::link_section::__support::PtrBounds::new(
                     {
                         #[allow(missing_unsafe_on_extern)]

--- a/link-section/tests/expand-linux/link_section_no_macro.expanded.rs
+++ b/link-section/tests/expand-linux/link_section_no_macro.expanded.rs
@@ -7,6 +7,7 @@ impl FOO {
     pub const fn const_deref(&self) -> &'static TypedSection<fn()> {
         static SECTION: TypedSection<fn()> = {
             let section = {
+                mod item {}
                 ::link_section::__support::PtrBounds::new(
                     {
                         #[allow(missing_unsafe_on_extern)]
@@ -86,6 +87,7 @@ impl BAR {
     pub const fn const_deref(&self) -> &'static TypedSection<fn()> {
         static SECTION: TypedSection<fn()> = {
             let section = {
+                mod item {}
                 ::link_section::__support::PtrBounds::new(
                     {
                         #[allow(missing_unsafe_on_extern)]

--- a/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section-const/powerpc64-ibm-aix.rs
@@ -22,6 +22,7 @@ impl FOO {
             {
                 let section =
                     {
+                        ;
                         ::link_section::__support::PtrBounds::new({
                                 #[allow(missing_unsafe_on_extern)]
                                 extern "C" {

--- a/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
+++ b/link-section/tests/target-test/link-section/powerpc64-ibm-aix.rs
@@ -14,6 +14,7 @@ impl FOO {
             {
                 let section =
                     {
+                        ;
                         ::link_section::__support::PtrBounds::new({
                                 #[allow(missing_unsafe_on_extern)]
                                 extern "C" {

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -304,4 +304,13 @@ mod tests {
         assert!(items.contains(&2));
         assert!(items.contains(&3));
     }
+
+    __iterable!(gather pub EMPTY_ITERABLE: u32);
+
+    #[test]
+    fn test_empty_scattered_iterable() {
+        assert_eq!(EMPTY_ITERABLE.len(), 0);
+        assert!(EMPTY_ITERABLE.is_empty());
+        assert_eq!((&EMPTY_ITERABLE).into_iter().count(), 0);
+    }
 }

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -321,4 +321,14 @@ mod link_tests {
         TEST_MAP_2.find(&"B").unwrap().call();
         TEST_MAP_2.find(&"C").unwrap().call();
     }
+
+    __map!(@gather B pub static EMPTY_MAP: ScatteredMap<&'static str, u32>;);
+
+    #[test]
+    fn test_empty_scattered_map() {
+        assert_eq!(EMPTY_MAP.len(), 0);
+        assert!(EMPTY_MAP.is_empty());
+        assert_eq!(EMPTY_MAP.find(&"apple"), None);
+        assert!(!EMPTY_MAP.contains_key(&"apple"));
+    }
 }

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -103,4 +103,13 @@ mod tests {
         assert_eq!(*REF_SLICE_ITEM_B, 3);
         assert_eq!(*REF_SLICE_ITEM_C, 2);
     }
+
+    __referenced_slice!(@gather B pub static EMPTY_REF_SLICE: ScatteredReferencedSlice<u32>;);
+
+    #[test]
+    fn test_empty_scattered_referenced_slice() {
+        assert_eq!(EMPTY_REF_SLICE.len(), 0);
+        assert!(EMPTY_REF_SLICE.is_empty());
+        assert_eq!(&*EMPTY_REF_SLICE, &[] as &[u32]);
+    }
 }

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -72,4 +72,13 @@ mod tests {
         assert!(TEST_SLICE.contains(&2));
         assert!(TEST_SLICE.contains(&3));
     }
+
+    __slice!(@gather B pub static EMPTY_SLICE: ScatteredSlice<u32>;);
+
+    #[test]
+    fn test_empty_scattered_slice() {
+        assert_eq!(EMPTY_SLICE.len(), 0);
+        assert!(EMPTY_SLICE.is_empty());
+        assert_eq!(&*EMPTY_SLICE, &[] as &[u32]);
+    }
 }

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -126,4 +126,13 @@ mod tests {
         assert_eq!(*SORT_REF_ITEM_B, 3);
         assert_eq!(*SORT_REF_ITEM_C, 2);
     }
+
+    __sorted_referenced_slice!(@gather B pub static EMPTY_SORT_REF: ScatteredSortedReferencedSlice<u32>;);
+
+    #[test]
+    fn test_empty_scattered_sorted_referenced_slice() {
+        assert_eq!(EMPTY_SORT_REF.len(), 0);
+        assert!(EMPTY_SORT_REF.is_empty());
+        assert_eq!(&*EMPTY_SORT_REF, &[] as &[u32]);
+    }
 }

--- a/scattered-collect/src/sorted_slice.rs
+++ b/scattered-collect/src/sorted_slice.rs
@@ -119,4 +119,13 @@ mod tests {
             println!("item: {}", item);
         }
     }
+
+    __sorted_slice!(@gather B pub static EMPTY_SORTED_SLICE: ScatteredSortedSlice<u32>;);
+
+    #[test]
+    fn test_empty_scattered_sorted_slice() {
+        assert_eq!(EMPTY_SORTED_SLICE.len(), 0);
+        assert!(EMPTY_SORTED_SLICE.is_empty());
+        assert_eq!(&*EMPTY_SORTED_SLICE, &[] as &[u32]);
+    }
 }

--- a/tests/wasm/rust/src/lib.rs
+++ b/tests/wasm/rust/src/lib.rs
@@ -89,11 +89,19 @@ mod link_section {
         }
     }
 
+    mod empty {
+        use linktime::link_section::{section, TypedSection};
+
+        #[section(typed)]
+        pub static EMPTY_LINK_SECTION: TypedSection<u32>;
+    }
+
     pub fn test_link_section() {
         libc_println!("test_link_section");
         libc_println!("DRIVER: {}", reference::DRIVER.name);
         (reference::DRIVER.f)();
         assert!(reference::DRIVERS.offset_of(&reference::DRIVER) == Some(0));
+        assert!(empty::EMPTY_LINK_SECTION.is_empty());
     }
 }
 


### PR DESCRIPTION
## Problem

On ELF targets a `#[gather]` collection with **no** corresponding `#[scatter]` submissions fails to **link**:

```
ld.lld: error: undefined symbol: __start__data_link_section_STATIC_RCSTRS...
ld.lld: error: undefined symbol: __stop__data_link_section_STATIC_RCSTRS...
>>> the encapsulation symbol needs to be retained under --gc-sections properly;
    consider -z nostart-stop-gc
```

ELF linkers only synthesize the `__start_`/`__stop_` encapsulation symbols for sections that are actually emitted. A gather with zero scatters never emits its section, so the `extern` references generated by `__address_of_symbol!` are undefined and the link fails under `--gc-sections`. This breaks infrastructure/test setups that reference a gather but legitimately link zero scatters (e.g. the next.js/turbopack build that surfaced this in https://github.com/vercel/next.js/pull/94498).

macOS (Mach-O `section$start$`/`section$end$`) and Windows (alignment markers, always non-empty) already tolerate empty sections, so the fix is ELF-only. The runtime already handled emptiness correctly,  only the link step was broken.

## Fix

Tag the start/end symbols as weak via a new `__weak_section_symbols` macro

### Why `global_asm!` and not `#[linkage = "weak"]`

`#[linkage = "extern_weak"]` would express this directly but requires `#![feature(linkage)]`, which is nightly-only (`error[E0554]` on stable). This crate is stable (MSRV 1.85) with zero feature gates, and adopting `#[linkage]` would force every downstream consumer onto nightly. The `.weak` assembler directive produces the identical linker behavior on stable.

The directive is wrapped in a module (`mod $ref_or_item { global_asm!(...) }`) because `global_asm!` requires item position, while `get_section!` expands inside a `static` initializer block (statement position). 

## Tests

- Empty-collection regression tests for every gather type (`ScatteredSlice`, `ScatteredSortedSlice`, `ScatteredReferencedSlice`, `ScatteredSortedReferencedSlice`, `ScatteredMap`, `ScatteredIterable`)
- A new `link-section/examples/empty.rs` exercising empty typed/mutable/movable/reference sections directly at the link-section layer, wired into `Cargo.toml` and `.github/jobs/zigbuild.sh`.
- Regenerated the Linux macro-expansion snapshots.

## Verification

- Reproduced the exact reported error pre-fix via `cargo zigbuild -p scattered-collect --tests --target x86_64-unknown-linux-gnu`.
- Post-fix: links clean; all scattered-collect tests (incl. the new empty ones) pass when **run in an `x86_64` Linux container**, with non-empty cases still correct.
- Host macOS tests green with `-D warnings`; wasm unaffected; `pass_linux` expansion snapshots match.
