### PR TITLE
Ensure all the scattered collections have offset_of functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ctor",
  "divan",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "linktime-proc-macro",
  "macrotest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ repository = "https://github.com/mmastrac/linktime"
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.7", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
-link-section = { path = "link-section", version = "0.18.1", default-features = false }
+link-section = { path = "link-section", version = "0.18.2", default-features = false }
 linktime = { path = "linktime", version = "0.17.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }
 
-scattered-collect = { path = "scattered-collect", version = "0.10.0" }
+scattered-collect = { path = "scattered-collect", version = "0.11.0" }

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.18.1"
+version = "0.18.2"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/examples/map.rs
+++ b/scattered-collect/examples/map.rs
@@ -21,6 +21,10 @@ fn main() {
     println!("BANANA: {:?}", BANANA);
     println!("ORANGE: {:?}", ORANGE);
 
+    assert!(ScatteredMap::offset_of(&MAP, &APPLE).is_some());
+    assert!(ScatteredMap::offset_of(&MAP, &BANANA).is_some());
+    assert!(ScatteredMap::offset_of(&MAP, &ORANGE).is_some());
+
     println!("Entries:");
     for (key, value) in &MAP {
         println!(" - {}: {:?}", key, value);

--- a/scattered-collect/examples/map.rs
+++ b/scattered-collect/examples/map.rs
@@ -21,10 +21,6 @@ fn main() {
     println!("BANANA: {:?}", BANANA);
     println!("ORANGE: {:?}", ORANGE);
 
-    assert!(ScatteredMap::offset_of(&MAP, &APPLE).is_some());
-    assert!(ScatteredMap::offset_of(&MAP, &BANANA).is_some());
-    assert!(ScatteredMap::offset_of(&MAP, &ORANGE).is_some());
-
     println!("Entries:");
     for (key, value) in &MAP {
         println!(" - {}: {:?}", key, value);

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -123,6 +123,11 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
     pub fn is_empty(&self) -> bool {
         self.state.records.is_empty()
     }
+
+    /// The offset of the record in the map, if it is from this map.
+    pub fn offset_of(this: &Self, record: &MapRecord<K, V>) -> Option<usize> {
+        this.state.records.offset_of(record)
+    }
 }
 
 impl<K: 'static, V: 'static> IntoIterator for &'static ScatteredMap<K, V> {

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -20,6 +20,11 @@ impl<T> ScatteredSlice<T> {
     pub const unsafe fn new(section: &'static TypedSection<T>) -> Self {
         Self { section }
     }
+
+    /// The offset of the item in the slice, if it is from this slice.
+    pub fn offset_of(this: &Self, item: &T) -> Option<usize> {
+        TypedSection::offset_of(this.section, item)
+    }
 }
 
 impl<T> ::core::ops::Deref for ScatteredSlice<T> {


### PR DESCRIPTION
One of the advantages to scattered collections is the "free" ID function. Ensure that all the collections have one.
