### PR TITLE
Implement a ScatteredSet in `scattered-collect`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ctor",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ linktime = { path = "linktime", version = "0.17.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }
 
-scattered-collect = { path = "scattered-collect", version = "0.11.0" }
+scattered-collect = { path = "scattered-collect", version = "0.12.0" }

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -396,4 +396,4 @@ mod my_registry {
 
 ## Inspiration
 
-`link-section` was originally inspired by the `linkme` project.
+`link-section` would have been far more challenging to implement without dtolnay's great `linkme` project paving the way.

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -396,4 +396,4 @@ mod my_registry {
 
 ## Inspiration
 
-`link-section` would have been far more challenging to implement without dtolnay's great `linkme` project paving the way.
+`link-section` was originally inspired by the `linkme` project.

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -396,4 +396,4 @@ mod my_registry {
 
 ## Inspiration
 
-`link-section` was originally inspired by the `linkme` project.
+`link-section` would have been far more challenging to implement without dtolnay's great `linkme` project paving the way.

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/README.md
+++ b/scattered-collect/README.md
@@ -62,6 +62,11 @@ collection. This ID is guaranteed to be stable per executable build.
 † Each item in the collection is assigned a unique ID which is guaranteed to be
 stable per executable build.
 
+## Re-exporting the scatter/gather macros
+
+The scatter/gather macros can be easily re-exported from other crates using the
+[`declarative`] module.
+
 ## Scatter/Gather syntax
 
 The collections are defined as a single scatter call with multiple gather calls

--- a/scattered-collect/README.md
+++ b/scattered-collect/README.md
@@ -56,7 +56,8 @@ collection. This ID is guaranteed to be stable per executable build.
 | `ScatteredIterable`              | Arbitrary (link order) | No (iterator only)    | No †        | Yes              | Singly-linked list            |
 | `ScatteredReferencedSlice`       | Arbitrary (link order) | Yes (slice)           | No †        | Yes              | Un-ordered slice with handles |
 | `ScatteredSortedReferencedSlice` | Sorted                 | Yes (slice)           | No †        | Yes              | Sorted slice with handles     |
-| `ScatteredMap`                   | None (hash-based)      | Yes (by key or entry) | Yes         | Yes              | Swiss-table style map         |
+| `ScatteredMap`                   | None (link order)      | Yes (by key or entry) | Yes         | Yes              | Swiss-table style map         |
+| `ScatteredSet`                   | None (link order)      | n/a                   | Yes         | No               | Swiss-table style set         |
 
 † Each item in the collection is assigned a unique ID which is guaranteed to be
 stable per executable build.

--- a/scattered-collect/examples/set.rs
+++ b/scattered-collect/examples/set.rs
@@ -1,0 +1,28 @@
+//! Example for `ScatteredMap`.
+use scattered_collect::{gather, set::ScatteredSet, scatter};
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct MyId(u32);
+
+#[gather]
+static SET: ScatteredSet<&'static str>;
+
+#[scatter(SET)]
+static APPLE: &'static str = "apple";
+
+#[scatter(SET)]
+static BANANA: &'static str = "banana";
+
+#[scatter(SET)]
+static ORANGE: &'static str = "orange";
+
+fn main() {
+    println!("APPLE: {:?}", APPLE);
+    println!("BANANA: {:?}", BANANA);
+    println!("ORANGE: {:?}", ORANGE);
+
+    println!("Entries:");
+    for key in &SET {
+        println!(" - {:?}", key);
+    }
+}

--- a/scattered-collect/examples/set.rs
+++ b/scattered-collect/examples/set.rs
@@ -1,8 +1,5 @@
 //! Example for `ScatteredMap`.
-use scattered_collect::{gather, set::ScatteredSet, scatter};
-
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-struct MyId(u32);
+use scattered_collect::{gather, scatter, set::ScatteredSet};
 
 #[gather]
 static SET: ScatteredSet<&'static str>;

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -151,7 +151,7 @@ impl<T: 'static> ExactSizeIterator for Iter<'_, T> {
 ///
 /// This collection is thread-safe: access before initialization completes will
 /// yield fewer items, but will not panic or cause undefined behavior. The count
-/// returned by [`len`] may be stale while constructors are still running; the
+/// returned by [`ScatteredIterable::len`] may be stale while constructors are still running; the
 /// [`ExactSizeIterator::len`] on [`Iter`] is derived from each node's [`Ref::offset_of`]
 /// index and stays consistent for the suffix being iterated.
 ///

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -3,16 +3,16 @@
 pub mod hash;
 pub mod iterable;
 pub mod map;
-pub mod set;
 pub mod referenced_slice;
+pub mod set;
 pub mod slice;
 pub mod sorted_referenced_slice;
 pub mod sorted_slice;
 
 pub use iterable::ScatteredIterable;
 pub use map::ScatteredMap;
-pub use set::ScatteredSet;
 pub use referenced_slice::ScatteredReferencedSlice;
+pub use set::ScatteredSet;
 pub use slice::ScatteredSlice;
 pub use sorted_referenced_slice::ScatteredSortedReferencedSlice;
 pub use sorted_slice::ScatteredSortedSlice;
@@ -160,7 +160,6 @@ pub mod __support {
 /// }
 /// # }
 /// ```
-
 pub mod declarative {
     /// Declarative form of the `#[gather]` macro.
     ///

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod hash;
 pub mod iterable;
 pub mod map;
+pub mod set;
 pub mod referenced_slice;
 pub mod slice;
 pub mod sorted_referenced_slice;
@@ -10,6 +11,7 @@ pub mod sorted_slice;
 
 pub use iterable::ScatteredIterable;
 pub use map::ScatteredMap;
+pub use set::ScatteredSet;
 pub use referenced_slice::ScatteredReferencedSlice;
 pub use slice::ScatteredSlice;
 pub use sorted_referenced_slice::ScatteredSortedReferencedSlice;
@@ -91,6 +93,10 @@ macro_rules! __gather_parse {
 
     (@done ($map:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredMap < $key:ty, $value:ty >; ) => {
         $crate::__support::gather_parse!(@dispatch __map $(#[$imeta])* $vis static $name: $map ( $key, $value ););
+    };
+
+    (@done ($set:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSet < $key:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __set $(#[$imeta])* $vis static $name: $set ( $key ););
     };
 
     (@done ($collection:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredIterable < $ty:ty >; ) => {

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -131,8 +131,76 @@ pub mod __support {
 }
 
 /// Declarative `scatter!` / `gather!` entry points.
+///
+/// These are useful for cases where the scattered collections are used within
+/// your own macros.
+///
+/// The syntax is identical to the proc-macro form in both the `scatter` and
+/// `gather` cases, with the declarative macro wrapped around them.
+///
+/// ```rust
+/// use scattered_collect::declarative::{scatter, gather};
+/// use scattered_collect::slice::ScatteredSlice;
+///
+/// # fn main() {
+/// gather! {
+///   #[gather]
+///   static ITEMS: ScatteredSlice<u32>;
+/// }
+///
+/// scatter! {
+///   #[scatter(ITEMS)]
+///   const _: u32 = 1;
+/// }
+/// # }
+/// ```
+
 pub mod declarative {
+    /// Declarative form of the `#[gather]` macro.
+    ///
+    /// Useful for re-exporting these macros from other crates. Wrap this around
+    /// the proc-macro form:
+    ///
+    /// ```rust
+    /// # use scattered_collect::declarative::{scatter, gather};
+    /// # use scattered_collect::slice::ScatteredSlice;
+    ///
+    /// # fn main() {
+    /// gather! {
+    ///   #[gather]
+    ///   static ITEMS: ScatteredSlice<u32>;
+    /// }
+    ///
+    /// scatter! {
+    ///   #[scatter(ITEMS)]
+    ///   const _: u32 = 1;
+    /// }
+    /// # }
+    /// ```
+    #[doc(inline)]
     pub use crate::__gather_brace as gather;
+    /// Declarative form of the `#[scatter]` macro.
+    ///
+    /// Useful for re-exporting these macros from other crates. Wrap this around
+    /// the proc-macro form:
+    ///
+    /// ```rust
+    /// # use scattered_collect::declarative::{scatter, gather};
+    /// # use scattered_collect::slice::ScatteredSlice;
+    ///
+    /// # fn main() {
+    /// gather! {
+    ///   #[gather]
+    ///   static ITEMS: ScatteredSlice<u32>;
+    /// }
+    ///
+    /// scatter! {
+    ///   #[scatter(ITEMS)]
+    ///   const _: u32 = 1;
+    /// }
+    /// # }
+    /// ```
+    #[doc(inline)]
     pub use crate::__scatter_brace as scatter;
 }
 
@@ -143,7 +211,7 @@ pub use linktime_proc_macro::{gather, scatter};
 #[macro_export]
 macro_rules! __gather_brace {
     ($($item:tt)*) => {
-        $crate::__support::gather_parse!(#[gather] $($item)*);
+        $crate::__support::gather_parse!($($item)*);
     };
 }
 

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -125,6 +125,7 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
     }
 
     /// The offset of the record in the map, if it is from this map.
+    #[inline]
     pub fn offset_of(this: &Self, record: &MapRecord<K, V>) -> Option<usize> {
         this.state.records.offset_of(record)
     }
@@ -162,7 +163,7 @@ impl<K: 'static, V: 'static> IntoIterator for &'static ScatteredMap<K, V> {
 #[doc = include_str!("../../examples/map.rs")]
 /// ```
 pub struct ScatteredMap<K: 'static, V: 'static> {
-    state: &'static __ScatteredMapState<K, V>,
+    pub(crate) state: &'static __ScatteredMapState<K, V>,
 }
 
 #[doc(hidden)]
@@ -190,6 +191,10 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
     #[doc(hidden)]
     pub fn __initialize(&self) {
         self.ensure_initialized();
+    }
+
+    pub(crate) fn records(&self) -> &[MapRecord<K, V>] {
+        self.records.as_slice()
     }
 
     #[allow(unsafe_code)]

--- a/scattered-collect/src/set.rs
+++ b/scattered-collect/src/set.rs
@@ -1,10 +1,15 @@
-use crate::{ScatteredMap, hash::ConstHash, map::{__ScatteredMapState, MapRecord}};
+//! A swiss-table-style set initialized with link-time data.
+use crate::{
+    ScatteredMap,
+    hash::ConstHash,
+    map::{__ScatteredMapState, MapRecord},
+};
 
 /// A set of items gathered into a set in arbitrary link order.
-/// 
+///
 /// See [`ScatteredMap`] for more information about performance and algorithm
 /// details.
-/// 
+///
 /// ```rust
 #[doc = include_str!("../examples/set.rs")]
 /// ```
@@ -15,35 +20,43 @@ pub struct ScatteredSet<T: 'static> {
 impl<T: ConstHash + PartialEq + 'static> ScatteredSet<T> {
     #[doc(hidden)]
     pub const fn __new(state: &'static __ScatteredMapState<T, ()>) -> Self {
-        Self { map: ScatteredMap::__new(state) }
+        Self {
+            map: ScatteredMap::__new(state),
+        }
     }
 
+    /// The number of records in the set.
     #[inline]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
+    /// True if the set is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
 
+    /// True if the set contains the given key.
     #[inline]
     pub fn contains(&self, key: &T) -> bool {
         self.map.contains_key(key)
     }
-    
+
+    /// Iterate over the values in the set.
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.map.keys()
     }
 
+    /// The offset of the record in the set, if it is from this set.
     #[inline]
     pub fn offset_of(this: &Self, key: &SetRecord<T>) -> Option<usize> {
         ScatteredMap::offset_of(&this.map, key.as_map_record_ref())
     }
 }
 
+/// One gathered set entry.
 #[repr(transparent)]
 pub struct SetRecord<T: 'static> {
     record: MapRecord<T, ()>,
@@ -51,10 +64,9 @@ pub struct SetRecord<T: 'static> {
 
 impl<K: 'static> IntoIterator for &'static ScatteredSet<K> {
     type Item = &'static K;
-    type IntoIter = ::std::iter::Map<
-        ::std::slice::Iter<'static, SetRecord<K>>,
-        fn(&SetRecord<K>) -> &K,
-    >;
+    type IntoIter =
+        ::std::iter::Map<::std::slice::Iter<'static, SetRecord<K>>, fn(&SetRecord<K>) -> &K>;
+    #[allow(unsafe_code)]
     fn into_iter(self) -> Self::IntoIter {
         let records: &[SetRecord<K>] = unsafe { core::mem::transmute(self.map.state.records()) };
         records.iter().map(|record| &record.record.key)
@@ -84,6 +96,7 @@ impl<T: ConstHash + 'static> ::core::ops::Deref for SetRecord<T> {
 }
 
 impl<T: ConstHash + 'static> SetRecord<T> {
+    #[allow(unsafe_code)]
     pub(crate) fn as_map_record_ref(&self) -> &MapRecord<T, ()> {
         unsafe { core::mem::transmute(&self.record) }
     }

--- a/scattered-collect/src/set.rs
+++ b/scattered-collect/src/set.rs
@@ -1,0 +1,141 @@
+use crate::{ScatteredMap, hash::ConstHash, map::{__ScatteredMapState, MapRecord}};
+
+/// A set of items gathered into a set in arbitrary link order.
+/// 
+/// See [`ScatteredMap`] for more information about performance and algorithm
+/// details.
+/// 
+/// ```rust
+#[doc = include_str!("../examples/set.rs")]
+/// ```
+pub struct ScatteredSet<T: 'static> {
+    map: ScatteredMap<T, ()>,
+}
+
+impl<T: ConstHash + PartialEq + 'static> ScatteredSet<T> {
+    #[doc(hidden)]
+    pub const fn __new(state: &'static __ScatteredMapState<T, ()>) -> Self {
+        Self { map: ScatteredMap::__new(state) }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    #[inline]
+    pub fn contains(&self, key: &T) -> bool {
+        self.map.contains_key(key)
+    }
+    
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.map.keys()
+    }
+
+    #[inline]
+    pub fn offset_of(this: &Self, key: &SetRecord<T>) -> Option<usize> {
+        ScatteredMap::offset_of(&this.map, key.as_map_record_ref())
+    }
+}
+
+#[repr(transparent)]
+pub struct SetRecord<T: 'static> {
+    record: MapRecord<T, ()>,
+}
+
+impl<K: 'static> IntoIterator for &'static ScatteredSet<K> {
+    type Item = &'static K;
+    type IntoIter = ::std::iter::Map<
+        ::std::slice::Iter<'static, SetRecord<K>>,
+        fn(&SetRecord<K>) -> &K,
+    >;
+    fn into_iter(self) -> Self::IntoIter {
+        let records: &[SetRecord<K>] = unsafe { core::mem::transmute(self.map.state.records()) };
+        records.iter().map(|record| &record.record.key)
+    }
+}
+
+impl<T: ConstHash + ::core::fmt::Debug + 'static> ::core::fmt::Debug for SetRecord<T> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        ::core::fmt::Debug::fmt(&self.record.key, f)
+    }
+}
+
+impl<T: ConstHash + 'static> SetRecord<T> {
+    #[doc(hidden)]
+    pub const fn new(key: T, hash: u64) -> Self {
+        Self {
+            record: MapRecord::new(key, (), hash),
+        }
+    }
+}
+
+impl<T: ConstHash + 'static> ::core::ops::Deref for SetRecord<T> {
+    type Target = MapRecord<T, ()>;
+    fn deref(&self) -> &Self::Target {
+        &self.record
+    }
+}
+
+impl<T: ConstHash + 'static> SetRecord<T> {
+    pub(crate) fn as_map_record_ref(&self) -> &MapRecord<T, ()> {
+        unsafe { core::mem::transmute(&self.record) }
+    }
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __set {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $set:ident < $key:ty >;) => {
+        $(#[$meta])*
+        $vis static $name: $set<$key> = {
+            $crate::__support::link_section::declarative::section!(
+                #[section(unsafe, type = typed, name = $name :: $unique)]
+                static $name: $crate::__support::link_section::TypedSection<
+                    $crate::set::SetRecord<$key>
+                >;
+            );
+
+            $crate::__support::link_section::declarative::section!(
+                #[section(unsafe, type = mutable, name = $name :: $unique :: MAP_META)]
+                static MAP_META: $crate::__support::link_section::TypedMutableSection<u8>;
+            );
+
+            $crate::__support::link_section::declarative::in_section!(
+                #[in_section(unsafe, type = mutable, name = $name :: $unique :: MAP_META)]
+                const _: $crate::map::MapMetadataChunkBase = $crate::map::MAP_METADATA_CHUNK_BASE_ZERO;
+            );
+
+            static __MAP_STATE: $crate::map::__ScatteredMapState<$key, ()> = $crate::map::__ScatteredMapState::new(unsafe { core::mem::transmute($name.const_deref()) }, MAP_META.const_deref());
+
+            $crate::__support::ctor::declarative::ctor!(
+                #[ctor(unsafe, anonymous, priority = 0)]
+                fn __map_init() {
+                    __MAP_STATE.__initialize();
+                }
+            );
+
+            $crate::set::ScatteredSet::__new(&__MAP_STATE)
+        };
+    };
+    (@scatter [$collection_name:ident :: $unique:ident] [$key:ty] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = $key_expr:expr;)) => {
+        $crate::__support::link_section::declarative::in_section!(
+            #[in_section(unsafe, name = $collection_name :: $unique, type = typed)]
+            $(#[$imeta])*
+            $vis $kind $name: $crate::set::SetRecord<$key> = $crate::set::SetRecord::new(
+                $key_expr,
+                $crate::const_hash!($key_expr)
+            );
+        );
+        $crate::__support::link_section::declarative::in_section!(
+            #[in_section(unsafe, name = $collection_name :: $unique :: MAP_META, type = mutable)]
+            const _: $crate::map::MapMetadataChunk = $crate::map::MAP_METADATA_CHUNK_ZERO;
+        );
+    };
+}

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -20,11 +20,6 @@ impl<T> ScatteredSlice<T> {
     pub const unsafe fn new(section: &'static TypedSection<T>) -> Self {
         Self { section }
     }
-
-    /// The offset of the item in the slice, if it is from this slice.
-    pub fn offset_of(this: &Self, item: &T) -> Option<usize> {
-        TypedSection::offset_of(this.section, item)
-    }
 }
 
 impl<T> ::core::ops::Deref for ScatteredSlice<T> {


### PR DESCRIPTION
A `ScatteredSet` is a thin shim over `ScatteredMap` that includes some expected QoL improvements to avoid needing to use `MapRecord<T, ()>`.