### PR TITLE
Allow full paths for scattered collections

### DIFF
--- a/.github/jobs/sanitize.sh
+++ b/.github/jobs/sanitize.sh
@@ -19,6 +19,9 @@ sanitize_runs=(
   "scattered-collect:scattered-collect-sorted-slice"
   "scattered-collect:scattered-collect-referenced-slice"
   "scattered-collect:scattered-collect-sorted-referenced-slice"
+  "scattered-collect:scattered-collect-map"
+  "scattered-collect:scattered-collect-set"
+  "scattered-collect:scattered-collect-iterable"
 )
 
 for spec in "${sanitize_runs[@]}"; do

--- a/.github/jobs/zigbuild.sh
+++ b/.github/jobs/zigbuild.sh
@@ -14,6 +14,14 @@ zig_examples=(
   link-section-empty
   link-section-example
   link-section-mut
+  scattered-collect-intern-strings
+  scattered-collect-slice
+  scattered-collect-sorted-slice
+  scattered-collect-referenced-slice
+  scattered-collect-sorted-referenced-slice
+  scattered-collect-map
+  scattered-collect-set
+  scattered-collect-iterable
 )
 
 for bin in "${zig_examples[@]}"; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.12.0"
+version = "0.20.0"
 dependencies = [
  "ctor",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ linktime = { path = "linktime", version = "0.17.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }
 
-scattered-collect = { path = "scattered-collect", version = "0.12.0" }
+scattered-collect = { path = "scattered-collect", version = "0.20.0" }

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.12.0"
+version = "0.20.0"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -37,6 +37,10 @@ name = "scattered-collect-map"
 path = "examples/map.rs"
 
 [[example]]
+name = "scattered-collect-set"
+path = "examples/set.rs"
+
+[[example]]
 name = "scattered-collect-slice"
 path = "examples/slice.rs"
 

--- a/scattered-collect/README.md
+++ b/scattered-collect/README.md
@@ -20,6 +20,13 @@ referenced variants allow you to access the items as `static` handles at the
 declaration site, while the unreferenced variants allow you to access the items
 as a slice only. The latter, unreferenced variants may be more efficient.
 
+## MSRV
+
+This crate currently has a MSRV of **Rust >= 1.85**. 
+
+For collections that have duplicate names across different files, **Rust >=
+1.88** is required (the `proc_macro_span` is used to generate unique filenames).
+
 ## Zero-allocation collections
 
 The collections are all zero-allocation. This means that they can be used in

--- a/scattered-collect/examples/intern_strings.rs
+++ b/scattered-collect/examples/intern_strings.rs
@@ -72,10 +72,10 @@ impl Ord for Str {
 }
 
 mod intern {
-    use crate::{ScatteredSortedReferencedSlice, Str, gather};
+    use crate::{Str, gather};
 
     #[gather]
-    pub(crate) static INTERNED_STRINGS: ScatteredSortedReferencedSlice<Str>;
+    pub(crate) static INTERNED_STRINGS: crate::ScatteredSortedReferencedSlice<Str>;
 
     macro_rules! intern_string {
         ($name:ident, $string:literal) => {

--- a/scattered-collect/examples/referenced_slice.rs
+++ b/scattered-collect/examples/referenced_slice.rs
@@ -1,12 +1,12 @@
 //! Example for `ScatteredReferencedSlice`.
-use scattered_collect::{gather, referenced_slice::ScatteredReferencedSlice, scatter};
+use scattered_collect::{gather, scatter};
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 struct MyId(u32);
 
 /// A scattered referenced slice of `u32`.
 #[gather]
-static COLLECTION: ScatteredReferencedSlice<MyId>;
+static COLLECTION: scattered_collect::referenced_slice::ScatteredReferencedSlice<MyId>;
 
 #[scatter(COLLECTION)]
 static ITEM_ONE: MyId = MyId(1);

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -210,10 +210,7 @@ macro_rules! __iterable_state {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __iterable {
-    (gather $vis:vis $name:ident: $ty:ty) => {
-        $crate::__iterable!(@gather $name $vis static $name: ScatteredIterable<$ty>;);
-    };
-    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($collection:tt)*) < $ty:ty >;) => {
         $crate::__support::combine!(
             output=ident
             prefix=(static )
@@ -221,7 +218,7 @@ macro_rules! __iterable {
         suffix=(: $crate::iterable::__ScatteredIterableState<$ty> = $crate::iterable::__ScatteredIterableState::new();));
 
         $(#[$meta])*
-        $vis static $name: $collection<$ty> = {
+        $vis static $name: $($collection)* <$ty> = {
             $crate::iterable::ScatteredIterable::new(&$crate::__iterable_state!($name))
         };
     };
@@ -242,7 +239,7 @@ macro_rules! __iterable {
 mod tests {
     use crate::iterable::{Ref, ScatteredIterable};
 
-    __iterable!(gather pub TEST_ITERABLE: u32);
+    __iterable!(@gather pub static TEST_ITERABLE: (ScatteredIterable)<u32>;);
     __iterable!(@scatter [TEST_ITERABLE :: A] [u32] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_A: u32 = 1;));
     __iterable!(@scatter [TEST_ITERABLE :: A] [u32] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_B: u32 = 3;));
     __iterable!(@scatter [TEST_ITERABLE :: A] [u32] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_C: u32 = 2;));
@@ -305,7 +302,7 @@ mod tests {
         assert!(items.contains(&3));
     }
 
-    __iterable!(gather pub EMPTY_ITERABLE: u32);
+    __iterable!(@gather pub static EMPTY_ITERABLE: (ScatteredIterable)<u32>;);
 
     #[test]
     fn test_empty_scattered_iterable() {

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -63,8 +63,8 @@ macro_rules! __gather_parse {
         ) paren_suffix=($macro $(#[$imeta])* $vis static $name $($rest)*) suffix=(;));
     };
 
-    (@unique $unique:ident $macro:ident $(#[$imeta:meta])* $vis:vis static $name:ident: $collection:ident ($($ty:tt)*);) => {
-        $crate::$macro!(@gather $unique $(#[$imeta])* $vis static $name: $collection <$($ty)*>;);
+    (@unique $unique:ident $macro:ident $(#[$imeta:meta])* $vis:vis static $name:ident: ($($collection:tt)*) ($($ty:tt)*);) => {
+        $crate::$macro!(@gather $unique $(#[$imeta])* $vis static $name: ($($collection)*) <$($ty)*>;);
 
         $crate::__support::combine!(output=ident prefix=(#[doc(hidden)] #[macro_export] macro_rules!) input=(__ $name __ $macro __ $unique) suffix=({
             ($passthru:tt) => {
@@ -75,32 +75,32 @@ macro_rules! __gather_parse {
         $crate::__support::combine!(output=ident prefix=(#[doc(hidden)] $vis use) input=(__ $name __ $macro __ $unique) suffix=(as $name;));
     };
 
-    (@done ($collection:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSlice < $ty:ty >; ) => {
-        $crate::__support::gather_parse!(@dispatch __slice $(#[$imeta])* $vis static $name: $collection ( $ty ););
+    (@done ($($collection:tt)*) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSlice < $ty:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __slice $(#[$imeta])* $vis static $name: ($($collection)*) ( $ty ););
     };
 
-    (@done ($collection:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSortedSlice < $ty:ty >; ) => {
-        $crate::__support::gather_parse!(@dispatch __sorted_slice $(#[$imeta])* $vis static $name: $collection ( $ty ););
+    (@done ($($collection:tt)*) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSortedSlice < $ty:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __sorted_slice $(#[$imeta])* $vis static $name: ($($collection)*) ( $ty ););
     };
 
-    (@done ($collection:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredReferencedSlice < $ty:ty >; ) => {
-        $crate::__support::gather_parse!(@dispatch __referenced_slice $(#[$imeta])* $vis static $name: $collection ( $ty ););
+    (@done ($($collection:tt)*) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredReferencedSlice < $ty:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __referenced_slice $(#[$imeta])* $vis static $name: ($($collection)*) ( $ty ););
     };
 
-    (@done ($collection:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSortedReferencedSlice < $ty:ty >; ) => {
-        $crate::__support::gather_parse!(@dispatch __sorted_referenced_slice $(#[$imeta])* $vis static $name: $collection ( $ty ););
+    (@done ($($collection:tt)*) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSortedReferencedSlice < $ty:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __sorted_referenced_slice $(#[$imeta])* $vis static $name: ($($collection)*) ( $ty ););
     };
 
-    (@done ($map:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredMap < $key:ty, $value:ty >; ) => {
-        $crate::__support::gather_parse!(@dispatch __map $(#[$imeta])* $vis static $name: $map ( $key, $value ););
+    (@done ($($collection:tt)*) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredMap < $key:ty, $value:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __map $(#[$imeta])* $vis static $name: ($($collection)*) ( $key, $value ););
     };
 
-    (@done ($set:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSet < $key:ty >; ) => {
-        $crate::__support::gather_parse!(@dispatch __set $(#[$imeta])* $vis static $name: $set ( $key ););
+    (@done ($($collection:tt)*) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredSet < $key:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __set $(#[$imeta])* $vis static $name: ($($collection)*) ( $key ););
     };
 
-    (@done ($collection:ident) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredIterable < $ty:ty >; ) => {
-        $crate::__support::gather_parse!(@dispatch __iterable $(#[$imeta])* $vis static $name: $collection ( $ty ););
+    (@done ($($collection:tt)*) #[gather] $(#[$imeta:meta])* $vis:vis static $name:ident: ScatteredIterable < $ty:ty >; ) => {
+        $crate::__support::gather_parse!(@dispatch __iterable $(#[$imeta])* $vis static $name: ($($collection)*) ( $ty ););
     };
 
     (@done #[gather] $($rest:tt)* ) => {
@@ -120,8 +120,28 @@ macro_rules! __gather_parse {
         compile_error!("Missing #[gather] attribute.");
     };
 
+    // Chomp through the path until we hit the collection's generics.
+    (@path ($($path_part:tt)*) ($(#$meta:tt)* $vis:vis static $name:ident) ($collection:ident < $($rest:tt)*)) => {
+        $crate::__support::gather_parse!(@reorder ($(#$meta)* $vis static $name: $collection < $($rest)*) () ($($path_part)* $collection));
+    };
+    (@path ($($path_part:tt)*) ($(#$meta:tt)* $vis:vis static $name:ident) ($next_path_part:ident $($rest:tt)*)) => {
+        $crate::__support::gather_parse!(@path ($($path_part)* $next_path_part) ($(#$meta)* $vis static $name) ($($rest)*));
+    };
+    (@path ($($path_part:tt)*) ($(#$meta:tt)* $vis:vis static $name:ident) (:: $($rest:tt)*)) => {
+        $crate::__support::gather_parse!(@path ($($path_part)* ::) ($(#$meta)* $vis static $name) ($($rest)*));
+    };
+    (@path ($($path_part:tt)*) ($(#$meta:tt)* $vis:vis static $name:ident) (:: $($rest:tt)*)) => {
+        compile_error!("Expected: #[gather] name: path::to::collection<generics>;");
+    };
+
     ($(#$meta:tt)* $vis:vis static $name:ident: $collection:ident < $($rest:tt)* ) => {
         $crate::__support::gather_parse!(@reorder ($(#$meta)* $vis static $name: $collection < $($rest)*) () ($collection));
+    };
+    ($(#$meta:tt)* $vis:vis static $name:ident: :: $($path:tt)* ) => {
+        $crate::__support::gather_parse!(@path (::) ($(#$meta)* $vis static $name) ($($path)*));
+    };
+    ($(#$meta:tt)* $vis:vis static $name:ident: $path_part:ident $($path:tt)* ) => {
+        $crate::__support::gather_parse!(@path ($path_part) ($(#$meta)* $vis static $name) ($($path)*));
     };
 }
 

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -220,9 +220,9 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __map {
-    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $map:ident < $key:ty, $value:ty >;) => {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($map:tt)*) < $key:ty, $value:ty >;) => {
         $(#[$meta])*
-        $vis static $name: $map<$key, $value> = {
+        $vis static $name: $($map)* <$key, $value> = {
             $crate::__support::link_section::declarative::section!(
                 #[section(unsafe, type = typed, name = $name :: $unique)]
                 static $name: $crate::__support::link_section::TypedSection<
@@ -273,7 +273,7 @@ macro_rules! __map {
 mod link_tests {
     use crate::ScatteredMap;
 
-    __map!(@gather A pub static TEST_MAP: ScatteredMap<&'static str, u32>;);
+    __map!(@gather A pub static TEST_MAP: (ScatteredMap)<&'static str, u32>;);
     __map!(@scatter [TEST_MAP::A] [&'static str, u32] ([TEST_MAP] => pub static APPLE: (&'static str, u32) = ("apple", 1);));
     __map!(@scatter [TEST_MAP::A] [&'static str, u32] ([TEST_MAP] => pub static BANANA: (&'static str, u32) = ("banana", 2);));
 
@@ -301,7 +301,7 @@ mod link_tests {
         }
     }
 
-    __map!(@gather A static TEST_MAP_2: ScatteredMap<&'static str, Record>;);
+    __map!(@gather A static TEST_MAP_2: (ScatteredMap)<&'static str, Record>;);
 
     macro_rules! make_test {
         ($($name:ident)*) => {
@@ -332,7 +332,7 @@ mod link_tests {
         TEST_MAP_2.find(&"C").unwrap().call();
     }
 
-    __map!(@gather B pub static EMPTY_MAP: ScatteredMap<&'static str, u32>;);
+    __map!(@gather B pub static EMPTY_MAP: (ScatteredMap)<&'static str, u32>;);
 
     #[test]
     fn test_empty_scattered_map() {

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -60,9 +60,9 @@ impl<T: 'static> ::core::ops::Deref for ScatteredReferencedSlice<T> {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __referenced_slice {
-    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($collection:tt)*) < $ty:ty >;) => {
         $(#[$meta])*
-        $vis static $name: $collection<$ty> = {
+        $vis static $name: $($collection)* <$ty> = {
             $crate::__support::link_section::declarative::section!(
                 #[section(unsafe, type = reference, name = $name :: $unique)]
                 static $name: $crate::__support::link_section::TypedReferenceSection<$ty>;
@@ -87,7 +87,7 @@ macro_rules! __referenced_slice {
 mod tests {
     use crate::referenced_slice::ScatteredReferencedSlice;
 
-    __referenced_slice!(@gather A pub static TEST_REF_SLICE: ScatteredReferencedSlice<u32>;);
+    __referenced_slice!(@gather A pub static TEST_REF_SLICE: (ScatteredReferencedSlice)<u32>;);
     __referenced_slice!(@scatter [TEST_REF_SLICE::A] [u32] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_A: u32 = 1;));
     __referenced_slice!(@scatter [TEST_REF_SLICE::A] [u32] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_B: u32 = 3;));
     __referenced_slice!(@scatter [TEST_REF_SLICE::A] [u32] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_C: u32 = 2;));
@@ -104,7 +104,7 @@ mod tests {
         assert_eq!(*REF_SLICE_ITEM_C, 2);
     }
 
-    __referenced_slice!(@gather B pub static EMPTY_REF_SLICE: ScatteredReferencedSlice<u32>;);
+    __referenced_slice!(@gather B pub static EMPTY_REF_SLICE: (ScatteredReferencedSlice)<u32>;);
 
     #[test]
     fn test_empty_scattered_referenced_slice() {

--- a/scattered-collect/src/set.rs
+++ b/scattered-collect/src/set.rs
@@ -105,9 +105,9 @@ impl<T: ConstHash + 'static> SetRecord<T> {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __set {
-    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $set:ident < $key:ty >;) => {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($set:tt)*) < $key:ty >;) => {
         $(#[$meta])*
-        $vis static $name: $set<$key> = {
+        $vis static $name: $($set)* <$key> = {
             $crate::__support::link_section::declarative::section!(
                 #[section(unsafe, type = typed, name = $name :: $unique)]
                 static $name: $crate::__support::link_section::TypedSection<

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -33,9 +33,9 @@ impl<T> ::core::ops::Deref for ScatteredSlice<T> {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __slice {
-    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($collection:tt)*) < $ty:ty >;) => {
         $(#[$meta])*
-        $vis static $name: $collection<$ty> = {
+        $vis static $name: $($collection)* <$ty> = {
             $crate::__support::link_section::declarative::section!(
                 #[section(unsafe, type = typed, name = $name :: $unique)]
                 static $name: $crate::__support::link_section::TypedSection<$ty>;
@@ -60,7 +60,7 @@ macro_rules! __slice {
 mod tests {
     pub use super::ScatteredSlice;
 
-    __slice!(@gather A pub static TEST_SLICE: ScatteredSlice<u32>;);
+    __slice!(@gather A pub static TEST_SLICE: (ScatteredSlice)<u32>;);
     __slice!(@scatter [TEST_SLICE :: A] [u32] ([TEST_SLICE] => const _: u32 = 1;));
     __slice!(@scatter [TEST_SLICE :: A] [u32] ([TEST_SLICE] => const _: u32 = 3;));
     __slice!(@scatter [TEST_SLICE :: A] [u32] ([TEST_SLICE] => const _: u32 = 2;));
@@ -73,7 +73,7 @@ mod tests {
         assert!(TEST_SLICE.contains(&3));
     }
 
-    __slice!(@gather B pub static EMPTY_SLICE: ScatteredSlice<u32>;);
+    __slice!(@gather B pub static EMPTY_SLICE: (ScatteredSlice)<u32>;);
 
     #[test]
     fn test_empty_scattered_slice() {

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -77,9 +77,9 @@ impl<T: Ord + 'static> ::core::iter::IntoIterator for &'static ScatteredSortedRe
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __sorted_referenced_slice {
-    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($collection:tt)*) < $ty:ty >;) => {
         $(#[$meta])*
-        $vis static $name: $collection<$ty> = const {
+        $vis static $name: $($collection)* <$ty> = const {
             $crate::__support::link_section::declarative::section!(
                 #[section(unsafe, type = movable, name = $name :: $unique)]
                 static $name: $crate::__support::link_section::TypedMovableSection<$ty>;
@@ -112,7 +112,7 @@ macro_rules! __sorted_referenced_slice {
 mod tests {
     use crate::sorted_referenced_slice::{Ref, ScatteredSortedReferencedSlice};
 
-    __sorted_referenced_slice!(@gather A pub static TEST_SORT_REF: ScatteredSortedReferencedSlice<u32>;);
+    __sorted_referenced_slice!(@gather A pub static TEST_SORT_REF: (ScatteredSortedReferencedSlice)<u32>;);
     __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] [u32] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_A: u32 = 1;));
     __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] [u32] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_B: u32 = 3;));
     __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] [u32] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_C: u32 = 2;));
@@ -127,7 +127,7 @@ mod tests {
         assert_eq!(*SORT_REF_ITEM_C, 2);
     }
 
-    __sorted_referenced_slice!(@gather B pub static EMPTY_SORT_REF: ScatteredSortedReferencedSlice<u32>;);
+    __sorted_referenced_slice!(@gather B pub static EMPTY_SORT_REF: (ScatteredSortedReferencedSlice)<u32>;);
 
     #[test]
     fn test_empty_scattered_sorted_referenced_slice() {

--- a/scattered-collect/src/sorted_slice.rs
+++ b/scattered-collect/src/sorted_slice.rs
@@ -68,9 +68,9 @@ pub fn initialize_scattered_sorted_slice<T: Ord>(main: &mut [T]) {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __sorted_slice {
-    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: $collection:ident < $ty:ty >;) => {
+    (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($collection:tt)*) < $ty:ty >;) => {
         $(#[$meta])*
-        $vis static $name: $collection<$ty> = {
+        $vis static $name: $($collection)* <$ty> = {
             $crate::__support::link_section::declarative::section!(
                 #[section(unsafe, type = mutable, name = $name :: $unique)]
                 static $name: $crate::__support::link_section::TypedMutableSection<$ty>;
@@ -103,7 +103,7 @@ macro_rules! __sorted_slice {
 mod tests {
     pub use super::ScatteredSortedSlice;
 
-    __sorted_slice!(@gather A pub static TEST_SORTED_SLICE: ScatteredSortedSlice<u32>;);
+    __sorted_slice!(@gather A pub static TEST_SORTED_SLICE: (ScatteredSortedSlice)<u32>;);
     __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 6;));
     __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 3;));
     __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 2;));
@@ -120,7 +120,7 @@ mod tests {
         }
     }
 
-    __sorted_slice!(@gather B pub static EMPTY_SORTED_SLICE: ScatteredSortedSlice<u32>;);
+    __sorted_slice!(@gather B pub static EMPTY_SORTED_SLICE: (ScatteredSortedSlice)<u32>;);
 
     #[test]
     fn test_empty_scattered_sorted_slice() {


### PR DESCRIPTION
Fix for #477: we allow for fully-qualified paths to collections. There are two requirements: the path must end in the correct collection name for the collection you are generating (ie: `ScatteredSlice`), and the path must resolve to the same type that the crate itself generates (ie: if you declare a `ScatteredSlice`, it must be the correct one from the crate.

All path types are supported (`crate::`, `super::`, `self::`).
