### PR TITLE
Repro for LLVM provenance issue on Windows

### DIFF
--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -3,6 +3,8 @@ pub mod standard;
 pub mod wasm;
 pub mod windows;
 
+use core::ptr;
+
 #[cfg(target_vendor = "apple")]
 pub use apple::{get_section, section_name};
 #[cfg(all(
@@ -34,6 +36,10 @@ pub const fn validate_section_name(name: &str) {
     )) {
         standard::is_valid_section_name(name);
     }
+}
+
+pub fn launder_pointer_provenance<T>(ptr: *const T) -> *const T {
+    core::ptr::with_exposed_provenance(ptr.expose_provenance())
 }
 
 /// Constant bounds for a pointer-based section.

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -37,8 +37,14 @@ pub const fn validate_section_name(name: &str) {
 }
 
 /// Launder a pointer's provenance so it appears as an "exposed" pointer.
+#[cfg(not(windows))]
 pub fn launder_pointer_provenance<T>(ptr: *const T) -> *const T {
     core::ptr::with_exposed_provenance(ptr.expose_provenance())
+}
+
+#[cfg(windows)]
+pub fn launder_pointer_provenance<T>(ptr: *const T) -> *const T {
+    core::hint::black_box(core::ptr::with_exposed_provenance(ptr.expose_provenance()))
 }
 
 /// Constant bounds for a pointer-based section.

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -37,14 +37,17 @@ pub const fn validate_section_name(name: &str) {
 }
 
 /// Launder a pointer's provenance so it appears as an "exposed" pointer.
-#[cfg(not(windows))]
 pub fn launder_pointer_provenance<T>(ptr: *const T) -> *const T {
-    core::ptr::with_exposed_provenance(ptr.expose_provenance())
-}
+    #[cfg(not(windows))]
+    {
+        core::ptr::with_exposed_provenance(ptr.expose_provenance())
+    }
 
-#[cfg(windows)]
-pub fn launder_pointer_provenance<T>(ptr: *const T) -> *const T {
-    core::hint::black_box(core::ptr::with_exposed_provenance(ptr.expose_provenance()))
+    // Windows requires a stronger hint to avoid mis-optimization.
+    #[cfg(windows)]
+    {
+        core::hint::black_box(core::ptr::with_exposed_provenance(ptr.expose_provenance()))
+    }
 }
 
 /// Constant bounds for a pointer-based section.

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -57,7 +57,7 @@ impl PtrBounds {
     }
 }
 
-#[cfg(all(not(miri), not(target_os = "windows")))]
+#[cfg(not(miri))]
 impl PtrBounds {
     #[inline(always)]
     /// Start as an opaque pointer.
@@ -72,44 +72,6 @@ impl PtrBounds {
     #[inline(always)]
     /// Length in bytes (`end - start`).
     pub const fn byte_len(&self) -> usize {
-        // NOTE: MSRV for non-WASM targets doesn't allow byte_offset_from,
-        // so we manually implement it here.
-        unsafe { (self.end.cast::<u8>()).offset_from(self.start.cast::<u8>()) as usize }
-    }
-}
-
-#[cfg(all(not(miri), target_os = "windows"))]
-impl PtrBounds {
-    // On Windows the bounds are the addresses of two distinct marker statics
-    // (`__START` / `__END`) and the items live in *separate* statics in
-    // between. A pointer that keeps its `&__START` provenance only covers the
-    // `__START` allocation, so a `&[T]` spanning the items through it is UB —
-    // and LLVM exploits it: it proves every element load observes `__START`'s
-    // zero bytes and constant-folds `iter().copied().collect()` into a
-    // zero-filled allocation, so the slice reads as all-null at runtime.
-    //
-    // `black_box` lowers to an inline-asm barrier with a memory clobber, which
-    // yields a pointer of unknown provenance the optimizer cannot trace back to
-    // `__START` — so it can no longer prove the span. An exposed-provenance
-    // round-trip (`with_exposed_provenance(ptr.expose_provenance())`) is *not*
-    // sufficient: it lowers to `inttoptr`/`ptrtoint`, which LLVM folds back to
-    // the original pointer (and thus the original provenance) under LTO.
-    // ELF/Mach-O don't need this: their bounds come from opaque linker-defined
-    // `extern` symbols, which already have unknown provenance.
-    #[inline(always)]
-    /// Start as an opaque pointer, with provenance opacified (see the impl
-    /// comment for why this is required on COFF/Windows).
-    pub fn start_ptr(&self) -> *const () {
-        ::core::hint::black_box(self.start)
-    }
-    #[inline(always)]
-    /// End as an opaque pointer, with provenance opacified.
-    pub fn end_ptr(&self) -> *const () {
-        ::core::hint::black_box(self.end)
-    }
-    #[inline(always)]
-    /// Length in bytes (`end - start`).
-    pub fn byte_len(&self) -> usize {
         // NOTE: MSRV for non-WASM targets doesn't allow byte_offset_from,
         // so we manually implement it here.
         unsafe { (self.end.cast::<u8>()).offset_from(self.start.cast::<u8>()) as usize }

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -43,7 +43,13 @@ pub fn launder_pointer_provenance<T>(ptr: *const T) -> *const T {
         core::ptr::with_exposed_provenance(ptr.expose_provenance())
     }
 
-    // Windows requires a stronger hint to avoid mis-optimization.
+    // Windows requires a stronger hint to avoid mis-optimization. On Windows, section bounds
+    // come from marker sections. LLVM may fold ptrtoint/inttoptr under LTO, which takes our
+    // exposed provenance and reverts it, which it then traces to the marker allocation which
+    // it then believes all slice loads come from.
+    //
+    // Treating this provenance round-trip as a no-op is arguably an LLVM optimization issue
+    // somewhere between Rust and LLVM.
     #[cfg(windows)]
     {
         core::hint::black_box(core::ptr::with_exposed_provenance(ptr.expose_provenance()))

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -3,8 +3,6 @@ pub mod standard;
 pub mod wasm;
 pub mod windows;
 
-use core::ptr;
-
 #[cfg(target_vendor = "apple")]
 pub use apple::{get_section, section_name};
 #[cfg(all(

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -36,6 +36,7 @@ pub const fn validate_section_name(name: &str) {
     }
 }
 
+/// Launder a pointer's provenance so it appears as an "exposed" pointer.
 pub fn launder_pointer_provenance<T>(ptr: *const T) -> *const T {
     core::ptr::with_exposed_provenance(ptr.expose_provenance())
 }

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -55,40 +55,24 @@ impl PtrBounds {
     }
 }
 
-#[cfg(not(miri))]
 impl PtrBounds {
     #[inline(always)]
-    /// Start as an opaque pointer.
-    pub const fn start_ptr(&self) -> *const () {
-        self.start
-    }
-    #[inline(always)]
-    /// End as an opaque pointer.
-    pub const fn end_ptr(&self) -> *const () {
-        self.end
-    }
-    #[inline(always)]
-    /// Length in bytes (`end - start`).
-    pub const fn byte_len(&self) -> usize {
-        // NOTE: MSRV for non-WASM targets doesn't allow byte_offset_from,
-        // so we manually implement it here.
-        unsafe { (self.end.cast::<u8>()).offset_from(self.start.cast::<u8>()) as usize }
-    }
-}
-
-#[cfg(miri)]
-impl PtrBounds {
-    /// Start as an opaque pointer.
+    /// Start pointer as an opaque pointer, with the same provenance as the end pointer.
     pub fn start_ptr(&self) -> *const () {
-        self.start as usize as *const ()
+        launder_pointer_provenance(self.start)
     }
-    /// End as an opaque pointer.
+
+    #[inline(always)]
+    /// End pointer for the section, with the same provenance as the start pointer.
     pub fn end_ptr(&self) -> *const () {
-        self.end as usize as *const ()
+        unsafe { (self.start_ptr() as *const u8).add(self.byte_len()) as *const () }
     }
+
+    #[inline(always)]
     /// Length in bytes (`end - start`).
     pub fn byte_len(&self) -> usize {
-        self.end as usize - self.start as usize
+        // Provenance-insensitive difference.
+        self.end.addr() - self.start.addr()
     }
 }
 
@@ -125,11 +109,6 @@ impl PtrMovableBounds {
     #[inline(always)]
     pub fn backrefs_start_ptr(&self) -> *const () {
         self.refs.start_ptr()
-    }
-    /// End pointer for the movable backref section.
-    #[inline(always)]
-    pub fn backrefs_end_ptr(&self) -> *const () {
-        self.refs.end_ptr()
     }
     /// Length in bytes of the movable backref section.
     #[inline(always)]

--- a/link-section/src/platform/windows.rs
+++ b/link-section/src/platform/windows.rs
@@ -27,36 +27,34 @@ macro_rules! __get_section_windows {
                     #[link_section = __]
                     static __START: SyncUnsafeCell<Alignment<$generic_ty>> = SyncUnsafeCell::new(Alignment::new());
                 );
-                let start = unsafe {
-                    let start = &raw const __START;
-                    start.cast::<u8>().add(mem::size_of::<Alignment<$generic_ty>>()) as *const()
-                };
-                let start = $crate::__support::launder_pointer_provenance(start);
-
                 add_section_link_attribute!(
                     item data end $name
                     #[link_section = __]
                     static __END: SyncUnsafeCell<Alignment<$generic_ty>> = SyncUnsafeCell::new(Alignment::new());
                 );
-                let end = unsafe { &raw const __END as *const () };
-                let end = $crate::__support::launder_pointer_provenance(end);
-
                 add_section_link_attribute!(
                     backref data start $name
                     #[link_section = __]
                     static __REF_START: SyncUnsafeCell<Alignment<$crate::MovableBackref<$generic_ty>>> =
                         SyncUnsafeCell::new(Alignment::new());
                 );
-                let ref_start = unsafe {
-                    let start = &raw const __REF_START;
-                    start.cast::<u8>().add(mem::size_of::<Alignment<$crate::MovableBackref<$generic_ty>>>()) as *const()
-                };
                 add_section_link_attribute!(
                     backref data end $name
                     #[link_section = __]
                     static __REF_END: SyncUnsafeCell<Alignment<$crate::MovableBackref<$generic_ty>>> =
                         SyncUnsafeCell::new(Alignment::new());
                 );
+
+                let start = $crate::__support::launder_pointer_provenance(unsafe { &raw const __START as *const () });
+                let start = unsafe {
+                    start.cast::<u8>().add(mem::size_of::<Alignment<$generic_ty>>()) as *const()
+                };
+                let end = unsafe { &raw const __END as *const () };
+
+                let ref_start = $crate::__support::launder_pointer_provenance(unsafe { &raw const __REF_START as *const () });
+                let ref_start = unsafe {
+                    start.cast::<u8>().add(mem::size_of::<Alignment<$crate::MovableBackref<$generic_ty>>>()) as *const()
+                };
                 let ref_end = unsafe { &raw const __REF_END as *const () };
 
                 $crate::__support::MovableBounds::new(

--- a/link-section/src/platform/windows.rs
+++ b/link-section/src/platform/windows.rs
@@ -53,7 +53,7 @@ macro_rules! __get_section_windows {
 
                 let ref_start = unsafe { &raw const __REF_START as *const () };
                 let ref_start = unsafe {
-                    start.cast::<u8>().add(mem::size_of::<Alignment<$crate::MovableBackref<$generic_ty>>>()) as *const()
+                    ref_start.cast::<u8>().add(mem::size_of::<Alignment<$crate::MovableBackref<$generic_ty>>>()) as *const ()
                 };
                 let ref_end = unsafe { &raw const __REF_END as *const () };
 

--- a/link-section/src/platform/windows.rs
+++ b/link-section/src/platform/windows.rs
@@ -31,12 +31,15 @@ macro_rules! __get_section_windows {
                     let start = &raw const __START;
                     start.cast::<u8>().add(mem::size_of::<Alignment<$generic_ty>>()) as *const()
                 };
+                let start = $crate::__support::launder_pointer_provenance(start);
+
                 add_section_link_attribute!(
                     item data end $name
                     #[link_section = __]
                     static __END: SyncUnsafeCell<Alignment<$generic_ty>> = SyncUnsafeCell::new(Alignment::new());
                 );
                 let end = unsafe { &raw const __END as *const () };
+                let end = $crate::__support::launder_pointer_provenance(end);
 
                 add_section_link_attribute!(
                     backref data start $name

--- a/link-section/src/platform/windows.rs
+++ b/link-section/src/platform/windows.rs
@@ -45,13 +45,13 @@ macro_rules! __get_section_windows {
                         SyncUnsafeCell::new(Alignment::new());
                 );
 
-                let start = $crate::__support::launder_pointer_provenance(unsafe { &raw const __START as *const () });
+                let start = unsafe { &raw const __START as *const () };
                 let start = unsafe {
                     start.cast::<u8>().add(mem::size_of::<Alignment<$generic_ty>>()) as *const()
                 };
                 let end = unsafe { &raw const __END as *const () };
 
-                let ref_start = $crate::__support::launder_pointer_provenance(unsafe { &raw const __REF_START as *const () });
+                let ref_start = unsafe { &raw const __REF_START as *const () };
                 let ref_start = unsafe {
                     start.cast::<u8>().add(mem::size_of::<Alignment<$crate::MovableBackref<$generic_ty>>>()) as *const()
                 };

--- a/link-section/src/sections.rs
+++ b/link-section/src/sections.rs
@@ -36,7 +36,7 @@ impl Section {
     /// The end address of the section.
     #[inline]
     pub fn end_ptr(&self) -> *const () {
-        self.bounds.end_ptr()
+        unsafe { (self.start_ptr() as *const u8).add(self.byte_len()) as *const () }
     }
 
     /// Ensures that a section exists at the given path.

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -19,7 +19,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$start$__DATA$FOO5e2dUfYsWwq"]
+                            #[link_name = "\u{1}section$start$__DATA$FOObZ9fWg33QKS"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -27,14 +27,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$end$__DATA$FOO5e2dUfYsWwq"]
+                            #[link_name = "\u{1}section$end$__DATA$FOObZ9fWg33QKS"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "__DATA,FOO5e2dUfYsWwq";
+            let name = "__DATA,FOObZ9fWg33QKS";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -76,7 +76,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "__DATA,FOO5e2dUfYsWwq,regular,no_dead_strip"]
+        #[link_section = "__DATA,FOObZ9fWg33QKS,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -19,7 +19,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$start$__DATA$FOO8biNBtPjE23"]
+                            #[link_name = "\u{1}section$start$__DATA$FOO5e2dUfYsWwq"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -27,14 +27,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$end$__DATA$FOO8biNBtPjE23"]
+                            #[link_name = "\u{1}section$end$__DATA$FOO5e2dUfYsWwq"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "__DATA,FOO8biNBtPjE23";
+            let name = "__DATA,FOO5e2dUfYsWwq";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -76,7 +76,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "__DATA,FOO8biNBtPjE23,regular,no_dead_strip"]
+        #[link_section = "__DATA,FOO5e2dUfYsWwq,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -19,7 +19,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$start$__DATA$FOOa_TEzcsG71v"]
+                            #[link_name = "\u{1}section$start$__DATA$FOO8biNBtPjE23"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -27,14 +27,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$end$__DATA$FOOa_TEzcsG71v"]
+                            #[link_name = "\u{1}section$end$__DATA$FOO8biNBtPjE23"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "__DATA,FOOa_TEzcsG71v";
+            let name = "__DATA,FOO8biNBtPjE23";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -76,7 +76,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "__DATA,FOOa_TEzcsG71v,regular,no_dead_strip"]
+        #[link_section = "__DATA,FOO8biNBtPjE23,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -19,7 +19,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$start$__DATA$FOObZ9fWg33QKS"]
+                            #[link_name = "\u{1}section$start$__DATA$FOO74oV7cnUspp"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -27,14 +27,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$end$__DATA$FOObZ9fWg33QKS"]
+                            #[link_name = "\u{1}section$end$__DATA$FOO74oV7cnUspp"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "__DATA,FOObZ9fWg33QKS";
+            let name = "__DATA,FOO74oV7cnUspp";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -76,7 +76,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "__DATA,FOObZ9fWg33QKS,regular,no_dead_strip"]
+        #[link_section = "__DATA,FOO74oV7cnUspp,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-linux/link_section.expanded.rs
+++ b/link-section/tests/expand-linux/link_section.expanded.rs
@@ -20,7 +20,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__start__data_link_section_FOObZ9fWg33QKS"]
+                            #[link_name = "__start__data_link_section_FOO74oV7cnUspp"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -28,14 +28,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__stop__data_link_section_FOObZ9fWg33QKS"]
+                            #[link_name = "__stop__data_link_section_FOO74oV7cnUspp"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "_data_link_section_FOObZ9fWg33QKS";
+            let name = "_data_link_section_FOO74oV7cnUspp";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -77,7 +77,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "_data_link_section_FOObZ9fWg33QKS"]
+        #[link_section = "_data_link_section_FOO74oV7cnUspp"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-linux/link_section.expanded.rs
+++ b/link-section/tests/expand-linux/link_section.expanded.rs
@@ -20,7 +20,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__start__data_link_section_FOO74oV7cnUspp"]
+                            #[link_name = "__start__data_link_section_FOObZ9fWg33QKS"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -28,14 +28,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__stop__data_link_section_FOO74oV7cnUspp"]
+                            #[link_name = "__stop__data_link_section_FOObZ9fWg33QKS"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "_data_link_section_FOO74oV7cnUspp";
+            let name = "_data_link_section_FOObZ9fWg33QKS";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -77,7 +77,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "_data_link_section_FOO74oV7cnUspp"]
+        #[link_section = "_data_link_section_FOObZ9fWg33QKS"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-linux/link_section.expanded.rs
+++ b/link-section/tests/expand-linux/link_section.expanded.rs
@@ -20,7 +20,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__start__data_link_section_FOOa_TEzcsG71v"]
+                            #[link_name = "__start__data_link_section_FOObZ9fWg33QKS"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -28,14 +28,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__stop__data_link_section_FOOa_TEzcsG71v"]
+                            #[link_name = "__stop__data_link_section_FOObZ9fWg33QKS"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "_data_link_section_FOOa_TEzcsG71v";
+            let name = "_data_link_section_FOObZ9fWg33QKS";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -77,7 +77,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "_data_link_section_FOOa_TEzcsG71v"]
+        #[link_section = "_data_link_section_FOObZ9fWg33QKS"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/tests/link_section/copied/Cargo.toml
+++ b/tests/link_section/copied/Cargo.toml
@@ -10,11 +10,13 @@ link-section = { path = "../../../link-section" }
 libc-print = "0.5"
 
 [profile.dev]
-lto = true
 opt-level = 3
+lto = "fat"
+codegen-units = 1
 
 [profile.release]
-lto = true
 opt-level = 3
+lto = "fat"
+codegen-units = 1
 
 [workspace]

--- a/tests/link_section/copied/Cargo.toml
+++ b/tests/link_section/copied/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+ctor = { path = "../../../ctor" }
+link-section = { path = "../../../link-section" }
+libc-print = "0.5"
+
+[profile.dev]
+lto = true
+
+[profile.release]
+lto = true
+
+[workspace]

--- a/tests/link_section/copied/Cargo.toml
+++ b/tests/link_section/copied/Cargo.toml
@@ -11,10 +11,10 @@ libc-print = "0.5"
 
 [profile.dev]
 lto = true
-opt-level = "3"
+opt-level = 3
 
 [profile.release]
 lto = true
-opt-level = "3"
+opt-level = 3
 
 [workspace]

--- a/tests/link_section/copied/Cargo.toml
+++ b/tests/link_section/copied/Cargo.toml
@@ -11,8 +11,10 @@ libc-print = "0.5"
 
 [profile.dev]
 lto = true
+opt-level = "3"
 
 [profile.release]
 lto = true
+opt-level = "3"
 
 [workspace]

--- a/tests/link_section/copied/src/main.rs
+++ b/tests/link_section/copied/src/main.rs
@@ -1,7 +1,6 @@
 //! Example usage of the `link-section` crate.
 
 use link_section::{in_section, section};
-use std::fmt;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct ComplexType {
@@ -17,6 +16,43 @@ pub struct OtherType {
 
 static OTHER_TYPE: OtherType = OtherType { u32: 1, u64: 2 };
 static OTHER_TYPE_2: OtherType = OtherType { u32: 3, u64: 4 };
+
+#[section(typed)]
+static VALUES: link_section::TypedSection<&'static u64>;
+
+// Scatter several `&'static u64` from distinct modules. The values are distinct
+// and non-zero so a correct read sorts to a known order; a miscompiled read
+// yields nulls.
+#[in_section(VALUES)]
+const _: &'static u64 = {
+    static V: u64 = 50;
+    &V
+};
+#[in_section(VALUES)]
+const _: &'static u64 = {
+    static V: u64 = 10;
+    &V
+};
+
+mod more {
+    use link_section::in_section;
+
+    #[in_section(crate::VALUES)]
+    const _: &'static u64 = {
+        static V: u64 = 40;
+        &V
+    };
+    #[in_section(crate::VALUES)]
+    const _: &'static u64 = {
+        static V: u64 = 20;
+        &V
+    };
+    #[in_section(crate::VALUES)]
+    const _: &'static u64 = {
+        static V: u64 = 30;
+        &V
+    };
+}
 
 #[section(mutable)]
 pub static MUT_LINK_SECTION: link_section::TypedMutableSection<ComplexType>;
@@ -89,4 +125,23 @@ pub fn main() {
     let mut copied_section = IMMUTABLE_LINK_SECTION.iter().copied().collect::<Vec<_>>();
     copied_section.sort();
     eprintln!("IMMUTABLE: {:?}", copied_section);
+
+    let mut v: Vec<&'static u64> = VALUES.iter().copied().collect();
+    println!("LEN={}", v.len());
+
+    v.sort_unstable_by_key(|p| **p);
+    let vals: Vec<u64> = v.iter().map(|p| **p).collect();
+    println!("VALS={vals:?}");
+
+    assert_eq!(v.len(), 5, "expected 5 gathered pointers");
+    assert_eq!(
+        vals,
+        vec![10, 20, 30, 40, 50],
+        "gathered pointers must read back their real values, not zeros"
+    );
+    assert!(
+        v.iter().all(|p| **p != 0),
+        "NULL pointer in gathered slice (provenance miscompile)"
+    );
+    println!("OK");
 }

--- a/tests/link_section/copied/src/main.rs
+++ b/tests/link_section/copied/src/main.rs
@@ -1,120 +1,8 @@
 //! Example usage of the `link-section` crate.
 
-use link_section::{in_section, section};
+mod sections;
 
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub struct ComplexType {
-    static_string: &'static str,
-    static_ptr: &'static OtherType,
-}
-
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub struct OtherType {
-    u32: u32,
-    u64: u64,
-}
-
-static OTHER_TYPE: OtherType = OtherType { u32: 1, u64: 2 };
-static OTHER_TYPE_2: OtherType = OtherType { u32: 3, u64: 4 };
-
-#[section(typed)]
-static VALUES: link_section::TypedSection<&'static u64>;
-
-// Scatter several `&'static u64` from distinct modules. The values are distinct
-// and non-zero so a correct read sorts to a known order; a miscompiled read
-// yields nulls.
-#[in_section(VALUES)]
-const _: &'static u64 = {
-    static V: u64 = 50;
-    &V
-};
-#[in_section(VALUES)]
-const _: &'static u64 = {
-    static V: u64 = 10;
-    &V
-};
-
-mod more {
-    use link_section::in_section;
-
-    #[in_section(crate::VALUES)]
-    const _: &'static u64 = {
-        static V: u64 = 40;
-        &V
-    };
-    #[in_section(crate::VALUES)]
-    const _: &'static u64 = {
-        static V: u64 = 20;
-        &V
-    };
-    #[in_section(crate::VALUES)]
-    const _: &'static u64 = {
-        static V: u64 = 30;
-        &V
-    };
-}
-
-#[section(mutable)]
-pub static MUT_LINK_SECTION: link_section::TypedMutableSection<ComplexType>;
-
-#[in_section(MUT_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "1",
-    static_ptr: &OTHER_TYPE,
-};
-
-#[in_section(MUT_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "2",
-    static_ptr: &OTHER_TYPE,
-};
-
-#[in_section(MUT_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "3",
-    static_ptr: &OTHER_TYPE,
-};
-
-mod other {
-    use super::*;
-
-    #[in_section(MUT_LINK_SECTION)]
-    const _: ComplexType = ComplexType {
-        static_string: "4",
-        static_ptr: &OTHER_TYPE_2,
-    };
-
-    #[in_section(MUT_LINK_SECTION)]
-    const _: ComplexType = ComplexType {
-        static_string: "5",
-        static_ptr: &OTHER_TYPE,
-    };
-}
-
-#[section(typed)]
-pub static IMMUTABLE_LINK_SECTION: link_section::TypedSection<ComplexType>;
-
-#[in_section(IMMUTABLE_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "1",
-    static_ptr: &OTHER_TYPE,
-};
-
-mod other_immutable {
-    use super::*;
-
-    #[in_section(IMMUTABLE_LINK_SECTION)]
-    const _: ComplexType = ComplexType {
-        static_string: "9",
-        static_ptr: &OTHER_TYPE_2,
-    };
-
-    #[in_section(IMMUTABLE_LINK_SECTION)]
-    const _: ComplexType = ComplexType {
-        static_string: "4",
-        static_ptr: &OTHER_TYPE,
-    };
-}
+use sections::{IMMUTABLE_LINK_SECTION, MUT_LINK_SECTION, VALUES};
 
 pub fn main() {
     // LLVM was optimizing these copies into memsets
@@ -127,11 +15,11 @@ pub fn main() {
     eprintln!("IMMUTABLE: {:?}", copied_section);
 
     let mut v: Vec<&'static u64> = VALUES.iter().copied().collect();
-    println!("LEN={}", v.len());
+    eprintln!("LEN={}", v.len());
 
     v.sort_unstable_by_key(|p| **p);
     let vals: Vec<u64> = v.iter().map(|p| **p).collect();
-    println!("VALS={vals:?}");
+    eprintln!("VALS={vals:?}");
 
     assert_eq!(v.len(), 5, "expected 5 gathered pointers");
     assert_eq!(
@@ -143,5 +31,5 @@ pub fn main() {
         v.iter().all(|p| **p != 0),
         "NULL pointer in gathered slice (provenance miscompile)"
     );
-    println!("OK");
+    eprintln!("OK");
 }

--- a/tests/link_section/copied/src/main.rs
+++ b/tests/link_section/copied/src/main.rs
@@ -1,36 +1,82 @@
 //! Example usage of the `link-section` crate.
 
 use link_section::{in_section, section};
+use std::fmt;
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct ComplexType {
+    static_string: &'static str,
+    static_ptr: &'static OtherType,
+}
+
+impl fmt::Debug for ComplexType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.static_string)
+    }
+}
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct OtherType {
+    u32: u32,
+    u64: u64,
+}
+
+static OTHER_TYPE: OtherType = OtherType { u32: 1, u64: 2 };
+static OTHER_TYPE_2: OtherType = OtherType { u32: 3, u64: 4 };
 
 #[section(mutable)]
-pub static MUT_LINK_SECTION: link_section::TypedMutableSection<u32>;
+pub static MUT_LINK_SECTION: link_section::TypedMutableSection<ComplexType>;
 
 #[in_section(MUT_LINK_SECTION)]
-const _: u32 = 4;
+const _: ComplexType = ComplexType {
+    static_string: "1",
+    static_ptr: &OTHER_TYPE,
+};
 
 #[in_section(MUT_LINK_SECTION)]
-const _: u32 = 2;
+const _: ComplexType = ComplexType {
+    static_string: "2",
+    static_ptr: &OTHER_TYPE,
+};
 
 #[in_section(MUT_LINK_SECTION)]
-const _: u32 = 1;
+const _: ComplexType = ComplexType {
+    static_string: "3",
+    static_ptr: &OTHER_TYPE,
+};
 
 #[in_section(MUT_LINK_SECTION)]
-const _: u32 = 3;
+const _: ComplexType = ComplexType {
+    static_string: "4",
+    static_ptr: &OTHER_TYPE_2,
+};
 
 #[in_section(MUT_LINK_SECTION)]
-const _: u32 = 5;
+const _: ComplexType = ComplexType {
+    static_string: "5",
+    static_ptr: &OTHER_TYPE,
+};
 
 #[section(typed)]
-pub static IMMUTABLE_LINK_SECTION: link_section::TypedSection<u32>;
+pub static IMMUTABLE_LINK_SECTION: link_section::TypedSection<ComplexType>;
 
 #[in_section(IMMUTABLE_LINK_SECTION)]
-const _: u32 = 4;
+const _: ComplexType = ComplexType {
+    static_string: "1",
+    static_ptr: &OTHER_TYPE,
+};
 
 #[in_section(IMMUTABLE_LINK_SECTION)]
-const _: u32 = 2;
+const _: ComplexType = ComplexType {
+    static_string: "9",
+    static_ptr: &OTHER_TYPE_2,
+};
 
 #[in_section(IMMUTABLE_LINK_SECTION)]
-const _: u32 = 1;
+const _: ComplexType = ComplexType {
+    static_string: "4",
+    static_ptr: &OTHER_TYPE,
+};
 
 pub fn main() {
     // LLVM was optimizing these copies into memsets

--- a/tests/link_section/copied/src/main.rs
+++ b/tests/link_section/copied/src/main.rs
@@ -1,0 +1,44 @@
+//! Example usage of the `link-section` crate.
+
+use link_section::{in_section, section};
+
+#[section(mutable)]
+pub static MUT_LINK_SECTION: link_section::TypedMutableSection<u32>;
+
+#[in_section(MUT_LINK_SECTION)]
+const _: u32 = 4;
+
+#[in_section(MUT_LINK_SECTION)]
+const _: u32 = 2;
+
+#[in_section(MUT_LINK_SECTION)]
+const _: u32 = 1;
+
+#[in_section(MUT_LINK_SECTION)]
+const _: u32 = 3;
+
+#[in_section(MUT_LINK_SECTION)]
+const _: u32 = 5;
+
+#[section(typed)]
+pub static IMMUTABLE_LINK_SECTION: link_section::TypedSection<u32>;
+
+#[in_section(IMMUTABLE_LINK_SECTION)]
+const _: u32 = 4;
+
+#[in_section(IMMUTABLE_LINK_SECTION)]
+const _: u32 = 2;
+
+#[in_section(IMMUTABLE_LINK_SECTION)]
+const _: u32 = 1;
+
+pub fn main() {
+    // LLVM was optimizing these copies into memsets
+    let mut copied_section = MUT_LINK_SECTION.iter().copied().collect::<Vec<_>>();
+    copied_section.sort();
+    eprintln!("MUTABLE: {:?}", copied_section);
+
+    let mut copied_section = IMMUTABLE_LINK_SECTION.iter().copied().collect::<Vec<_>>();
+    copied_section.sort();
+    eprintln!("IMMUTABLE: {:?}", copied_section);
+}

--- a/tests/link_section/copied/src/main.rs
+++ b/tests/link_section/copied/src/main.rs
@@ -45,17 +45,21 @@ const _: ComplexType = ComplexType {
     static_ptr: &OTHER_TYPE,
 };
 
-#[in_section(MUT_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "4",
-    static_ptr: &OTHER_TYPE_2,
-};
+mod other {
+    use super::*;
 
-#[in_section(MUT_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "5",
-    static_ptr: &OTHER_TYPE,
-};
+    #[in_section(MUT_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "4",
+        static_ptr: &OTHER_TYPE_2,
+    };
+
+    #[in_section(MUT_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "5",
+        static_ptr: &OTHER_TYPE,
+    };
+}
 
 #[section(typed)]
 pub static IMMUTABLE_LINK_SECTION: link_section::TypedSection<ComplexType>;
@@ -66,17 +70,21 @@ const _: ComplexType = ComplexType {
     static_ptr: &OTHER_TYPE,
 };
 
-#[in_section(IMMUTABLE_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "9",
-    static_ptr: &OTHER_TYPE_2,
-};
+mod other_immutable {
+    use super::*;
 
-#[in_section(IMMUTABLE_LINK_SECTION)]
-const _: ComplexType = ComplexType {
-    static_string: "4",
-    static_ptr: &OTHER_TYPE,
-};
+    #[in_section(IMMUTABLE_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "9",
+        static_ptr: &OTHER_TYPE_2,
+    };
+
+    #[in_section(IMMUTABLE_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "4",
+        static_ptr: &OTHER_TYPE,
+    };
+}
 
 pub fn main() {
     // LLVM was optimizing these copies into memsets

--- a/tests/link_section/copied/src/main.rs
+++ b/tests/link_section/copied/src/main.rs
@@ -3,19 +3,13 @@
 use link_section::{in_section, section};
 use std::fmt;
 
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct ComplexType {
     static_string: &'static str,
     static_ptr: &'static OtherType,
 }
 
-impl fmt::Debug for ComplexType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.static_string)
-    }
-}
-
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct OtherType {
     u32: u32,
     u64: u64,

--- a/tests/link_section/copied/src/sections.rs
+++ b/tests/link_section/copied/src/sections.rs
@@ -1,0 +1,115 @@
+use link_section::{in_section, section};
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct ComplexType {
+    static_string: &'static str,
+    static_ptr: &'static OtherType,
+}
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct OtherType {
+    u32: u32,
+    u64: u64,
+}
+
+static OTHER_TYPE: OtherType = OtherType { u32: 1, u64: 2 };
+static OTHER_TYPE_2: OtherType = OtherType { u32: 3, u64: 4 };
+
+#[section(typed)]
+pub static VALUES: link_section::TypedSection<&'static u64>;
+
+// Scatter several `&'static u64` from distinct modules. The values are distinct
+// and non-zero so a correct read sorts to a known order; a miscompiled read
+// yields nulls.
+#[in_section(VALUES)]
+const _: &'static u64 = {
+    static V: u64 = 50;
+    &V
+};
+#[in_section(VALUES)]
+const _: &'static u64 = {
+    static V: u64 = 10;
+    &V
+};
+
+mod more {
+    use link_section::in_section;
+
+    #[in_section(super::VALUES)]
+    const _: &'static u64 = {
+        static V: u64 = 40;
+        &V
+    };
+    #[in_section(super::VALUES)]
+    const _: &'static u64 = {
+        static V: u64 = 20;
+        &V
+    };
+    #[in_section(super::VALUES)]
+    const _: &'static u64 = {
+        static V: u64 = 30;
+        &V
+    };
+}
+
+#[section(mutable)]
+pub static MUT_LINK_SECTION: link_section::TypedMutableSection<ComplexType>;
+
+#[in_section(MUT_LINK_SECTION)]
+const _: ComplexType = ComplexType {
+    static_string: "1",
+    static_ptr: &OTHER_TYPE,
+};
+
+#[in_section(MUT_LINK_SECTION)]
+const _: ComplexType = ComplexType {
+    static_string: "2",
+    static_ptr: &OTHER_TYPE,
+};
+
+#[in_section(MUT_LINK_SECTION)]
+const _: ComplexType = ComplexType {
+    static_string: "3",
+    static_ptr: &OTHER_TYPE,
+};
+
+mod other {
+    use super::*;
+
+    #[in_section(MUT_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "4",
+        static_ptr: &OTHER_TYPE_2,
+    };
+
+    #[in_section(MUT_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "5",
+        static_ptr: &OTHER_TYPE,
+    };
+}
+
+#[section(typed)]
+pub static IMMUTABLE_LINK_SECTION: link_section::TypedSection<ComplexType>;
+
+#[in_section(IMMUTABLE_LINK_SECTION)]
+const _: ComplexType = ComplexType {
+    static_string: "1",
+    static_ptr: &OTHER_TYPE,
+};
+
+mod other_immutable {
+    use super::*;
+
+    #[in_section(IMMUTABLE_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "9",
+        static_ptr: &OTHER_TYPE_2,
+    };
+
+    #[in_section(IMMUTABLE_LINK_SECTION)]
+    const _: ComplexType = ComplexType {
+        static_string: "4",
+        static_ptr: &OTHER_TYPE,
+    };
+}

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -46,7 +46,7 @@ defer {
 $ cargo run --quiet
 """
 MUTABLE: [ComplexType { static_string: "1", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "2", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "3", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "4", static_ptr: OtherType { u32: 3, u64: 4 } }, ComplexType { static_string: "5", static_ptr: OtherType { u32: 1, u64: 2 } }]
-IMMUTABLE: [ComplexType { static_string: "1", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType {static_string: "4", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "9", static_ptr: OtherType { u32: 3, u64: 4 } }]
+IMMUTABLE: [ComplexType { static_string: "1", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "4", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "9", static_ptr: OtherType { u32: 3, u64: 4 } }]
 LEN=5
 VALS=[10, 20, 30, 40, 50]
 OK

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -36,6 +36,20 @@ choice {
 );
 
 clitest!(
+    copied,
+    r#"
+set RUSTFLAGS "";
+cd "link_section/copied";
+defer {
+    $ cargo clean --quiet
+}
+$ cargo run --quiet
+! MUTABLE: [1, 2, 3, 4, 5]
+! IMMUTABLE: [1, 2, 4]
+"#
+);
+
+clitest!(
     interior_mut,
     r#"
 set RUSTFLAGS "";

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -47,6 +47,9 @@ $ cargo run --quiet
 """
 MUTABLE: [ComplexType { static_string: "1", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "2", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "3", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "4", static_ptr: OtherType { u32: 3, u64: 4 } }, ComplexType { static_string: "5", static_ptr: OtherType { u32: 1, u64: 2 } }]
 IMMUTABLE: [ComplexType { static_string: "1", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType {static_string: "4", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "9", static_ptr: OtherType { u32: 3, u64: 4 } }]
+LEN=5
+VALS=[10, 20, 30, 40, 50]
+OK
 """
 "#
 );

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -45,7 +45,7 @@ defer {
 }
 $ cargo run --quiet
 ! MUTABLE: [1, 2, 3, 4, 5]
-! IMMUTABLE: [1, 2, 4]
+! IMMUTABLE: [1, 4, 9]
 "#
 );
 

--- a/tests/link_section/mod.rs
+++ b/tests/link_section/mod.rs
@@ -44,8 +44,10 @@ defer {
     $ cargo clean --quiet
 }
 $ cargo run --quiet
-! MUTABLE: [1, 2, 3, 4, 5]
-! IMMUTABLE: [1, 4, 9]
+"""
+MUTABLE: [ComplexType { static_string: "1", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "2", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "3", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "4", static_ptr: OtherType { u32: 3, u64: 4 } }, ComplexType { static_string: "5", static_ptr: OtherType { u32: 1, u64: 2 } }]
+IMMUTABLE: [ComplexType { static_string: "1", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType {static_string: "4", static_ptr: OtherType { u32: 1, u64: 2 } }, ComplexType { static_string: "9", static_ptr: OtherType { u32: 3, u64: 4 } }]
+"""
 "#
 );
 

--- a/tests/link_section/mut/Cargo.toml
+++ b/tests/link_section/mut/Cargo.toml
@@ -9,4 +9,10 @@ ctor = { path = "../../../ctor" }
 link-section = { path = "../../../link-section" }
 libc-print = "0.5"
 
+[profile.dev]
+lto = true
+
+[profile.release]
+lto = true
+
 [workspace]


### PR DESCRIPTION
In #479, a crash was reported on Windows because LLVM because LLVM believed that our start marker was just zeroed, read-only data with no meaning and helpfully just called memset.

We need to start using `with_exposed_provenance` to hide the underlying pointer.

First step - testing with LTO and copies to see if we can trigger it (reliably triggers).

Then, we use  `with_exposed_provenance` on most platforms and `with_exposed_provenance` + `black_box` on windows to ensure that test passes. Note that this is probably not the correct fix - that will come using `with_addr` in a follow-up PR.