### PR TITLE
Fix Windows/COFF pointer-provenance miscompile in scattered-collect section bounds

### DIFF
--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.3] - 2026-06-23
+
+### Fixed
+
+- Windows/COFF: section start/end pointers are now opacified with `black_box`,
+  fixing a miscompile where an optimizing (LTO) build could prove a gathered
+  slice (e.g. `ScatteredSlice<&'static T>`) reads as all-zero and fold it to
+  null values, crashing on use (`0xC0000005`). Fixes
+  [#479](https://github.com/mmastrac/linktime/issues/479).
+
 ## [0.18.2] - 2026-06-06
 
 ### Changed

--- a/link-section/src/platform/mod.rs
+++ b/link-section/src/platform/mod.rs
@@ -51,7 +51,7 @@ impl PtrBounds {
     }
 }
 
-#[cfg(not(miri))]
+#[cfg(all(not(miri), not(target_os = "windows")))]
 impl PtrBounds {
     #[inline(always)]
     /// Start as an opaque pointer.
@@ -66,6 +66,44 @@ impl PtrBounds {
     #[inline(always)]
     /// Length in bytes (`end - start`).
     pub const fn byte_len(&self) -> usize {
+        // NOTE: MSRV for non-WASM targets doesn't allow byte_offset_from,
+        // so we manually implement it here.
+        unsafe { (self.end.cast::<u8>()).offset_from(self.start.cast::<u8>()) as usize }
+    }
+}
+
+#[cfg(all(not(miri), target_os = "windows"))]
+impl PtrBounds {
+    // On Windows the bounds are the addresses of two distinct marker statics
+    // (`__START` / `__END`) and the items live in *separate* statics in
+    // between. A pointer that keeps its `&__START` provenance only covers the
+    // `__START` allocation, so a `&[T]` spanning the items through it is UB —
+    // and LLVM exploits it: it proves every element load observes `__START`'s
+    // zero bytes and constant-folds `iter().copied().collect()` into a
+    // zero-filled allocation, so the slice reads as all-null at runtime.
+    //
+    // `black_box` lowers to an inline-asm barrier with a memory clobber, which
+    // yields a pointer of unknown provenance the optimizer cannot trace back to
+    // `__START` — so it can no longer prove the span. An exposed-provenance
+    // round-trip (`with_exposed_provenance(ptr.expose_provenance())`) is *not*
+    // sufficient: it lowers to `inttoptr`/`ptrtoint`, which LLVM folds back to
+    // the original pointer (and thus the original provenance) under LTO.
+    // ELF/Mach-O don't need this: their bounds come from opaque linker-defined
+    // `extern` symbols, which already have unknown provenance.
+    #[inline(always)]
+    /// Start as an opaque pointer, with provenance opacified (see the impl
+    /// comment for why this is required on COFF/Windows).
+    pub fn start_ptr(&self) -> *const () {
+        ::core::hint::black_box(self.start)
+    }
+    #[inline(always)]
+    /// End as an opaque pointer, with provenance opacified.
+    pub fn end_ptr(&self) -> *const () {
+        ::core::hint::black_box(self.end)
+    }
+    #[inline(always)]
+    /// Length in bytes (`end - start`).
+    pub fn byte_len(&self) -> usize {
         // NOTE: MSRV for non-WASM targets doesn't allow byte_offset_from,
         // so we manually implement it here.
         unsafe { (self.end.cast::<u8>()).offset_from(self.start.cast::<u8>()) as usize }

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -19,7 +19,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$start$__DATA$FOOqv8HR0HPk9"]
+                            #[link_name = "\u{1}section$start$__DATA$FOOa_TEzcsG71v"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -27,14 +27,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$end$__DATA$FOOqv8HR0HPk9"]
+                            #[link_name = "\u{1}section$end$__DATA$FOOa_TEzcsG71v"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "__DATA,FOOqv8HR0HPk9";
+            let name = "__DATA,FOOa_TEzcsG71v";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -76,7 +76,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "__DATA,FOOqv8HR0HPk9,regular,no_dead_strip"]
+        #[link_section = "__DATA,FOOa_TEzcsG71v,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-linux/link_section.expanded.rs
+++ b/link-section/tests/expand-linux/link_section.expanded.rs
@@ -20,7 +20,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__start__data_link_section_FOOqv8HR0HPk9"]
+                            #[link_name = "__start__data_link_section_FOOa_TEzcsG71v"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -28,14 +28,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__stop__data_link_section_FOOqv8HR0HPk9"]
+                            #[link_name = "__stop__data_link_section_FOOa_TEzcsG71v"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "_data_link_section_FOOqv8HR0HPk9";
+            let name = "_data_link_section_FOOa_TEzcsG71v";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -77,7 +77,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "_data_link_section_FOOqv8HR0HPk9"]
+        #[link_section = "_data_link_section_FOOa_TEzcsG71v"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };


### PR DESCRIPTION
Fixes #479.

## Problem

On Windows, Turbopack (next.js, via `scattered-collect`) crashes with `0xC0000005` (exit `3221225477`), sometimes surfacing as `IllegalAccess` in its mmap persistence layer. The faulting read is a gathered slice — e.g. `VALUES_SLICE: ScatteredSlice<&'static ValueType>` — that comes back the **correct length but all-null pointers**; `init_registry` then sorts that copy (`item.ty()` dereferences null) and faults.

## Root cause

A **pointer-provenance miscompile**, not a linker/layout problem.

On Windows the section bounds are the addresses of two distinct marker statics (`__START` / `__END`), with the item statics placed *separately* in between (COFF has no `__start_`/`__stop_` encapsulation symbols). The slice pointer keeps its `&__START` provenance, which only covers the marker allocation. Spanning the items through it is UB, and under **whole-program LTO** LLVM proves every element load observes `__START`'s zero bytes and folds `iter().copied().collect()` into a zero-filled allocation — so the slice reads back all-null at runtime even though the data is correct in the binary.

ELF / Mach-O are unaffected: their bounds come from opaque linker-defined `extern` symbols (`__start_`/`section$start$`) with unknown provenance, so spanning them is sound.

(Isolated by inspecting the shipped `@next/swc-win32-x64-msvc` PE/COFF DLL: the scattered arrays are populated and relocated on disk, yet read null at runtime — i.e. the compiler elided the loads.)

## Fix

Opacify the start/end pointers with `core::hint::black_box` on Windows. `black_box` lowers to an inline-asm barrier with a memory clobber, yielding a pointer the optimizer cannot trace back to `__START` — so it can no longer prove the span, **even under LTO**. Confirmed to fix the crash on Windows against the full Turbopack build.

An exposed-provenance round-trip (`with_exposed_provenance(ptr.expose_provenance())`) was tried first and is **insufficient**: it lowers to `inttoptr`/`ptrtoint`, which LLVM folds back to the original pointer (restoring the bad provenance) under LTO — confirmed to still crash on a Windows VM. The opacification is done in the runtime `start_ptr`/`end_ptr` accessors (not the `const` `get_section!` builder, since `black_box` is not `const`). MSRV-safe (`black_box` stable since 1.66; crate MSRV is 1.85).

## Verification

- Confirmed fixed on Windows against the full Turbopack build.
- IR analysis on macOS (`--emit=llvm-ir`, x86_64-pc-windows-msvc): the buggy read lowers to `__rust_alloc_zeroed` with no loads; exposed-provenance lowers to foldable `inttoptr`/`ptrtoint`; `black_box` lowers to a non-foldable `asm sideeffect "" ... ~{memory}` barrier.
- Host (macOS/Linux) test suites and macro-expansion snapshots pass.

## Note: no regression test

This PR intentionally ships **without** a new regression test. The miscompile only manifests under whole-program LTO across the real Turbopack crate graph; no minimal standalone reproducer has been found (a single-crate test does not trigger the fold even with `lto = "fat"`). Per discussion with upstream, a non-reproducing test is more misleading than useful, so it was dropped. The changelog and `link-section`'s expansion snapshots are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
