### PR TITLE
Improve scattered map ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ctor",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ repository = "https://github.com/mmastrac/linktime"
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.7", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
-link-section = { path = "link-section", version = "0.18.2", default-features = false }
+link-section = { path = "link-section", version = "0.18.3", default-features = false }
 linktime = { path = "linktime", version = "0.17.0", default-features = false }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }
 
-scattered-collect = { path = "scattered-collect", version = "0.20.0" }
+scattered-collect = { path = "scattered-collect", version = "0.21.0" }

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.21.0] - 2026-06-25
+
+### Changed
+
+- `ScatteredMap` now implements `get` rather than `find` using `Borrow<Q>` instead of `&Q`.
+- `ConstHash` now implements `hash` for more string-like types.
+
+### Fixed
+
+- #[allow(...)] no longer breaks #[scatter] attribute parsing.

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/examples/command_registration.rs
+++ b/scattered-collect/examples/command_registration.rs
@@ -1,0 +1,45 @@
+use scattered_collect::{ScatteredMap, gather, scatter};
+
+trait Command: Send + Sync {
+    fn execute(&self);
+}
+
+#[gather]
+static COMMANDS: ScatteredMap<&'static str, &'static dyn Command>;
+
+#[macro_export]
+macro_rules! register_commands {
+    ($($command:ident: $type:ident),* $(,)?) => {
+        $(
+            #[allow(non_upper_case_globals)]
+            #[scatter(COMMANDS)]
+            static $command: (&'static str, $type) = (stringify!($command), &$type);
+        )*
+    };
+}
+
+struct Command1;
+impl Command for Command1 {
+    fn execute(&self) {
+        println!("Command1");
+    }
+}
+
+struct Command2;
+impl Command for Command2 {
+    fn execute(&self) {
+        println!("Command2");
+    }
+}
+
+register_commands!(
+    command_1: Command1,
+    command_2: Command2,
+);
+
+fn main() {
+    for command in ["command_1", "command_2"] {
+        let command = COMMANDS.get(command).unwrap();
+        command.execute();
+    }
+}

--- a/scattered-collect/examples/command_registration.rs
+++ b/scattered-collect/examples/command_registration.rs
@@ -1,3 +1,4 @@
+//! Example for `ScatteredMap`: registering named commands at link-time.
 use scattered_collect::{ScatteredMap, gather, scatter};
 
 trait Command: Send + Sync {
@@ -7,6 +8,7 @@ trait Command: Send + Sync {
 #[gather]
 static COMMANDS: ScatteredMap<&'static str, &'static dyn Command>;
 
+/// Macro for registering commands at link-time.
 #[macro_export]
 macro_rules! register_commands {
     ($($command:ident: $type:ident),* $(,)?) => {

--- a/scattered-collect/src/hash.rs
+++ b/scattered-collect/src/hash.rs
@@ -15,21 +15,36 @@ pub trait ConstHash {
     fn hash(&self) -> u64;
 }
 
-impl ConstHash for &'static str {
-    type Hasher = StrHasher;
-    const HASHER: Self::Hasher = StrHasher;
+macro_rules! const_hash_str {
+    ($($ty:ty)*) => {
+        $(
+            impl ConstHash for $ty {
+                type Hasher = StrHasher;
+                const HASHER: Self::Hasher = StrHasher;
+                fn hash(&self) -> u64 {
+                    (Self::HASHER).const_hash(self)
+                }
+            }
 
-    fn hash(&self) -> u64 {
-        (Self::HASHER).const_hash(self)
+            impl <'a> ConstHash for &'a $ty {
+                type Hasher = StrHasher;
+                const HASHER: Self::Hasher = StrHasher;
+                fn hash(&self) -> u64 {
+                    (Self::HASHER).const_hash(self)
+                }
+            }
+        )*
     }
 }
+
+const_hash_str!(String str std::borrow::Cow<'_, str>);
 
 #[doc(hidden)]
 pub struct StrHasher;
 
 impl StrHasher {
     /// Hash a string at compile time.
-    pub const fn const_hash(self, s: &'static str) -> u64 {
+    pub const fn const_hash(self, s: &str) -> u64 {
         xxhash_rust::const_xxh3::xxh3_64(s.as_bytes())
     }
 }

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -21,16 +21,26 @@ pub use sorted_slice::ScatteredSortedSlice;
 #[macro_export]
 macro_rules! __scatter_parse {
     // Send the #[scatter]'d item into the collection's private macro.
-    (#[scatter ($($meta:tt)*)] $(#[$imeta:meta])* $($item:tt)*) => {
+    (#[scatter ($($meta:tt)*)] $(#[$imeta:meta])* $vis:vis static $($item:tt)*) => {
         $($meta)* ! (
             ([$($meta)*] =>
             $(#[$imeta])*
+            $vis static
+            $($item)*
+            )
+        );
+    };
+    (#[scatter ($($meta:tt)*)] $(#[$imeta:meta])* $vis:vis const $($item:tt)*) => {
+        $($meta)* ! (
+            ([$($meta)*] =>
+            $(#[$imeta])*
+            $vis const
             $($item)*
             )
         );
     };
     (#[scatter] $($rest:tt)* ) => {
-        compile_error!("Unknown collection type");
+        compile_error!("Missing collection for #[scatter] attribute. Expected: #[scatter(COLLECTION)] <item>;");
     };
 
     (@reorder (#[scatter] $($item:tt)*) ($($rest:tt)*)) => {

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -3,6 +3,7 @@
 
 use link_section::{TypedMutableSection, TypedSection};
 use std::{
+    borrow::Borrow,
     mem::MaybeUninit,
     ptr,
     sync::atomic::{AtomicU8, Ordering},
@@ -73,15 +74,29 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
         Self { state }
     }
 
+    #[deprecated(since = "0.21.0", note = "Use `get` instead.")]
+    #[inline]
+    pub fn find<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ConstHash + Eq + ?Sized,
+    {
+        self.get(key)
+    }
+
     /// Lookup a value by key.
     #[inline]
-    pub fn find(&self, key: &K) -> Option<&V> {
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ConstHash + Eq + ?Sized,
+    {
         let this = self.state;
         let table = this.ensure_initialized();
         let hash = ConstHash::hash(key);
         let offset = (table.lookup_fn)(table, hash)?;
         let record = &this.records[offset as usize];
-        if record.key == *key {
+        if record.key.borrow() == key {
             Some(&record.value)
         } else {
             None
@@ -108,8 +123,12 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
 
     /// True when a key is present in the map.
     #[inline]
-    pub fn contains_key(&self, key: &K) -> bool {
-        self.find(key).is_some()
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: ConstHash + Eq + ?Sized,
+    {
+        self.get(key).is_some()
     }
 
     /// The number of records in the map.
@@ -267,6 +286,13 @@ macro_rules! __map {
             const _: $crate::map::MapMetadataChunk = $crate::map::MAP_METADATA_CHUNK_ZERO;
         );
     };
+    (@scatter [$collection_name:ident :: $unique:ident] [$key:ty , $value:ty] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = $expr:expr;)) => {
+        ::core::compile_error!(
+            "invalid #[scatter] syntax for ScatteredMap: expected \
+             `static NAME: (Key, Value) = (key_expr, value_expr);` \
+             (for example: `static FOO: (&'static str, u32) = (\"foo\", 1);`)"
+        );
+    };
 }
 
 #[cfg(all(test, not(miri)))]
@@ -278,12 +304,16 @@ mod link_tests {
     __map!(@scatter [TEST_MAP::A] [&'static str, u32] ([TEST_MAP] => pub static BANANA: (&'static str, u32) = ("banana", 2);));
 
     #[test]
-    fn scattered_map_gather_scatter_find() {
+    fn scattered_map_gather_scatter_get() {
         assert_eq!(TEST_MAP.len(), 2);
-        assert_eq!(TEST_MAP.find(&"apple"), Some(&1));
-        assert_eq!(TEST_MAP.find(&"banana"), Some(&2));
-        assert_eq!(TEST_MAP.find(&"orange"), None);
+        assert_eq!(TEST_MAP.get(&"apple"), Some(&1));
+        assert_eq!(TEST_MAP.get(&"banana"), Some(&2));
+        assert_eq!(TEST_MAP.get(&"orange"), None);
         assert!(TEST_MAP.contains_key(&"apple"));
+
+        // This works for a borrow from a string too
+        let apple = String::from("apple");
+        assert_eq!(TEST_MAP.get(apple.as_str()), Some(&1));
     }
 
     struct Record {
@@ -326,10 +356,10 @@ mod link_tests {
     );
 
     #[test]
-    fn test_scattered_map_2() {
-        TEST_MAP_2.find(&"A").unwrap().call();
-        TEST_MAP_2.find(&"B").unwrap().call();
-        TEST_MAP_2.find(&"C").unwrap().call();
+    fn test_scattered_map_large() {
+        TEST_MAP_2.get(&"A").unwrap().call();
+        TEST_MAP_2.get(&"B").unwrap().call();
+        TEST_MAP_2.get(&"C").unwrap().call();
     }
 
     __map!(@gather B pub static EMPTY_MAP: (ScatteredMap)<&'static str, u32>;);
@@ -338,7 +368,7 @@ mod link_tests {
     fn test_empty_scattered_map() {
         assert_eq!(EMPTY_MAP.len(), 0);
         assert!(EMPTY_MAP.is_empty());
-        assert_eq!(EMPTY_MAP.find(&"apple"), None);
+        assert_eq!(EMPTY_MAP.get(&"apple"), None);
         assert!(!EMPTY_MAP.contains_key(&"apple"));
     }
 }

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -74,6 +74,7 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
         Self { state }
     }
 
+    /// Lookup a value by key (deprecated, use `get` instead).
     #[deprecated(since = "0.21.0", note = "Use `get` instead.")]
     #[inline]
     pub fn find<Q>(&self, key: &Q) -> Option<&V>

--- a/scattered-collect/src/set.rs
+++ b/scattered-collect/src/set.rs
@@ -1,4 +1,6 @@
 //! A swiss-table-style set initialized with link-time data.
+use std::borrow::Borrow;
+
 use crate::{
     ScatteredMap,
     hash::ConstHash,
@@ -39,7 +41,11 @@ impl<T: ConstHash + PartialEq + 'static> ScatteredSet<T> {
 
     /// True if the set contains the given key.
     #[inline]
-    pub fn contains(&self, key: &T) -> bool {
+    pub fn contains<Q>(&self, key: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: ConstHash + Eq + ?Sized,
+    {
         self.map.contains_key(key)
     }
 


### PR DESCRIPTION
Various improvements for scattered maps:

- `ScatteredMap` now implements `get` rather than `find` using `Borrow<Q>` instead of `&Q`.
- `ConstHash` now implements `hash` for more string-like types.
- #[allow(...)] no longer breaks #[scatter] attribute parsing.
