### PR TITLE
Fix for `$crate` in gathered types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "ctor",
  "divan",

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.2] - 2026-06-26
+
+### Fixes
+
+- `ScatteredMap` and `ScatteredSet` use type aliases from the `gather`'d
+  collection rather than re-exporting the `gather` macro's type. This fixes
+  issues using $crate in collection types.
+
 ## [0.21.1] - 2026-06-26
 
 ### Changed

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ScatteredMap` and `ScatteredSet` use type aliases from the `gather`'d
   collection rather than re-exporting the `gather` macro's type. This fixes
   issues using $crate in collection types.
+- `ScatteredIterable` cross-module fixes.
 
 ## [0.21.1] - 2026-06-26
 

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/examples/iterable.rs
+++ b/scattered-collect/examples/iterable.rs
@@ -17,6 +17,14 @@ static ITEM_TWO: MyId = MyId(2);
 #[scatter(COLLECTION)]
 static ITEM_THREE: MyId = MyId(3);
 
+// Scatter sites can live in other modules.
+mod other_module {
+    use scattered_collect::scatter;
+
+    #[scatter(crate::COLLECTION)]
+    static ITEM_FOUR: super::MyId = super::MyId(4);
+}
+
 fn main() {
     println!("COLLECTION len: {}", COLLECTION.len());
     println!("ITEM_ONE: {:?}", *ITEM_ONE);

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -172,6 +172,12 @@ impl<T: 'static> ScatteredIterable<T> {
         Self { state }
     }
 
+    /// Register a scattered node with this iterable.
+    #[doc(hidden)]
+    pub fn __submit(&self, node: &'static Ref<T>) {
+        submit(self.state, node);
+    }
+
     /// The number of items in the iterable.
     pub fn len(&self) -> usize {
         self.state.len.load(Ordering::Acquire)
@@ -229,7 +235,7 @@ macro_rules! __iterable {
         $crate::__support::ctor::declarative::ctor!(
             #[ctor(unsafe, anonymous, priority = 0)]
             fn __iterable_submit() {
-                $crate::iterable::submit(&$crate::__iterable_state!($($meta)*), &$name);
+                $($meta)*.__submit(&$name);
             }
         );
     };

--- a/scattered-collect/src/iterable.rs
+++ b/scattered-collect/src/iterable.rs
@@ -222,7 +222,7 @@ macro_rules! __iterable {
             $crate::iterable::ScatteredIterable::new(&$crate::__iterable_state!($name))
         };
     };
-    (@scatter [$collection_name:ident :: $unique:ident] $types:tt ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
         $(#[$imeta])*
         $vis static $name: $crate::iterable::Ref<$ty> = $crate::iterable::Ref::new($expr);
 
@@ -240,9 +240,9 @@ mod tests {
     use crate::iterable::{Ref, ScatteredIterable};
 
     __iterable!(@gather pub static TEST_ITERABLE: (ScatteredIterable)<u32>;);
-    __iterable!(@scatter [TEST_ITERABLE :: A] [u32] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_A: u32 = 1;));
-    __iterable!(@scatter [TEST_ITERABLE :: A] [u32] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_B: u32 = 3;));
-    __iterable!(@scatter [TEST_ITERABLE :: A] [u32] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_C: u32 = 2;));
+    __iterable!(@scatter [TEST_ITERABLE :: A] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_A: u32 = 1;));
+    __iterable!(@scatter [TEST_ITERABLE :: A] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_B: u32 = 3;));
+    __iterable!(@scatter [TEST_ITERABLE :: A] ([TEST_ITERABLE] => pub static ITERABLE_ITEM_C: u32 = 2;));
 
     fn offset_for_value(value: u32) -> usize {
         match value {

--- a/scattered-collect/src/lib.rs
+++ b/scattered-collect/src/lib.rs
@@ -18,6 +18,22 @@ pub use sorted_referenced_slice::ScatteredSortedReferencedSlice;
 pub use sorted_slice::ScatteredSortedSlice;
 
 #[doc(hidden)]
+/// The per-record storage type of a scattered collection.
+pub trait ScatteredElementType {
+    /// The per-record type stored in the collection's link section.
+    type T;
+}
+
+#[doc(hidden)]
+/// The two-component types of a tuple-shaped scattered collection.
+pub trait ScatteredElementTuple {
+    /// The first component (key) type.
+    type A;
+    /// The second component (value) type.
+    type B;
+}
+
+#[doc(hidden)]
 #[macro_export]
 macro_rules! __scatter_parse {
     // Send the #[scatter]'d item into the collection's private macro.
@@ -78,7 +94,7 @@ macro_rules! __gather_parse {
 
         $crate::__support::combine!(output=ident prefix=(#[doc(hidden)] #[macro_export] macro_rules!) input=(__ $name __ $macro __ $unique) suffix=({
             ($passthru:tt) => {
-                $crate::$macro!(@scatter [$name :: $unique] [$($ty)*] $passthru);
+                $crate::$macro!(@scatter [$name :: $unique] $passthru);
             };
         }));
 

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -39,6 +39,15 @@ impl<K, V> MapRecord<K, V> {
     }
 }
 
+impl<K: 'static, V: 'static> crate::ScatteredElementType for ScatteredMap<K, V> {
+    type T = MapRecord<K, V>;
+}
+
+impl<K: 'static, V: 'static> crate::ScatteredElementTuple for ScatteredMap<K, V> {
+    type A = K;
+    type B = V;
+}
+
 impl<K, V> ::core::fmt::Debug for MapRecord<K, V>
 where
     K: ::core::fmt::Debug,
@@ -241,6 +250,11 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
 #[doc(hidden)]
 macro_rules! __map {
     (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($map:tt)*) < $key:ty, $value:ty >;) => {
+        // Type alias for element type projection.
+        #[doc(hidden)]
+        #[allow(unused, non_camel_case_types)]
+        $vis type $name = $($map)* <$key, $value>;
+
         $(#[$meta])*
         $vis static $name: $($map)* <$key, $value> = {
             $crate::__support::link_section::declarative::section!(
@@ -273,13 +287,16 @@ macro_rules! __map {
         };
     };
     // Accept any initializer expression and let the compiler validate its shape
-    // through the typed `let (key, value): (Key, Value) = ...` binding below.
-    (@scatter [$collection_name:ident :: $unique:ident] [$key:ty , $value:ty] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = $init:expr;)) => {
+    // through the typed `let entry: (Key, Value) = ...` binding below.
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = $init:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
             #[in_section(unsafe, name = $collection_name :: $unique, type = typed)]
             $(#[$imeta])*
-            $vis $kind $name: $crate::map::MapRecord<$key, $value> = {
-                let entry: ($key, $value) = $init;
+            $vis $kind $name: <$($meta)* as $crate::ScatteredElementType>::T = {
+                let entry: (
+                    <$($meta)* as $crate::ScatteredElementTuple>::A,
+                    <$($meta)* as $crate::ScatteredElementTuple>::B,
+                ) = $init;
                 // Check against both types: local and collection
                 let _: &$ty = &entry;
                 let (key, value) = entry;
@@ -291,7 +308,7 @@ macro_rules! __map {
             const _: $crate::map::MapMetadataChunk = $crate::map::MAP_METADATA_CHUNK_ZERO;
         );
     };
-    (@scatter [$collection_name:ident :: $unique:ident] [$key:ty , $value:ty] ([$($meta:tt)*] => $($rest:tt)*)) => {
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $($rest:tt)*)) => {
         ::core::compile_error!(
             "invalid #[scatter] syntax for ScatteredMap: expected \
              `static NAME: (Key, Value) = <expr>;` where `<expr>` resolves to a \
@@ -305,8 +322,8 @@ mod link_tests {
     use crate::ScatteredMap;
 
     __map!(@gather A pub static TEST_MAP: (ScatteredMap)<&'static str, u32>;);
-    __map!(@scatter [TEST_MAP::A] [&'static str, u32] ([TEST_MAP] => pub static APPLE: (&'static str, u32) = ("apple", 1);));
-    __map!(@scatter [TEST_MAP::A] [&'static str, u32] ([TEST_MAP] => pub static BANANA: (&'static str, u32) = ("banana", 2);));
+    __map!(@scatter [TEST_MAP::A] ([TEST_MAP] => pub static APPLE: (&'static str, u32) = ("apple", 1);));
+    __map!(@scatter [TEST_MAP::A] ([TEST_MAP] => pub static BANANA: (&'static str, u32) = ("banana", 2);));
 
     #[test]
     fn scattered_map_gather_scatter_get() {
@@ -341,7 +358,7 @@ mod link_tests {
     macro_rules! make_test {
         ($($name:ident)*) => {
             $(
-            __map!(@scatter [TEST_MAP_2::A] [&'static str, Record] ([TEST_MAP_2] => pub static
+            __map!(@scatter [TEST_MAP_2::A] ([TEST_MAP_2] => pub static
                 $name: (&'static str, Record) = (
                     stringify!($name),
                     Record::new(stringify!($name), |_key| println!(stringify!($name)))
@@ -370,7 +387,7 @@ mod link_tests {
     // A `const` block initializer that resolves to a `(key, value)` tuple is
     // accepted just like a direct tuple literal.
     __map!(@gather C pub static BLOCK_MAP: (ScatteredMap)<&'static str, u32>;);
-    __map!(@scatter [BLOCK_MAP::C] [&'static str, u32] ([BLOCK_MAP] => pub static CHERRY: (&'static str, u32) = {
+    __map!(@scatter [BLOCK_MAP::C] ([BLOCK_MAP] => pub static CHERRY: (&'static str, u32) = {
         const KEY: &str = "cherry";
         (KEY, 3)
     };));

--- a/scattered-collect/src/referenced_slice.rs
+++ b/scattered-collect/src/referenced_slice.rs
@@ -75,7 +75,7 @@ macro_rules! __referenced_slice {
             }
         };
     };
-    (@scatter [$collection_name:ident :: $unique:ident] $types:tt ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
             #[in_section(unsafe, name = $collection_name :: $unique, type = reference)]
             $vis static $name: $ty = $expr;
@@ -88,9 +88,9 @@ mod tests {
     use crate::referenced_slice::ScatteredReferencedSlice;
 
     __referenced_slice!(@gather A pub static TEST_REF_SLICE: (ScatteredReferencedSlice)<u32>;);
-    __referenced_slice!(@scatter [TEST_REF_SLICE::A] [u32] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_A: u32 = 1;));
-    __referenced_slice!(@scatter [TEST_REF_SLICE::A] [u32] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_B: u32 = 3;));
-    __referenced_slice!(@scatter [TEST_REF_SLICE::A] [u32] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_C: u32 = 2;));
+    __referenced_slice!(@scatter [TEST_REF_SLICE::A] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_A: u32 = 1;));
+    __referenced_slice!(@scatter [TEST_REF_SLICE::A] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_B: u32 = 3;));
+    __referenced_slice!(@scatter [TEST_REF_SLICE::A] ([TEST_REF_SLICE] => pub static REF_SLICE_ITEM_C: u32 = 2;));
 
     #[test]
     fn test_scattered_referenced_slice() {

--- a/scattered-collect/src/set.rs
+++ b/scattered-collect/src/set.rs
@@ -108,10 +108,19 @@ impl<T: ConstHash + 'static> SetRecord<T> {
     }
 }
 
+impl<K: 'static> crate::ScatteredElementType for ScatteredSet<K> {
+    type T = SetRecord<K>;
+}
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __set {
     (@gather $unique:ident $(#[$meta:meta])* $vis:vis static $name:ident: ($($set:tt)*) < $key:ty >;) => {
+        // Type alias for element type projection.
+        #[doc(hidden)]
+        #[allow(unused, non_camel_case_types)]
+        $vis type $name = $($set)* <$key>;
+
         $(#[$meta])*
         $vis static $name: $($set)* <$key> = {
             $crate::__support::link_section::declarative::section!(
@@ -143,11 +152,11 @@ macro_rules! __set {
             $crate::set::ScatteredSet::__new(&__MAP_STATE)
         };
     };
-    (@scatter [$collection_name:ident :: $unique:ident] [$key:ty] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = $key_expr:expr;)) => {
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $kind:ident $name:tt: $ty:ty = $key_expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
             #[in_section(unsafe, name = $collection_name :: $unique, type = typed)]
             $(#[$imeta])*
-            $vis $kind $name: $crate::set::SetRecord<$key> = $crate::set::SetRecord::new(
+            $vis $kind $name: <$($meta)* as $crate::ScatteredElementType>::T = $crate::set::SetRecord::new(
                 $key_expr,
                 $crate::const_hash!($key_expr)
             );

--- a/scattered-collect/src/slice.rs
+++ b/scattered-collect/src/slice.rs
@@ -47,7 +47,7 @@ macro_rules! __slice {
         };
     };
 
-    (@scatter [$collection_name:ident :: $unique:ident] $types:tt ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
             #[in_section(unsafe, name = $collection_name :: $unique, type = typed)]
             $(#[$imeta])*
@@ -61,9 +61,9 @@ mod tests {
     pub use super::ScatteredSlice;
 
     __slice!(@gather A pub static TEST_SLICE: (ScatteredSlice)<u32>;);
-    __slice!(@scatter [TEST_SLICE :: A] [u32] ([TEST_SLICE] => const _: u32 = 1;));
-    __slice!(@scatter [TEST_SLICE :: A] [u32] ([TEST_SLICE] => const _: u32 = 3;));
-    __slice!(@scatter [TEST_SLICE :: A] [u32] ([TEST_SLICE] => const _: u32 = 2;));
+    __slice!(@scatter [TEST_SLICE :: A] ([TEST_SLICE] => const _: u32 = 1;));
+    __slice!(@scatter [TEST_SLICE :: A] ([TEST_SLICE] => const _: u32 = 3;));
+    __slice!(@scatter [TEST_SLICE :: A] ([TEST_SLICE] => const _: u32 = 2;));
 
     #[test]
     fn test_scattered_slice() {

--- a/scattered-collect/src/sorted_referenced_slice.rs
+++ b/scattered-collect/src/sorted_referenced_slice.rs
@@ -99,7 +99,7 @@ macro_rules! __sorted_referenced_slice {
             }
         };
     };
-    (@scatter [$collection_name:ident :: $unique:ident] $types:tt ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis static $name:ident: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
             #[in_section(unsafe, name = $collection_name :: $unique, type = movable)]
             $(#[$imeta])*
@@ -113,9 +113,9 @@ mod tests {
     use crate::sorted_referenced_slice::{Ref, ScatteredSortedReferencedSlice};
 
     __sorted_referenced_slice!(@gather A pub static TEST_SORT_REF: (ScatteredSortedReferencedSlice)<u32>;);
-    __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] [u32] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_A: u32 = 1;));
-    __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] [u32] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_B: u32 = 3;));
-    __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] [u32] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_C: u32 = 2;));
+    __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_A: u32 = 1;));
+    __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_B: u32 = 3;));
+    __sorted_referenced_slice!(@scatter [TEST_SORT_REF::A] ([TEST_SORT_REF] => pub static SORT_REF_ITEM_C: u32 = 2;));
 
     #[test]
     fn test_scattered_sorted_referenced_slice() {

--- a/scattered-collect/src/sorted_slice.rs
+++ b/scattered-collect/src/sorted_slice.rs
@@ -90,7 +90,7 @@ macro_rules! __sorted_slice {
         };
     };
 
-    (@scatter [$collection_name:ident :: $unique:ident] $types:tt ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
+    (@scatter [$collection_name:ident :: $unique:ident] ([$($meta:tt)*] => $(#[$imeta:meta])* $vis:vis $type:ident $name:tt: $ty:ty = $expr:expr;)) => {
         $crate::__support::link_section::declarative::in_section!(
             #[in_section(unsafe, name = $collection_name :: $unique, type = mutable)]
             $(#[$imeta])*
@@ -104,12 +104,12 @@ mod tests {
     pub use super::ScatteredSortedSlice;
 
     __sorted_slice!(@gather A pub static TEST_SORTED_SLICE: (ScatteredSortedSlice)<u32>;);
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 6;));
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 3;));
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 2;));
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 4;));
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 5;));
-    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] [u32] ([TEST_SORTED_SLICE] => const _: u32 = 1;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] ([TEST_SORTED_SLICE] => const _: u32 = 6;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] ([TEST_SORTED_SLICE] => const _: u32 = 3;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] ([TEST_SORTED_SLICE] => const _: u32 = 2;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] ([TEST_SORTED_SLICE] => const _: u32 = 4;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] ([TEST_SORTED_SLICE] => const _: u32 = 5;));
+    __sorted_slice!(@scatter [TEST_SORTED_SLICE::A] ([TEST_SORTED_SLICE] => const _: u32 = 1;));
 
     #[test]
     fn test_scattered_sorted_slice() {


### PR DESCRIPTION
`ScatteredMap` and `ScatteredSet` were re-using a raw type which would be re-evaluated at each submission site. `ScatteredIterable` was also broken cross-crate.