### PR TITLE
Bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "libc-print",
  "link-section",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.18.3"
+version = "0.19.0"
 dependencies = [
  "linktime-proc-macro",
  "macrotest",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "linktime"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ctor",
  "dtor",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "ctor",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,10 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.7", default-features = false }
+ctor = { path = "ctor", version = "1.0.8", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
-link-section = { path = "link-section", version = "0.18.3", default-features = false }
-linktime = { path = "linktime", version = "0.17.0", default-features = false }
+link-section = { path = "link-section", version = "0.19.0", default-features = false }
+linktime = { path = "linktime", version = "0.18.0", default-features = false }
+scattered-collect = { path = "scattered-collect", version = "0.21.3" }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }
-
-scattered-collect = { path = "scattered-collect", version = "0.21.0" }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2026-07-06
+
+### Changed
+
+- Bump `link-section` dependency to 0.19.0.
+
 ## [1.0.7] - 2026-05-28
 
 ### Changed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.7"
+version = "1.0.8"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.19.0] - 2026-07-06
 
 ### Fixed
 

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.18.3"
+version = "0.19.0"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/linktime/CHANGELOG.md
+++ b/linktime/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-07-06
+
+- Bumped `ctor`, `dtor` and `link-section` dependencies.
+
 ## [0.17.0] - 2026-05-28
 
 - Bumped `ctor`, `dtor` and `link-section` dependencies.

--- a/linktime/Cargo.toml
+++ b/linktime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linktime"
-version = "0.17.0"
+version = "0.18.0"
 authors.workspace = true
 edition = "2021"
 description = "Link-time registration patterns for Rust (ctors, dtors, link-time slices and sections)"

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.3] - 2026-07-06
+
+- Bumped `link-section` dependency to 0.19.0 to fix WASM LTO issues.
+
 ## [0.21.2] - 2026-06-26
 
 ### Fixes

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2024"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
`link-section` gets a new minor bump to fix #488 so we need patches for everything else. 