### PR TITLE
Make hashes more stable w.r.t link-section token ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,16 +132,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
 dependencies = [
  "link-section 0.19.0",
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linktime-proc-macro 0.2.0",
 ]
 
 [[package]]
 name = "ctor"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "libc-print",
- "link-section 0.19.1",
- "linktime-proc-macro 0.2.0",
+ "link-section 0.19.2",
+ "linktime-proc-macro 0.2.1",
  "macrotest",
  "tempfile",
  "trybuild",
@@ -246,7 +246,7 @@ name = "dtor"
 version = "1.0.5"
 dependencies = [
  "libc-print",
- "linktime-proc-macro 0.2.0",
+ "linktime-proc-macro 0.2.1",
  "macrotest",
  "tempfile",
  "trybuild",
@@ -259,7 +259,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d738e43aa64edab57c983d56de890d65fea7dc05605490c74451ce721dfd84b"
 dependencies = [
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linktime-proc-macro 0.2.0",
 ]
 
 [[package]]
@@ -421,14 +421,14 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
 dependencies = [
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linktime-proc-macro 0.2.0",
 ]
 
 [[package]]
 name = "link-section"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
- "linktime-proc-macro 0.2.0",
+ "linktime-proc-macro 0.2.1",
  "macrotest",
  "tempfile",
  "trybuild",
@@ -439,11 +439,11 @@ dependencies = [
 name = "linktime"
 version = "0.18.0"
 dependencies = [
- "ctor 1.0.11",
+ "ctor 1.0.12",
  "dtor 1.0.5",
  "libc-print",
- "link-section 0.19.1",
- "linktime-proc-macro 0.2.0",
+ "link-section 0.19.2",
+ "linktime-proc-macro 0.2.1",
 ]
 
 [[package]]
@@ -455,18 +455,18 @@ dependencies = [
  "ctor 1.0.9",
  "dtor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "link-section 0.19.0",
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linktime-proc-macro 0.2.0",
 ]
-
-[[package]]
-name = "linktime-proc-macro"
-version = "0.2.0"
 
 [[package]]
 name = "linktime-proc-macro"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -683,11 +683,11 @@ dependencies = [
 name = "scattered-collect"
 version = "0.21.3"
 dependencies = [
- "ctor 1.0.11",
+ "ctor 1.0.12",
  "divan",
- "link-section 0.19.1",
+ "link-section 0.19.2",
  "linktime 0.18.0",
- "linktime-proc-macro 0.2.0",
+ "linktime-proc-macro 0.2.1",
  "scattered-collect 0.21.3",
  "trybuild",
  "wide",
@@ -703,7 +703,7 @@ dependencies = [
  "ctor 1.0.9",
  "link-section 0.19.0",
  "linktime 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linktime-proc-macro 0.2.0",
  "wide",
  "xxhash-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.11", default-features = false }
+ctor = { path = "ctor", version = "1.0.12", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
-link-section = { path = "link-section", version = "0.19.1", default-features = false }
+link-section = { path = "link-section", version = "0.19.2", default-features = false }
 linktime = { path = "linktime", version = "0.18.0", default-features = false }
 scattered-collect = { path = "scattered-collect", version = "0.21.3" }
 
-linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.0" }
+linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.1" }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `linktime-proc-macro` dependency to 0.2.1 (makes link-section names more stable).
-- Internal changes to make doctests work more reliably for packagers.
 
 ## [1.0.11] - 2026-07-26
 

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.12] - 2026-07-29
+
+### Changed
+
+- Bump `linktime-proc-macro` dependency to 0.2.1 (makes link-section names more stable).
+- Internal changes to make doctests work more reliably for packagers.
+
 ## [1.0.11] - 2026-07-26
 
 ### Fixed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.11"
+version = "1.0.12"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - 2026-07-29
+
+### Changed
+
+- Bump `linktime-proc-macro` dependency to 0.2.1 (makes link-section names more stable).
+
 ## [0.19.1] - 2026-07-15
 
 ### Fixed

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.19.1"
+version = "0.19.2"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -193,7 +193,8 @@ pub mod __support {
                 )
             ))
         };
-        // Safe sections are always hashed.
+        // Safe sections are always hashed. Note: `ignore_base` below avoids
+        // churn on the expansion tests.
         ($definition:tt $prefix:tt $name:tt $suffix:tt $hash_length:literal $max_length:literal $valid_section_chars:literal) => {
             $crate::__support::combine!(output=string input=(
                 $prefix
@@ -201,12 +202,6 @@ pub mod __support {
                     __SUBSTRING__(input=(
                         __TOIDENT__(input=(__RAW__(input=($name))))
                     ) end=(__SUB__(a=$max_length b=$hash_length)))
-                    // Hash the location information for the full definition and
-                    // computed name. Tokens synthesized within link-section
-                    // itself (separators, group wrappers, ...) carry this
-                    // crate's own spans (ignore_base is used to ignore
-                    // file/line/column for link-section tokens for a more
-                    // stable identity).
                     __LOCATIONHASH__(of=($definition $name) alphabet=[_0-9a-zA-Z] ignore_base=("src/lib.rs"))
                 ) length=$max_length)
                 $suffix

--- a/link-section/src/lib.rs
+++ b/link-section/src/lib.rs
@@ -201,9 +201,13 @@ pub mod __support {
                     __SUBSTRING__(input=(
                         __TOIDENT__(input=(__RAW__(input=($name))))
                     ) end=(__SUB__(a=$max_length b=$hash_length)))
-                    // Hash the location information for the full
-                    // definition and computed name.
-                    __LOCATIONHASH__(of=($definition $name) alphabet=[_0-9a-zA-Z])
+                    // Hash the location information for the full definition and
+                    // computed name. Tokens synthesized within link-section
+                    // itself (separators, group wrappers, ...) carry this
+                    // crate's own spans (ignore_base is used to ignore
+                    // file/line/column for link-section tokens for a more
+                    // stable identity).
+                    __LOCATIONHASH__(of=($definition $name) alphabet=[_0-9a-zA-Z] ignore_base=("src/lib.rs"))
                 ) length=$max_length)
                 $suffix
             ))

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -581,7 +581,7 @@ impl LinkSectionMovableInfo {
         }
     }
 
-    /// The flattened backref range. Only valid once [`materialise_with`] has run.
+    /// The flattened backref range. Only valid once [`LinkSectionInfo::materialise_with`] has run.
     fn backrefs_range(&self) -> SectionRange {
         SectionRange::new(self.backrefs_start, self.backrefs_end)
     }

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -19,7 +19,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$start$__DATA$FOO8uHtVN3Ttdb"]
+                            #[link_name = "\u{1}section$start$__DATA$FOObh0r0BSfLQP"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -27,14 +27,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "\u{1}section$end$__DATA$FOO8uHtVN3Ttdb"]
+                            #[link_name = "\u{1}section$end$__DATA$FOObh0r0BSfLQP"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "__DATA,FOO8uHtVN3Ttdb";
+            let name = "__DATA,FOObh0r0BSfLQP";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -76,7 +76,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "__DATA,FOO8uHtVN3Ttdb,regular,no_dead_strip"]
+        #[link_section = "__DATA,FOObh0r0BSfLQP,regular,no_dead_strip"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/link-section/tests/expand-linux/link_section.expanded.rs
+++ b/link-section/tests/expand-linux/link_section.expanded.rs
@@ -20,7 +20,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__start__data_link_section_FOO8uHtVN3Ttdb"]
+                            #[link_name = "__start__data_link_section_FOObh0r0BSfLQP"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -28,14 +28,14 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "__stop__data_link_section_FOO8uHtVN3Ttdb"]
+                            #[link_name = "__stop__data_link_section_FOObh0r0BSfLQP"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
                     },
                 )
             };
-            let name = "_data_link_section_FOO8uHtVN3Ttdb";
+            let name = "_data_link_section_FOObh0r0BSfLQP";
             ::link_section::__support::validate_section_name(name);
             unsafe { <TypedSection<fn()>>::new(name, section) }
         };
@@ -77,7 +77,7 @@ fn foo() {
         type __InSecStoredTy = <FOO as ::link_section::__support::SectionItemType>::Item;
         const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = foo;
         #[used]
-        #[link_section = "_data_link_section_FOO8uHtVN3Ttdb"]
+        #[link_section = "_data_link_section_FOObh0r0BSfLQP"]
         static __LINK_SECTION_CONST_ITEM: __InSecStoredTy = __LINK_SECTION_CONST_ITEM_VALUE;
         __LINK_SECTION_CONST_ITEM_VALUE
     };

--- a/linktime-proc-macro/Cargo.toml
+++ b/linktime-proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linktime-proc-macro"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition = "2021"
 description = "proc-macro helpers for linktime crates (ctors, dtors, linker sections)"

--- a/linktime-proc-macro/src/combine/mod.rs
+++ b/linktime-proc-macro/src/combine/mod.rs
@@ -1,11 +1,13 @@
 mod args;
 
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use proc_macro::{Group, Ident, Literal, Span, TokenStream, TokenTree};
 
 use self::args::{
-    parse_arguments, pop_argument, pop_optional_argument, OutputType, PatternString,
+    parse_arguments, pop_argument, pop_optional_argument, Argument, OutputType, PatternString,
     TranslateString,
 };
 
@@ -118,6 +120,41 @@ fn parse_stream(s: &mut String, arg: &str, output: OutputType, input: TokenStrea
     }
 }
 
+/// Resolve the optional `ignore_base` argument of `__LOCATIONHASH__` into a base
+/// directory.
+///
+/// The argument is a single token (typically a string literal such as
+/// `"src/lib.rs"`) written in the source of the crate whose tokens should be
+/// treated as position-independent. Its *span* yields that crate's local file
+/// path and its *string value* is the suffix to strip off the end, leaving the
+/// base directory. Any token whose local file lives under that directory is then
+/// hashed by content rather than by location.
+///
+/// Returns `None` (i.e. "ignore nothing") when the marker has no local file
+/// (older compilers or remapped paths), when the path does not actually end with
+/// the given suffix, or when stripping it would yield a degenerate base (empty or
+/// filesystem root) that would match every token.
+fn pop_ignore_base(args: &mut HashMap<String, TokenTree>, ident: &str) -> Option<PathBuf> {
+    let token = args.remove("ignore_base")?;
+    let span = <Span as Argument>::from_token_tree(token.clone())
+        .unwrap_or_else(|e| panic!("{ident}: Invalid argument 'ignore_base': {e}"));
+    let suffix = <String as Argument>::from_token_tree(token)
+        .unwrap_or_else(|e| panic!("{ident}: Invalid argument 'ignore_base': {e}"));
+
+    let file = crate::fallback::local_file(&span)?;
+    if !file.ends_with(&suffix) {
+        return None;
+    }
+    // Strip one ancestor per component of the suffix to reach the base directory.
+    let components = Path::new(&suffix).components().count();
+    let base = file.ancestors().nth(components)?;
+    // Refuse degenerate bases that would match every token.
+    if base.as_os_str().is_empty() || base.parent().is_none() {
+        return None;
+    }
+    Some(base.to_path_buf())
+}
+
 fn parse_function(
     s: &mut String,
     arg: &str,
@@ -187,7 +224,8 @@ fn parse_function(
         "LOCATIONHASH" => {
             let input = pop_argument::<TokenStream>(&mut args, ident, "of");
             let alphabet = pop_optional_argument::<TranslateString>(&mut args, ident, "alphabet");
-            let mut hash = crate::hash::location_hash(input);
+            let ignore_base = pop_ignore_base(&mut args, ident);
+            let mut hash = crate::hash::location_hash(input, ignore_base.as_deref());
             if let Some(alphabet) = alphabet {
                 if hash == 0 {
                     s.push(alphabet.char(0));

--- a/linktime-proc-macro/src/combine/mod.rs
+++ b/linktime-proc-macro/src/combine/mod.rs
@@ -120,20 +120,13 @@ fn parse_stream(s: &mut String, arg: &str, output: OutputType, input: TokenStrea
     }
 }
 
-/// Resolve the optional `ignore_base` argument of `__LOCATIONHASH__` into a base
+/// Resolve `__LOCATIONHASH__`'s optional `ignore_base` into a crate-root
 /// directory.
 ///
-/// The argument is a single token (typically a string literal such as
-/// `"src/lib.rs"`) written in the source of the crate whose tokens should be
-/// treated as position-independent. Its *span* yields that crate's local file
-/// path and its *string value* is the suffix to strip off the end, leaving the
-/// base directory. Any token whose local file lives under that directory is then
-/// hashed by content rather than by location.
-///
-/// Returns `None` (i.e. "ignore nothing") when the marker has no local file
-/// (older compilers or remapped paths), when the path does not actually end with
-/// the given suffix, or when stripping it would yield a degenerate base (empty or
-/// filesystem root) that would match every token.
+/// The marker token's span locates the crate and its string value is a path
+/// suffix stripped to reach that crate's root. Returns `None` (ignore nothing)
+/// when `local_file` is unavailable, the suffix does not match, or the base
+/// would be empty/filesystem-root (would match every token).
 fn pop_ignore_base(args: &mut HashMap<String, TokenTree>, ident: &str) -> Option<PathBuf> {
     let token = args.remove("ignore_base")?;
     let span = <Span as Argument>::from_token_tree(token.clone())
@@ -145,10 +138,8 @@ fn pop_ignore_base(args: &mut HashMap<String, TokenTree>, ident: &str) -> Option
     if !file.ends_with(&suffix) {
         return None;
     }
-    // Strip one ancestor per component of the suffix to reach the base directory.
     let components = Path::new(&suffix).components().count();
     let base = file.ancestors().nth(components)?;
-    // Refuse degenerate bases that would match every token.
     if base.as_os_str().is_empty() || base.parent().is_none() {
         return None;
     }

--- a/linktime-proc-macro/src/fallback.rs
+++ b/linktime-proc-macro/src/fallback.rs
@@ -1,7 +1,7 @@
 #![allow(unstable_name_collisions)] // Intentional!
 
 use proc_macro::Span;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Trait providing a fallback method for `Span` methods.
 #[allow(unused)]
@@ -9,6 +9,7 @@ pub(crate) trait FallbackSpan {
     fn line(&self) -> usize;
     fn column(&self) -> usize;
     fn file(&self) -> String;
+    fn local_file(&self) -> Option<PathBuf>;
     fn source_text(&self) -> Option<String>;
 }
 
@@ -26,6 +27,10 @@ impl FallbackSpan for &Span {
     #[inline(always)]
     fn file(&self) -> String {
         String::new()
+    }
+    #[inline(always)]
+    fn local_file(&self) -> Option<PathBuf> {
+        None
     }
     #[inline(always)]
     fn source_text(&self) -> Option<String> {
@@ -59,6 +64,11 @@ pub(crate) fn file(span: &Span) -> String {
 #[inline(always)]
 pub(crate) fn line(span: &Span) -> usize {
     span.line()
+}
+
+#[inline(always)]
+pub(crate) fn local_file(span: &Span) -> Option<PathBuf> {
+    span.local_file()
 }
 
 #[inline(always)]

--- a/linktime-proc-macro/src/hash/mod.rs
+++ b/linktime-proc-macro/src/hash/mod.rs
@@ -50,6 +50,7 @@ fn token_content(token: &TokenTree) -> String {
 /// makes the hash stable against source movement within the "ignored" crate
 /// (e.g. the tokens a declarative macro synthesizes at its own definition site),
 /// while still distinguishing genuinely different tokens.
+#[allow(clippy::unnecessary_map_or)]
 pub(crate) fn location_hash(tokens: TokenStream, ignore_base: Option<&Path>) -> u64 {
     let iterator = TokenTreeDeepIterator {
         stack: vec![tokens.into_iter()],

--- a/linktime-proc-macro/src/hash/mod.rs
+++ b/linktime-proc-macro/src/hash/mod.rs
@@ -63,8 +63,8 @@ pub(crate) fn location_hash(tokens: TokenStream, ignore_base: Option<&Path>) -> 
         buffer.clear();
         buffer.extend_from_slice(&last_hash.to_be_bytes());
 
-        let ignored = ignore_base.is_some_and(|base| {
-            crate::fallback::local_file(&span).is_some_and(|file| file.starts_with(base))
+        let ignored = ignore_base.map_or(false, |base| {
+            crate::fallback::local_file(&span).map_or(false, |file| file.starts_with(base))
         });
 
         if ignored {

--- a/linktime-proc-macro/src/hash/mod.rs
+++ b/linktime-proc-macro/src/hash/mod.rs
@@ -25,10 +25,9 @@ impl Iterator for TokenTreeDeepIterator {
     }
 }
 
-/// A stable, position-independent identity for a single token: its own textual
-/// content (for leaves) or its delimiter (for groups). Group contents are
-/// visited separately by the deep iterator, so the delimiter alone is enough to
-/// keep groups distinct without pulling in the (potentially large) subtree.
+/// Content (position-independent) identity for an ignored token. Groups
+/// contribute only their delimiter and the deep iterator visits children
+/// separately.
 fn token_content(token: &TokenTree) -> String {
     match token {
         TokenTree::Group(group) => match group.delimiter() {
@@ -43,13 +42,8 @@ fn token_content(token: &TokenTree) -> String {
     }
 }
 
-/// Hashes the location (file/line/column) of every token within `tokens`.
-///
-/// If `ignore_base` is set, any token whose local source file lives under that
-/// base directory contributes its textual content instead of its location. This
-/// makes the hash stable against source movement within the "ignored" crate
-/// (e.g. the tokens a declarative macro synthesizes at its own definition site),
-/// while still distinguishing genuinely different tokens.
+/// Hash location of every token in `tokens`. Tokens under `ignore_base` contribute
+/// content instead, so def-site spans from that crate don't shift the hash.
 #[allow(clippy::unnecessary_map_or)]
 pub(crate) fn location_hash(tokens: TokenStream, ignore_base: Option<&Path>) -> u64 {
     let iterator = TokenTreeDeepIterator {
@@ -69,8 +63,6 @@ pub(crate) fn location_hash(tokens: TokenStream, ignore_base: Option<&Path>) -> 
         });
 
         if ignored {
-            // Content-only: neutralize file/line/column so edits to the ignored
-            // crate's own source don't perturb the hash.
             buffer.extend_from_slice(token_content(&token).as_bytes());
         } else {
             let line = crate::fallback::line(&span);

--- a/linktime-proc-macro/src/hash/mod.rs
+++ b/linktime-proc-macro/src/hash/mod.rs
@@ -1,4 +1,5 @@
-use proc_macro::{Span, TokenStream, TokenTree};
+use proc_macro::{Delimiter, TokenStream, TokenTree};
+use std::path::Path;
 
 pub(crate) mod xx3;
 
@@ -7,7 +8,7 @@ struct TokenTreeDeepIterator {
 }
 
 impl Iterator for TokenTreeDeepIterator {
-    type Item = Span;
+    type Item = TokenTree;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -16,43 +17,70 @@ impl Iterator for TokenTreeDeepIterator {
                 continue;
             };
             self.stack.push(iter);
-            match token {
-                TokenTree::Group(group) => {
-                    self.stack.push(group.stream().into_iter());
-                    return Some(group.span());
-                }
-                _ => return Some(token.span()),
+            if let TokenTree::Group(group) = &token {
+                self.stack.push(group.stream().into_iter());
             }
+            return Some(token);
         }
     }
 }
 
-pub(crate) fn location_hash(tokens: TokenStream) -> u64 {
+/// A stable, position-independent identity for a single token: its own textual
+/// content (for leaves) or its delimiter (for groups). Group contents are
+/// visited separately by the deep iterator, so the delimiter alone is enough to
+/// keep groups distinct without pulling in the (potentially large) subtree.
+fn token_content(token: &TokenTree) -> String {
+    match token {
+        TokenTree::Group(group) => match group.delimiter() {
+            Delimiter::Parenthesis => "(".to_string(),
+            Delimiter::Brace => "{".to_string(),
+            Delimiter::Bracket => "[".to_string(),
+            Delimiter::None => String::new(),
+        },
+        TokenTree::Ident(ident) => ident.to_string(),
+        TokenTree::Punct(punct) => punct.as_char().to_string(),
+        TokenTree::Literal(literal) => literal.to_string(),
+    }
+}
+
+/// Hashes the location (file/line/column) of every token within `tokens`.
+///
+/// If `ignore_base` is set, any token whose local source file lives under that
+/// base directory contributes its textual content instead of its location. This
+/// makes the hash stable against source movement within the "ignored" crate
+/// (e.g. the tokens a declarative macro synthesizes at its own definition site),
+/// while still distinguishing genuinely different tokens.
+pub(crate) fn location_hash(tokens: TokenStream, ignore_base: Option<&Path>) -> u64 {
     let iterator = TokenTreeDeepIterator {
         stack: vec![tokens.into_iter()],
     };
 
     // TODO: Can we avoid doing multiple hashes?
-    let mut buffer = [0_u8; 1024];
+    let mut buffer: Vec<u8> = Vec::with_capacity(1024);
     let mut last_hash = 0_u64;
-    for span in iterator {
-        let hash = last_hash.to_be_bytes();
-        let line = crate::fallback::line(&span).to_be_bytes();
-        let column = crate::fallback::column(&span).to_be_bytes();
-        let file = crate::fallback::file(&span);
-        let mut len = 0;
+    for token in iterator {
+        let span = token.span();
+        buffer.clear();
+        buffer.extend_from_slice(&last_hash.to_be_bytes());
 
-        for buf in [
-            hash.as_slice(),
-            line.as_slice(),
-            column.as_slice(),
-            file.as_bytes(),
-        ] {
-            buffer[len..len + buf.len()].copy_from_slice(buf);
-            len += buf.len();
+        let ignored = ignore_base.is_some_and(|base| {
+            crate::fallback::local_file(&span).is_some_and(|file| file.starts_with(base))
+        });
+
+        if ignored {
+            // Content-only: neutralize file/line/column so edits to the ignored
+            // crate's own source don't perturb the hash.
+            buffer.extend_from_slice(token_content(&token).as_bytes());
+        } else {
+            let line = crate::fallback::line(&span);
+            let column = crate::fallback::column(&span);
+            let file = crate::fallback::file(&span);
+            buffer.extend_from_slice(&line.to_be_bytes());
+            buffer.extend_from_slice(&column.to_be_bytes());
+            buffer.extend_from_slice(file.as_bytes());
         }
 
-        last_hash = crate::hash::xx3::xx3hash_bytes(&buffer[..len]);
+        last_hash = crate::hash::xx3::xx3hash_bytes(&buffer);
     }
 
     last_hash

--- a/linktime-proc-macro/src/lib.rs
+++ b/linktime-proc-macro/src/lib.rs
@@ -141,7 +141,7 @@ generators! {
 ///    particular crate, useful when `of` contains tokens synthesized by a
 ///    declarative macro (separators, group wrappers, ...) that carry that
 ///    crate's own def-site spans.
-/// ```rust
+/// ```rust,ignore
 /// # use linktime_proc_macro::combine;
 /// let location_hash = combine!(output=string input=("location_hash:" __LOCATIONHASH__(of=(a bunch of tokens) alphabet=[a-z])));
 /// assert_eq!(location_hash, "location_hash:dwsrxapjetrwwu");

--- a/linktime-proc-macro/src/lib.rs
+++ b/linktime-proc-macro/src/lib.rs
@@ -137,10 +137,9 @@ generators! {
 ///    using the characters in the `alphabet`. No zero padding is applied in this
 ///    case.
 ///
-///    `ignore_base` makes the hash stable against source movement within a
-///    particular crate, useful when `of` contains tokens synthesized by a
-///    declarative macro (separators, group wrappers, ...) that carry that
-///    crate's own def-site spans.
+///    `ignore_base` hashes tokens from that crate by content instead of location,
+///    so macro-synthesized def-site spans don't shift the hash when that crate
+///    is edited.
 /// ```rust,ignore
 /// # use linktime_proc_macro::combine;
 /// let location_hash = combine!(output=string input=("location_hash:" __LOCATIONHASH__(of=(a bunch of tokens) alphabet=[a-z])));

--- a/linktime-proc-macro/src/lib.rs
+++ b/linktime-proc-macro/src/lib.rs
@@ -131,11 +131,16 @@ generators! {
 /// assert_eq!(file, "file:linktime-proc-macro/src/lib.rs:6:110");
 /// ```
 ///
-///  - `__LOCATIONHASH__(of=token, alphabet=[chars...])`: Returns a hash of
-///    location information for all tokens within the tree of `token`. If
-///    `alphabet` is specified, the hash is converted to a string using the
-///    characters in the `alphabet`. No zero padding is applied in this case.
+///  - `__LOCATIONHASH__(of=token, alphabet=[chars...], ignore_base=token)`:
+///    Returns a hash of location information for all tokens within the tree of
+///    `token`. If `alphabet` is specified, the hash is converted to a string
+///    using the characters in the `alphabet`. No zero padding is applied in this
+///    case.
 ///
+///    `ignore_base` makes the hash stable against source movement within a
+///    particular crate, useful when `of` contains tokens synthesized by a
+///    declarative macro (separators, group wrappers, ...) that carry that
+///    crate's own def-site spans.
 /// ```rust
 /// # use linktime_proc_macro::combine;
 /// let location_hash = combine!(output=string input=("location_hash:" __LOCATIONHASH__(of=(a bunch of tokens) alphabet=[a-z])));


### PR DESCRIPTION
Recent PRs have required updating the hashes of the expansion tests because we're too sensitive to file location of tokens inside link-section.