### PR TITLE
Register the ctor dispatcher from the expansion site (Apple + `priority`)

### DIFF
--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -86,6 +86,23 @@ pub mod collect {
     ///
     /// If another copy of this function is running, we will return early, but
     /// the constructors will not have been guaranteed to have run.
+    /// The `extern "C"` entry point registered as a real initializer by each
+    /// `#[ctor]` expansion site. Registering from the expansion site -- rather
+    /// than only from this crate's own object -- keeps the registration in an
+    /// object the linker is already loading, which is what makes constructors
+    /// survive a `staticlib` linked by a foreign linker.
+    ///
+    /// # Safety
+    ///
+    /// Same as [`run_constructors`]: safe to call any number of times, as the
+    /// guard section admits a single runner and each record is marked
+    /// `PROCESSED` before it is invoked.
+    #[doc(hidden)]
+    #[allow(unsafe_code)]
+    pub unsafe extern "C" fn run_constructors_entry() {
+        unsafe { run_constructors() }
+    }
+
     #[allow(unsafe_code)]
     pub(crate) unsafe fn run_constructors() {
         // Multiple ctor crates may contribute multiple guards, but there will
@@ -167,6 +184,11 @@ pub mod collect {
             $crate::__register_ctor!(priority = ($crate::collect::LATE), fn = $fn);
         };
         (priority = $priority:tt, fn = $fn:ident) => {
+            #[used]
+            #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+            static __CTOR_DISPATCH: unsafe extern "C" fn() =
+                $crate::collect::run_constructors_entry;
+
             $crate::__support::in_section!(
                 #[in_section(unsafe, type = mutable, name = _CTOR0_ISIZE_FN)]
                 const _: $crate::collect::Constructor = $crate::collect::Constructor {
@@ -176,6 +198,11 @@ pub mod collect {
             );
         };
         (priority = $priority:tt, fn = (array $array:ident)) => {
+            #[used]
+            #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+            static __CTOR_DISPATCH: unsafe extern "C" fn() =
+                $crate::collect::run_constructors_entry;
+
             $crate::__support::in_section!(
                 #[in_section(unsafe, type = mutable, name = _CTOR0_ISIZE_FN)]
                 const _: [$crate::collect::Constructor; if $array.len() == 0 { 1 } else { $array.len() }] = {

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -14,6 +14,9 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -15,6 +15,9 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
+            #[used]
+            #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+            static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
             const _: ::ctor::collect::Constructor = const {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,
@@ -52,6 +55,9 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
+            #[used]
+            #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+            static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
             const _: ::ctor::collect::Constructor = const {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -18,6 +18,9 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -10,6 +10,9 @@ fn early() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -41,6 +44,9 @@ fn priority1() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -72,6 +78,9 @@ fn priority900() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -103,6 +112,9 @@ fn late() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -134,6 +146,9 @@ fn priority_default() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -165,6 +180,9 @@ fn priority_unspecified() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -17,6 +17,9 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
+    #[used]
+    #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+    static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
     const _: ::ctor::collect::Constructor = const {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
@@ -17,6 +17,9 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
+    #[used]
+    #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+    static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
     const _: ::ctor::collect::Constructor = const {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -14,6 +14,9 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -14,6 +14,9 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        #[used]
+        #[link_section = "__DATA,__mod_init_func,mod_init_funcs"]
+        static __CTOR_DISPATCH: unsafe extern "C" fn() = ::ctor::collect::run_constructors_entry;
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,


### PR DESCRIPTION
# Register the ctor dispatcher from the expansion site (Apple + `priority`)

Fixes #496.

On Apple with `priority`, the only `__mod_init_func` registration lives in ctor's own object (`priority_ctor`). In a `staticlib` linked by a foreign linker, nothing references that object, so `ld64` never pulls the archive member — the `_CTOR0_ISIZE_FN` records ship but nothing walks them, and constructors silently never run. `#[used]` can't help here; it doesn't force archive-member selection.

This registers the dispatcher from `__register_ctor!` instead, so it lands in the same object as the record it needs to reach. Safe once per site because `run_constructors` is already idempotent (guard + `PROCESSED` marking), and the pointer transitively pulls ctor's own member into the link. Both registering arms (single fn and `array`) get it; `naked` and custom-`link_section` sites bypass `__register_ctor!` and are unaffected.

## Verification

Minimal staticlib repro from #496 — `clang main.c libfoo.a`, dev profile, default features:

| | before | after |
| --- | --- | --- |
| `#[ctor]` runs | no | **yes** |
| priorities 1/50/100 | `[]` | `[1, 2, 3]` |
| `otool -l demo \| grep -c __init_offsets` | 0 | 1 |

- `cargo test -p ctor` (30) and `-p dtor` (27) pass.
- `expand-darwin` snapshots regenerated: the diff is the three added lines per `#[ctor]` site and nothing else. `ctor_naked` / `ctor_attribute` are unchanged, as expected.
- Apple-only by construction — `linux`/`android`/`wasm` expansions are byte-identical.

## Cost

One extra fn pointer per `#[ctor]` site; the dispatcher is entered once per registration instead of once — all but the first return immediately at the guard.

## Note

This fixes the common case, where the object holding the registration is linked for some other reason (a crate with a `#[ctor]` almost always exports something referenced). It can't fix a crate whose *only* contribution to the link is a constructor — nothing on the Rust side forces an unreferenced archive member to load; those still need `-force_load` or an explicit call. Happy to add a doc note to that effect if you'd like.
