### PR TITLE
Ensure that Apple-platform staticlibs expose ctors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,16 @@ dependencies = [
 [[package]]
 name = "ctor"
 version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
+dependencies = [
+ "link-section 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.9"
 dependencies = [
  "libc-print",
  "link-section 0.19.0",
@@ -136,16 +146,6 @@ dependencies = [
  "tempfile",
  "trybuild",
  "walkdir",
-]
-
-[[package]]
-name = "ctor"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
-dependencies = [
- "link-section 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -439,7 +439,7 @@ dependencies = [
 name = "linktime"
 version = "0.18.0"
 dependencies = [
- "ctor 1.0.8",
+ "ctor 1.0.9",
  "dtor 1.0.5",
  "libc-print",
  "link-section 0.19.0",
@@ -452,7 +452,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747e3b77d4686c927ec2052a2dcc3943e734a31b279c8f12b4332357ad9be5c8"
 dependencies = [
- "ctor 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 1.0.8",
  "dtor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "link-section 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,7 +683,7 @@ dependencies = [
 name = "scattered-collect"
 version = "0.21.3"
 dependencies = [
- "ctor 1.0.8",
+ "ctor 1.0.9",
  "divan",
  "link-section 0.19.0",
  "linktime 0.18.0",
@@ -700,7 +700,7 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdd12e1c322169b156f50601d3171a34980821744f0281bfb07b90c642c5686"
 dependencies = [
- "ctor 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 1.0.8",
  "link-section 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linktime 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.8", default-features = false }
+ctor = { path = "ctor", version = "1.0.9", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
 link-section = { path = "link-section", version = "0.19.0", default-features = false }
 linktime = { path = "linktime", version = "0.18.0", default-features = false }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2026-07-15
+
+### Fixed
+
+- Ensure the single executing priority ctor is kept alive on Apple platforms (#496).
+
 ## [1.0.8] - 2026-07-06
 
 ### Changed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.8"
+version = "1.0.9"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -45,6 +45,7 @@ crate::__ctor_parse_internal!(
     /// <https://github.com/rust-lang/rust/issues/52234>)
     #[ctor(unsafe, naked)]
     #[allow(unsafe_code)]
+    #[doc(hidden)]
     fn priority_ctor() {
         unsafe {
             crate::collect::run_constructors();
@@ -154,6 +155,39 @@ pub mod collect {
         pub static GUARD_ATOMIC: AtomicU8 = AtomicU8::new(GUARD_NOT_RUN);
     );
 
+    // TODO: We should allow explicit export_name on the ctor itself.
+    #[cfg(all(feature = "priority", target_vendor = "apple"))]
+    #[used]
+    #[doc(hidden)]
+    #[export_name = concat!(
+        "ctor_ap_",
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        "_",
+        env!("CARGO_PKG_VERSION_MINOR"),
+        "_",
+        env!("CARGO_PKG_VERSION_PATCH")
+    )]
+    pub static APPLE_PRIORITY_ANCHOR: fn() = crate::priority_ctor;
+
+    #[macro_export]
+    #[doc(hidden)]
+    macro_rules! __keep_alive {
+        () => {
+            /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+            /// (see https://github.com/mmastrac/linktime/issues/496).
+            const _: () = {
+                mod __ctor_force {
+                    ::core::arch::global_asm!(
+                        ".pushsection __DATA,__ctor_force,regular,no_dead_strip\n",
+                        ".quad {0}\n",
+                        ".popsection\n",
+                        sym $crate::collect::APPLE_PRIORITY_ANCHOR,
+                    );
+                }
+            };
+        };
+    }
+
     #[macro_export]
     #[doc(hidden)]
     macro_rules! __register_ctor {
@@ -167,6 +201,7 @@ pub mod collect {
             $crate::__register_ctor!(priority = ($crate::collect::LATE), fn = $fn);
         };
         (priority = $priority:tt, fn = $fn:ident) => {
+            $crate::__keep_alive!();
             $crate::__support::in_section!(
                 #[in_section(unsafe, type = mutable, name = _CTOR0_ISIZE_FN)]
                 const _: $crate::collect::Constructor = $crate::collect::Constructor {
@@ -176,6 +211,7 @@ pub mod collect {
             );
         };
         (priority = $priority:tt, fn = (array $array:ident)) => {
+            $crate::__keep_alive!();
             $crate::__support::in_section!(
                 #[in_section(unsafe, type = mutable, name = _CTOR0_ISIZE_FN)]
                 const _: [$crate::collect::Constructor; if $array.len() == 0 { 1 } else { $array.len() }] = {

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -159,6 +159,7 @@ pub mod collect {
     #[cfg(all(feature = "priority", target_vendor = "apple"))]
     #[used]
     #[doc(hidden)]
+    #[allow(unsafe_code)]
     #[cfg_attr(clippy, allow(unknown_lints, unsafe_attr_outside_unsafe))]
     #[export_name = concat!(
         "ctor_ap_",

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -159,6 +159,7 @@ pub mod collect {
     #[cfg(all(feature = "priority", target_vendor = "apple"))]
     #[used]
     #[doc(hidden)]
+    #[cfg_attr(clippy, allow(unknown_lints, unsafe_attr_outside_unsafe))]
     #[export_name = concat!(
         "ctor_ap_",
         env!("CARGO_PKG_VERSION_MAJOR"),

--- a/ctor/tests/expand-darwin/ctor.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor.expanded.rs
@@ -14,6 +14,11 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_anon.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_anon.expanded.rs
@@ -15,6 +15,11 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
+            /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+            /// (see https://github.com/mmastrac/linktime/issues/496).
+            const _: () = {
+                mod __ctor_force {}
+            };
             const _: ::ctor::collect::Constructor = const {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,
@@ -52,6 +57,11 @@ const _: () = {
             extern "C" fn __ctor_private() {
                 { unsafe { __ctor_private_inner() } }
             }
+            /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+            /// (see https://github.com/mmastrac/linktime/issues/496).
+            const _: () = {
+                mod __ctor_force {}
+            };
             const _: ::ctor::collect::Constructor = const {
                 type __InSecStoredTy = <::link_section::TypedSection<
                     ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_doc.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_doc.expanded.rs
@@ -18,6 +18,11 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_priority.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_priority.expanded.rs
@@ -10,6 +10,11 @@ fn early() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -41,6 +46,11 @@ fn priority1() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -72,6 +82,11 @@ fn priority900() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -103,6 +118,11 @@ fn late() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -134,6 +154,11 @@ fn priority_default() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,
@@ -165,6 +190,11 @@ fn priority_unspecified() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_static.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static.expanded.rs
@@ -17,6 +17,11 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
+    /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+    /// (see https://github.com/mmastrac/linktime/issues/496).
+    const _: () = {
+        mod __ctor_force {}
+    };
     const _: ::ctor::collect::Constructor = const {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_static_ref.expanded.rs
@@ -17,6 +17,11 @@ const _: () = {
     extern "C" fn __ctor_private() {
         { _ = &*STATIC_CTOR }
     }
+    /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+    /// (see https://github.com/mmastrac/linktime/issues/496).
+    const _: () = {
+        mod __ctor_force {}
+    };
     const _: ::ctor::collect::Constructor = const {
         type __InSecStoredTy = <::link_section::TypedSection<
             ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_unsafe.expanded.rs
@@ -14,6 +14,11 @@ unsafe fn foo() {
         extern "C" fn __ctor_private() {
             { unsafe { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
+++ b/ctor/tests/expand-darwin/ctor_used_linker_attr.expanded.rs
@@ -14,6 +14,11 @@ fn foo() {
         extern "C" fn __ctor_private() {
             { { __ctor_private_inner() } }
         }
+        /// Force `ld64` to pull the archive member owning `APPLE_PRIORITY_ANCHOR`
+        /// (see https://github.com/mmastrac/linktime/issues/496).
+        const _: () = {
+            mod __ctor_force {}
+        };
         const _: ::ctor::collect::Constructor = const {
             type __InSecStoredTy = <::link_section::TypedSection<
                 ::ctor::collect::Constructor,

--- a/tests/ctor/staticlib/Cargo.toml
+++ b/tests/ctor/staticlib/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "staticlib"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+ctor = { path = "../../../ctor" }
+
+[workspace]

--- a/tests/ctor/staticlib/Cargo.toml
+++ b/tests/ctor/staticlib/Cargo.toml
@@ -10,4 +10,8 @@ crate-type = ["staticlib"]
 [dependencies]
 ctor = { path = "../../../ctor" }
 
+[profile.dev]
+# This will run the ctor in `mod another_ctor` as well!
+#codegen-units = 1
+
 [workspace]

--- a/tests/ctor/staticlib/Cargo.toml
+++ b/tests/ctor/staticlib/Cargo.toml
@@ -13,5 +13,6 @@ ctor = { path = "../../../ctor" }
 [profile.dev]
 # This will run the ctor in `mod another_ctor` as well!
 #codegen-units = 1
+codegen-units = 99
 
 [workspace]

--- a/tests/ctor/staticlib/main.rs
+++ b/tests/ctor/staticlib/main.rs
@@ -1,0 +1,10 @@
+// Only references `ctor_ran`, so ld has no reason to pull ctor's archive
+// member that owns the `__mod_init_func` registration.
+extern "C" {
+    fn ctor_ran() -> i32;
+}
+
+fn main() {
+    let ran = unsafe { ctor_ran() } != 0;
+    println!("{}", if ran { "RAN" } else { "DID NOT RUN" });
+}

--- a/tests/ctor/staticlib/main.rs
+++ b/tests/ctor/staticlib/main.rs
@@ -5,6 +5,10 @@ extern "C" {
 }
 
 fn main() {
-    let ran = unsafe { ctor_ran() } != 0;
-    println!("{}", if ran { "RAN" } else { "DID NOT RUN" });
+    let ran = unsafe { ctor_ran() };
+    match ran {
+        0 => println!("DID NOT RUN"),
+        1 => println!("RAN"),
+        _ => panic!("ctor_ran returned unexpected value: {}", ran),
+    }
 }

--- a/tests/ctor/staticlib/src/another_ctor.rs
+++ b/tests/ctor/staticlib/src/another_ctor.rs
@@ -1,0 +1,7 @@
+use std::sync::atomic::Ordering;
+use crate::RAN;
+
+#[ctor::ctor(unsafe)]
+fn install_another_thing() {
+    RAN.fetch_add(1, Ordering::SeqCst);
+}

--- a/tests/ctor/staticlib/src/ctor.rs
+++ b/tests/ctor/staticlib/src/ctor.rs
@@ -1,0 +1,7 @@
+use std::sync::atomic::Ordering;
+use crate::RAN;
+
+#[ctor::ctor(unsafe)]
+fn install_thing() {
+    RAN.store(1, Ordering::SeqCst);
+}

--- a/tests/ctor/staticlib/src/lib.rs
+++ b/tests/ctor/staticlib/src/lib.rs
@@ -1,13 +1,16 @@
 use std::sync::atomic::{AtomicI32, Ordering};
 
-static RAN: AtomicI32 = AtomicI32::new(0);
+// Note: the ctor in this file will not be called unless LTO=fat.
+mod another_ctor;
 
-#[ctor::ctor(unsafe)]
-fn install_thing() {
-    RAN.store(1, Ordering::SeqCst);
-}
+pub static RAN: AtomicI32 = AtomicI32::new(0);
 
 #[no_mangle]
 pub extern "C" fn ctor_ran() -> i32 {
     RAN.load(Ordering::SeqCst)
+}
+
+#[ctor::ctor(unsafe)]
+fn install_thing() {
+    RAN.fetch_add(1, Ordering::SeqCst);
 }

--- a/tests/ctor/staticlib/src/lib.rs
+++ b/tests/ctor/staticlib/src/lib.rs
@@ -1,0 +1,13 @@
+use std::sync::atomic::{AtomicI32, Ordering};
+
+static RAN: AtomicI32 = AtomicI32::new(0);
+
+#[ctor::ctor(unsafe)]
+fn install_thing() {
+    RAN.store(1, Ordering::SeqCst);
+}
+
+#[no_mangle]
+pub extern "C" fn ctor_ran() -> i32 {
+    RAN.load(Ordering::SeqCst)
+}

--- a/tests/ctor/staticlib/test.crok
+++ b/tests/ctor/staticlib/test.crok
@@ -8,7 +8,9 @@
 #
 # `rustc -l static` uses the same archive-member selection as clang/ld64.
 if TARGET_OS != "macos" {
-    exit script;
+    if TARGET_OS != "linux" {
+        exit script;
+    }
 }
 set RUSTFLAGS "";
 defer {

--- a/tests/ctor/staticlib/test.crok
+++ b/tests/ctor/staticlib/test.crok
@@ -28,7 +28,9 @@ $ rustc main.rs -L target/debug -l static=staticlib -o target/debug/staticlib-de
 $ ./target/debug/staticlib-demo
 ! RAN
 
-$ nm ./target/debug/staticlib-demo
-*
-! %{DATA} _ctor_ap_%{DATA}
-*
+if target_os == "macos" {
+    $ nm ./target/debug/staticlib-demo
+    *
+    ! %{DATA} _ctor_ap_%{DATA}
+    *
+}

--- a/tests/ctor/staticlib/test.crok
+++ b/tests/ctor/staticlib/test.crok
@@ -7,18 +7,28 @@
 # constructors silently never run. Fat LTO hides this by collapsing objects.
 #
 # `rustc -l static` uses the same archive-member selection as clang/ld64.
+
+# NOTE: We can run this on Linux as well
 if TARGET_OS != "macos" {
     if TARGET_OS != "linux" {
         exit script;
     }
 }
+
 set RUSTFLAGS "";
 defer {
     $ cargo clean --quiet
 }
+
 $ cargo build --quiet
 *
 $ rustc main.rs -L target/debug -l static=staticlib -o target/debug/staticlib-demo
 *
+
 $ ./target/debug/staticlib-demo
 ! RAN
+
+$ nm ./target/debug/staticlib-demo
+*
+! %{DATA} _ctor_ap_%{DATA}
+*

--- a/tests/ctor/staticlib/test.crok
+++ b/tests/ctor/staticlib/test.crok
@@ -1,0 +1,22 @@
+#!/usr/bin/env crok --v0
+# Regression for https://github.com/mmastrac/linktime/issues/496
+#
+# On Apple with priority (default), the only real __mod_init_func registration
+# lives in ctor's archive member. Linking a Rust staticlib with a foreign linker
+# that only pulls members for referenced symbols skips that member, so
+# constructors silently never run. Fat LTO hides this by collapsing objects.
+#
+# `rustc -l static` uses the same archive-member selection as clang/ld64.
+if TARGET_OS != "macos" {
+    exit script;
+}
+set RUSTFLAGS "";
+defer {
+    $ cargo clean --quiet
+}
+$ cargo build --quiet
+*
+$ rustc main.rs -L target/debug -l static=staticlib -o target/debug/staticlib-demo
+*
+$ ./target/debug/staticlib-demo
+! RAN


### PR DESCRIPTION
Fixes #496 

The global ctor itself (which handles macOS priority) was not being kept because nothing was referencing it and it was possible for it to land in a `.o` file that was unused. We can ensure that it is kept alive by all submitted ctors.

Note that the ctors themselves are still subject to `codegen-units` and the whims of placement - if a ctor happens to land outside of referenced object files, it'll get tossed. `codegen-units=1` is therefore recommended for staticlibs. If multiple crates are aggregated into a single staticlib, it _might_ be a good idea to partially link the .a file into a .o and merge all internal sections:

```
ld.lld -r -o target/release/master_output.o \
  --whole-archive target/release/libyour_crate.a \
  --no-whole-archive
``` 
