### PR TITLE
Fix semicolons in expression position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
 dependencies = [
- "link-section 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "link-section 0.19.0",
  "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -140,7 +140,7 @@ name = "ctor"
 version = "1.0.9"
 dependencies = [
  "libc-print",
- "link-section 0.19.0",
+ "link-section 0.19.1",
  "linktime-proc-macro 0.2.0",
  "macrotest",
  "tempfile",
@@ -418,6 +418,15 @@ dependencies = [
 [[package]]
 name = "link-section"
 version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
+dependencies = [
+ "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "link-section"
+version = "0.19.1"
 dependencies = [
  "linktime-proc-macro 0.2.0",
  "macrotest",
@@ -427,22 +436,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-section"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
-dependencies = [
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "linktime"
 version = "0.18.0"
 dependencies = [
  "ctor 1.0.9",
  "dtor 1.0.5",
  "libc-print",
- "link-section 0.19.0",
+ "link-section 0.19.1",
  "linktime-proc-macro 0.2.0",
 ]
 
@@ -454,7 +454,7 @@ checksum = "747e3b77d4686c927ec2052a2dcc3943e734a31b279c8f12b4332357ad9be5c8"
 dependencies = [
  "ctor 1.0.8",
  "dtor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "link-section 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "link-section 0.19.0",
  "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -685,7 +685,7 @@ version = "0.21.3"
 dependencies = [
  "ctor 1.0.9",
  "divan",
- "link-section 0.19.0",
+ "link-section 0.19.1",
  "linktime 0.18.0",
  "linktime-proc-macro 0.2.0",
  "scattered-collect 0.21.3",
@@ -701,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdd12e1c322169b156f50601d3171a34980821744f0281bfb07b90c642c5686"
 dependencies = [
  "ctor 1.0.8",
- "link-section 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "link-section 0.19.0",
  "linktime 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/mmastrac/linktime"
 [workspace.dependencies]
 ctor = { path = "ctor", version = "1.0.9", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
-link-section = { path = "link-section", version = "0.19.0", default-features = false }
+link-section = { path = "link-section", version = "0.19.1", default-features = false }
 linktime = { path = "linktime", version = "0.18.0", default-features = false }
 scattered-collect = { path = "scattered-collect", version = "0.21.3" }
 

--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-07-15
+
+### Fixed
+
+- Fix for semicolons accidentally inserted in WASM expression macro (generates a
+  warning on nightly).
+
 ## [0.19.0] - 2026-07-06
 
 ### Fixed

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "link-section"
-version = "0.19.0"
+version = "0.19.1"
 authors.workspace = true
 edition = "2021"
 description = "Link-time initialized slices for Rust, with full support for Linux, macOS, Windows, WASM and many more platforms."

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -31,7 +31,7 @@ macro_rules! __get_section_wasm {
             ($crate::__support::wasm::LinkSectionMovableInfo),
             ($crate::__support::wasm::LinkSectionMovableInfo::new::<$generic_ty>(__LINK_SECTION_NAME)),
             ($crate::__support::MovableBounds)
-        );
+        )
     };
     ($section_type:ident, name=$name:tt, type=$generic_ty:ty) => {
         $crate::__get_section_wasm!(@emit
@@ -43,7 +43,7 @@ macro_rules! __get_section_wasm {
                 $crate::__support::wasm::section_has_slot!($section_type),
             )),
             ($crate::__support::Bounds)
-        );
+        )
     };
     (@emit
         ($name:tt),


### PR DESCRIPTION
This started appearing in nightly builds:

```
error: trailing semicolon in macro used in expression position
Error:   --> src/lib.rs:17:1
   |
17 | / section! {
18 | |     #[section(unsafe, type = typed)]
19 | |     static FOO: TypedSection<Driver>;
20 | | }
   | |_^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
   = note: this error originates in the macro `$crate::__support::get_section` which comes from the expansion of the macro `section` (in Nightly builds, run with -Z macro-backtrace for more info)
```