### PR TITLE
Split `Static::deref`'s slow path into cold fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,16 @@ dependencies = [
 [[package]]
 name = "ctor"
 version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
+dependencies = [
+ "link-section 0.19.0",
+ "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.10"
 dependencies = [
  "libc-print",
  "link-section 0.19.1",
@@ -136,16 +146,6 @@ dependencies = [
  "tempfile",
  "trybuild",
  "walkdir",
-]
-
-[[package]]
-name = "ctor"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
-dependencies = [
- "link-section 0.19.0",
- "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -439,7 +439,7 @@ dependencies = [
 name = "linktime"
 version = "0.18.0"
 dependencies = [
- "ctor 1.0.9",
+ "ctor 1.0.10",
  "dtor 1.0.5",
  "libc-print",
  "link-section 0.19.1",
@@ -452,7 +452,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747e3b77d4686c927ec2052a2dcc3943e734a31b279c8f12b4332357ad9be5c8"
 dependencies = [
- "ctor 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 1.0.9",
  "dtor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "link-section 0.19.0",
  "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,7 +683,7 @@ dependencies = [
 name = "scattered-collect"
 version = "0.21.3"
 dependencies = [
- "ctor 1.0.9",
+ "ctor 1.0.10",
  "divan",
  "link-section 0.19.1",
  "linktime 0.18.0",
@@ -700,7 +700,7 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdd12e1c322169b156f50601d3171a34980821744f0281bfb07b90c642c5686"
 dependencies = [
- "ctor 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 1.0.9",
  "link-section 0.19.0",
  "linktime 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linktime-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.9", default-features = false }
+ctor = { path = "ctor", version = "1.0.10", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
 link-section = { path = "link-section", version = "0.19.1", default-features = false }
 linktime = { path = "linktime", version = "0.18.0", default-features = false }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.10] - 2026-07-21
+
+### Changed
+
+ - Faster atomics and #[cold] for `Static::deref` initialization (@yvt PR #501)
+
 ## [1.0.9] - 2026-07-15
 
 ### Fixed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.9"
+version = "1.0.10"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/ctor/src/statics.rs
+++ b/ctor/src/statics.rs
@@ -100,6 +100,19 @@ impl<T: Sync> Deref for Static<T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &Self::Target {
+        if self.initialized.load(Ordering::Acquire) == INITIALIZED {
+            // SAFETY: We only access the static variable if the initialized
+            // state is `INITIALIZED`
+            unsafe { self.get_unchecked() }
+        } else {
+            self.deref_slow()
+        }
+    }
+}
+
+impl<T: Sync> Static<T> {
+    #[cold]
+    fn deref_slow(&self) -> &T {
         struct PanicGuard<'a> {
             initialized: &'a AtomicU8,
         }


### PR DESCRIPTION
Turn the fast (initialized) path into a single load-acquire, which is much cheaper than an atomic RMW.

While profiling my application, I found that a significant portion of time was spent on `lock cmpxchg; jne` in `deref`. This optimization improved whole-application throughput by 2.10%.
