### PR TITLE
Pointer-align the Apple ctor anchor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "libc-print",
  "link-section 0.19.1",
@@ -439,7 +439,7 @@ dependencies = [
 name = "linktime"
 version = "0.18.0"
 dependencies = [
- "ctor 1.0.10",
+ "ctor 1.0.11",
  "dtor 1.0.5",
  "libc-print",
  "link-section 0.19.1",
@@ -683,7 +683,7 @@ dependencies = [
 name = "scattered-collect"
 version = "0.21.3"
 dependencies = [
- "ctor 1.0.10",
+ "ctor 1.0.11",
  "divan",
  "link-section 0.19.1",
  "linktime 0.18.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/linktime"
 
 [workspace.dependencies]
-ctor = { path = "ctor", version = "1.0.10", default-features = false }
+ctor = { path = "ctor", version = "1.0.11", default-features = false }
 dtor = { path = "dtor", version = "1.0.5", default-features = false }
 link-section = { path = "link-section", version = "0.19.1", default-features = false }
 linktime = { path = "linktime", version = "0.18.0", default-features = false }

--- a/ctor/CHANGELOG.md
+++ b/ctor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.11] - 2026-07-26
+
+### Fixed
+
+- Pointer-align the priority ctor anchor on Apple platforms (#502).
+
 ## [1.0.10] - 2026-07-21
 
 ### Changed

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctor"
-version = "1.0.10"
+version = "1.0.11"
 authors.workspace = true
 edition = "2021"
 description = "Global, no_std-compatible constructors for all platforms that run before main (like C/C++ __attribute__((constructor)))"

--- a/ctor/src/lib.rs
+++ b/ctor/src/lib.rs
@@ -181,6 +181,8 @@ pub mod collect {
                 mod __ctor_force {
                     ::core::arch::global_asm!(
                         ".pushsection __DATA,__ctor_force,regular,no_dead_strip\n",
+                        // Pointer-align a `.quad` with the anchor
+                        ".p2align 3\n",
                         ".quad {0}\n",
                         ".popsection\n",
                         sym $crate::collect::APPLE_PRIORITY_ANCHOR,


### PR DESCRIPTION
Fixes #502. The alignment marker was missing on our keepalive declaration.