### PR TITLE
Ensure hashes always compute 64-bit chunks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,7 +98,7 @@ jobs:
       if: ${{ contains(matrix.target, 'i686') }}
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-multilib
+        sudo apt-get install -y gcc-multilib lib32z1 lib32stdc++6
 
     # rustup refuses non-host toolchains without --force-non-host
     - name: Install Rust toolchain (${{ matrix.rust-toolchain }}, non-host)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,16 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc-multilib
 
+    # rustup refuses non-host toolchains without --force-non-host
+    - name: Install Rust toolchain (${{ matrix.rust-toolchain }}, non-host)
+      if: ${{ contains(matrix.rust-toolchain, 'i686') }}
+      shell: bash
+      run: |
+        rustup toolchain install "${{ matrix.rust-toolchain }}" --force-non-host --profile minimal --no-self-update
+        rustup override set "${{ matrix.rust-toolchain }}"
+
     - name: Install Rust toolchain (${{ matrix.rust-toolchain }})
+      if: ${{ !contains(matrix.rust-toolchain, 'i686') }}
       uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
       with:
         toolchain: ${{ matrix.rust-toolchain }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,8 @@ jobs:
                 "this.job == 'zigbuild'": "cargo-zigbuild"
             rust-toolchain:
               $match:
+                # i686 host toolchain
+                "this.label == 'linux-x86'": stable-i686-unknown-linux-gnu
                 "this.job == 'miri'": nightly
                 "this.job == 'lint'": [stable, nightly]
                 "this.job == 'test-used-linker'": nightly
@@ -57,6 +59,10 @@ jobs:
                 os: ubuntu-latest
                 job: [build, lint, test]
                 target: x86_64-unknown-linux-musl
+              linux-x86:
+                os: ubuntu-latest
+                job: test
+                target: i686-unknown-linux-gnu
               macos:
                 os: macOS-latest
                 job: [lint, test, test-used-linker, miri, zigbuild, sanitize, build-minimal]
@@ -88,6 +94,12 @@ jobs:
       with:
         tool: ${{ matrix.needs }}
   
+    - name: Install 32-bit host libraries
+      if: ${{ contains(matrix.target, 'i686') }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-multilib
+
     - name: Install Rust toolchain (${{ matrix.rust-toolchain }})
       uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
       with:

--- a/linktime-proc-macro/src/combine/mod.rs
+++ b/linktime-proc-macro/src/combine/mod.rs
@@ -203,7 +203,7 @@ fn parse_function(
                 } else {
                     let mut hash_str = String::with_capacity(32);
                     while hash > 0 {
-                        hash_str.push(alphabet.char(hash as usize % alphabet.len()));
+                        hash_str.push(alphabet.char((hash % alphabet.len() as u64) as usize));
                         hash /= alphabet.len() as u64;
                     }
                     s.extend(hash_str.chars().rev());
@@ -223,7 +223,7 @@ fn parse_function(
                 } else {
                     let mut hash_str = String::with_capacity(32);
                     while hash > 0 {
-                        hash_str.push(alphabet.char(hash as usize % alphabet.len()));
+                        hash_str.push(alphabet.char((hash % alphabet.len() as u64) as usize));
                         hash /= alphabet.len() as u64;
                     }
                     s.extend(hash_str.chars().rev());

--- a/linktime-proc-macro/src/hash/mod.rs
+++ b/linktime-proc-macro/src/hash/mod.rs
@@ -68,8 +68,8 @@ pub(crate) fn location_hash(tokens: TokenStream, ignore_base: Option<&Path>) -> 
             let line = crate::fallback::line(&span);
             let column = crate::fallback::column(&span);
             let file = crate::fallback::file(&span);
-            buffer.extend_from_slice(&line.to_be_bytes());
-            buffer.extend_from_slice(&column.to_be_bytes());
+            buffer.extend_from_slice(&(line as u64).to_be_bytes());
+            buffer.extend_from_slice(&(column as u64).to_be_bytes());
             buffer.extend_from_slice(file.as_bytes());
         }
 

--- a/tests/ctor/crt-static/test.crok
+++ b/tests/ctor/crt-static/test.crok
@@ -7,14 +7,35 @@ set RUSTFLAGS "-C target-feature=+crt-static";
 defer {
     $ cargo clean --quiet
 }
+
 $ rustc -vV
 %SET TARGET "$target"
 *
 ! host: %{DATA:target}
 *
+
 $ cargo build --quiet --target $TARGET
 *
+
 $ cargo run --quiet --target $TARGET
+# GNU ld (not rust-lld) warns via linker_messages: getaddrinfo/getpwuid_r
+# need runtime glibc under +crt-static
+ignore {
+    sequence {
+        ! %{DATA}: in function %{DATA}
+        ! %{DATA}Using 'getaddrinfo'%{DATA}
+        ! %{DATA}: in function %{DATA}
+        ! %{DATA}Using 'getpwuid_r'%{DATA}
+        ! %{SPACE}|
+        ! %{SPACE}= note: `#[warn(linker_messages)]` on by default
+        ! %{SPACE}
+    }
+    sequence {
+        ! %{DATA}note: the message above does not take linker garbage collection into account
+        ! %{DATA}note: the message above does not take linker garbage collection into account
+        ! %{SPACE}
+    }
+}
 if TARGET_OS == "openbsd" {
     # Appears to be a legit Rust/OpenBSD bug?
     ! -crt-static

--- a/tests/dtor/link-section/test-crt-static.crok
+++ b/tests/dtor/link-section/test-crt-static.crok
@@ -4,12 +4,32 @@ set CARGO_TARGET_DIR "target/link-section-crt-static";
 defer {
     $ cargo clean --quiet
 }
+
 $ rustc -vV
 %SET TARGET "$target"
 *
 ! host: %{DATA:target}
 *
+
 $ cargo run --quiet --target $TARGET
+# GNU ld (not rust-lld) warns via linker_messages: getaddrinfo/getpwuid_r
+# need runtime glibc under +crt-static
+ignore {
+    sequence {
+        ! %{DATA}: in function %{DATA}
+        ! %{DATA}Using 'getaddrinfo'%{DATA}
+        ! %{DATA}: in function %{DATA}
+        ! %{DATA}Using 'getpwuid_r'%{DATA}
+        ! %{SPACE}|
+        ! %{SPACE}= note: `#[warn(linker_messages)]` on by default
+        ! %{SPACE}
+    }
+    sequence {
+        ! %{DATA}note: the message above does not take linker garbage collection into account
+        ! %{DATA}note: the message above does not take linker garbage collection into account
+        ! %{SPACE}
+    }
+}
 ! dtor-link-section:main
 if TARGET_OS == "linux" {
     ! dtor-link-section:dtor

--- a/tests/link_section/basic/test.crok
+++ b/tests/link_section/basic/test.crok
@@ -3,17 +3,25 @@ set RUSTFLAGS "";
 defer {
     $ cargo clean --quiet
 }
+
 $ cargo build --quiet
 *
+
 $ cargo run --quiet
 ! LINK_SECTION: Section { name: "%{DATA}LINK_SEC%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, byte_len: %{INT} }
 ! link_section_function
+# u32
 ! TYPED_LINK_SECTION: TypedSection { name: "%{DATA}TYPED_LI%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 2, stride: 4 }
 ! address of TYPED_LINK_SECTION[0]: %{BASE16NUM}
 ! address of TYPED_LINK_SECTION[1]: %{BASE16NUM}
+# u32
 ! AUX_LINK_SECTION: TypedSection { name: "%{DATA}TYPED_LI%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 1, stride: 4 }
 ! aux: 1234
-! CODE_SECTION: TypedSection { name: "%{DATA}FN_ARRAY%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 3, stride: 8 }
+# stride is a fn pointer
+choice {
+    ! CODE_SECTION: TypedSection { name: "%{DATA}FN_ARRAY%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 3, stride: 4 }
+    ! CODE_SECTION: TypedSection { name: "%{DATA}FN_ARRAY%{DATA}", start: %{BASE16NUM}, end: %{BASE16NUM}, len: 3, stride: 8 }
+}
 ! [%{BASE16NUM}, %{BASE16NUM}, %{BASE16NUM}]
 unordered {
     ! f: %{BASE16NUM}
@@ -23,6 +31,8 @@ unordered {
     ! f: %{BASE16NUM}
     ! linked_function_2
 }
+# In theory there's no defined order for these three but they always appear
+# in one of these two orders.
 choice {
     ! DEBUGGABLES: [1, 2, debuggable_function]
     ! DEBUGGABLES: [debuggable_function, 2, 1]


### PR DESCRIPTION
Hashes were inconsistent across platforms - always add 64-bit sized chunks to fix this. Fixes #507 