### PR TITLE
Improve BSD reliability

### DIFF
--- a/.github/jobs/vmactions.sh
+++ b/.github/jobs/vmactions.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Runs inside vmactions BSD VMs (plain sh; BSD base systems have no bash).
+# Usage: vmactions.sh provision|test
+set -xe
+
+mode="$1"
+os=$(uname -s)
+
+case "$os" in
+  FreeBSD) os_dir=freebsd ;;
+  OpenBSD) os_dir=openbsd ;;
+  NetBSD) os_dir=netbsd ;;
+  DragonFly) os_dir=dragonfly ;;
+  *) echo "unknown OS: $os"; exit 1 ;;
+esac
+
+if [ "$os" = "NetBSD" ]; then
+  export PATH="/usr/pkg/sbin:/usr/pkg/bin:/usr/sbin:/usr/bin:${PATH}"
+fi
+
+# Under the workspace so vmactions copyback + actions/cache persist it.
+export CARGO_HOME="$(pwd)/.cache/ci/vmactions/${os_dir}/cargo-home"
+mkdir -p "${CARGO_HOME}/bin"
+export PATH="${CARGO_HOME}/bin:${PATH}"
+
+provision() {
+  case "$os" in
+    FreeBSD)
+      # pkg's rustc lags stable, use rustup. Fetch the binary directly
+      # (sh.rustup.rs needs curl/wget). RUSTUP_HOME stays VM-local so the
+      # synced cache dir stays small.
+      if ! command -v rustup >/dev/null 2>&1; then
+        fetch -o /tmp/rustup-init https://static.rust-lang.org/rustup/dist/x86_64-unknown-freebsd/rustup-init
+        chmod +x /tmp/rustup-init
+        /tmp/rustup-init -y --profile minimal --default-toolchain none --no-modify-path
+      fi
+      # Installs stable into the fresh VM even when rustup came from the cache.
+      rustup default stable
+      ;;
+    OpenBSD)
+      # rustup has no OpenBSD dist; pkg_add only
+      if ! command -v cargo >/dev/null 2>&1; then
+        pkg_add rust
+      fi
+      ;;
+    NetBSD)
+      if [ -x /usr/pkg/bin/pkgin ]; then
+        /usr/pkg/bin/pkgin update
+        /usr/pkg/bin/pkgin -y install rust
+      else
+        export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/amd64/10.1/All"
+        /usr/sbin/pkg_add rust
+      fi
+      ;;
+    DragonFly)
+      pkg install -y rust
+      ;;
+  esac
+
+  # macrotest needs `cargo expand` (full-test OSes only - on NetBSD its dep
+  # tree fails to build against kqueue udata typing).
+  case "$os" in
+    FreeBSD|OpenBSD)
+      if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
+        cargo install cargo-expand --locked
+      fi
+      ;;
+  esac
+
+  cargo fetch
+}
+
+run_tests() {
+  case "$os" in
+    FreeBSD|OpenBSD)
+      cargo build
+      cargo test
+      ;;
+    *)
+      cargo build --examples -p ctor -p dtor -p link-section
+      for example in ctor-basic ctor-example ctor-advanced ctor-priority; do
+        cargo run -p ctor --example "$example"
+      done
+      cargo run -p dtor --example dtor-example
+      cargo run -p link-section --example link-section-example
+      ;;
+  esac
+}
+
+case "$mode" in
+  provision) provision ;;
+  test) run_tests ;;
+  *) echo "usage: $0 provision|test"; exit 1 ;;
+esac

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,6 +180,7 @@ jobs:
   vmactions-freebsd:
     runs-on: ubuntu-latest
     name: FreeBSD / test (stable)
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       # macrotest needs `cargo expand`. Cache `CARGO_HOME` under the workspace (registry/git/bin)
@@ -201,14 +202,19 @@ jobs:
           usesh: true
           run: |
             set -xe
-            # Only install rust if missing. Do not use `pkg install -U`: fresh images have no
-            # repo catalog yet and fail with "Repository FreeBSD cannot be opened. pkg update required".
-            if ! command -v cargo >/dev/null 2>&1; then
-              pkg install -y rust
-            fi
             export CARGO_HOME="${GITHUB_WORKSPACE}/.cache/ci/vmactions/freebsd/cargo-home"
             mkdir -p "${CARGO_HOME}/bin"
             export PATH="${CARGO_HOME}/bin:${PATH}"
+            # pkg's rustc lags stable, use rustup.
+            # Fetch the binary directly (sh.rustup.rs needs curl/wget); RUSTUP_HOME
+            # stays VM-local so the synced cache dir stays small.
+            if ! command -v rustup >/dev/null 2>&1; then
+              fetch -o /tmp/rustup-init https://static.rust-lang.org/rustup/dist/x86_64-unknown-freebsd/rustup-init
+              chmod +x /tmp/rustup-init
+              /tmp/rustup-init -y --profile minimal --default-toolchain none --no-modify-path
+            fi
+            # Installs stable into the fresh VM even when rustup came from the cache.
+            rustup default stable
             if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
               cargo install cargo-expand --locked
             fi
@@ -219,6 +225,8 @@ jobs:
   vmactions-openbsd:
     runs-on: ubuntu-latest
     name: OpenBSD / test (stable)
+    # rustup has no OpenBSD dist; pkg_add only
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -250,8 +258,9 @@ jobs:
   vmactions-netbsd:
     runs-on: ubuntu-latest
     # Full `cargo test` needs `cargo-expand`; installing it pulls deps (e.g. mio) that fail on NetBSD kqueue (udata typing).
-    # Smoke-test examples only — same as DragonFly vmactions job.
+    # Smoke-test examples only
     name: NetBSD / examples (stable)
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Start VM
@@ -281,8 +290,9 @@ jobs:
   vmactions-dragonflybsd:
     runs-on: ubuntu-latest
     # Packaged Rust is often behind crates.io; full `cargo test` needs `cargo-expand` (rustc 1.88+ as of 2025).
-    # Smoke-test published examples only (same spirit as zigbuild.sh).
+    # Smoke-test published examples only
     name: DragonFly BSD / examples (stable)
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Start VM

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -176,6 +176,11 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
 
   # Tier-*BSD smoke tests (QEMU); see https://github.com/vmactions
+  #
+  # All four jobs run .github/jobs/vmactions.sh, which branches on uname.
+  # Provisioning happens in the VM action step because copyback (which feeds
+  # the cache) runs when that step ends. Tests run in a `shell: <os>` step so
+  # failures show up in the log instead of a collapsed "ssh exited with code 1".
 
   vmactions-freebsd:
     runs-on: ubuntu-latest
@@ -183,55 +188,25 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      # macrotest needs `cargo expand`. Cache `CARGO_HOME` under the workspace (registry/git/bin)
-      # so vmactions copyback + actions/cache reuse downloads and the installed `cargo-expand`.
       - uses: actions/cache@v5
         with:
           path: .cache/ci/vmactions/freebsd
           key: vmactions-freebsd-14.4-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-freebsd-14.4-
-      # Cache-relevant work (registry, installed bins) must happen in the VM action
-      # step: copyback runs when it finishes, before (and regardless of) the tests.
-      # Tests run in a `shell: freebsd` step so failures aren't buried in the
-      # action's collapsed log group behind "ssh exited with code 1".
       - name: Provision VM
         uses: vmactions/freebsd-vm@v1
         with:
           release: "14.4"
           usesh: true
-          run: |
-            set -xe
-            export CARGO_HOME="${GITHUB_WORKSPACE}/.cache/ci/vmactions/freebsd/cargo-home"
-            mkdir -p "${CARGO_HOME}/bin"
-            export PATH="${CARGO_HOME}/bin:${PATH}"
-            # pkg's rustc lags stable, use rustup.
-            # Fetch the binary directly (sh.rustup.rs needs curl/wget); RUSTUP_HOME
-            # stays VM-local so the synced cache dir stays small.
-            if ! command -v rustup >/dev/null 2>&1; then
-              fetch -o /tmp/rustup-init https://static.rust-lang.org/rustup/dist/x86_64-unknown-freebsd/rustup-init
-              chmod +x /tmp/rustup-init
-              /tmp/rustup-init -y --profile minimal --default-toolchain none --no-modify-path
-            fi
-            # Installs stable into the fresh VM even when rustup came from the cache.
-            rustup default stable
-            if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
-              cargo install cargo-expand --locked
-            fi
-            cargo fetch
+          run: sh .github/jobs/vmactions.sh provision
       - name: Build and test
         shell: freebsd {0}
-        run: |
-          set -xe
-          export CARGO_HOME="$(pwd)/.cache/ci/vmactions/freebsd/cargo-home"
-          export PATH="${CARGO_HOME}/bin:${PATH}"
-          cargo build
-          cargo test
+        run: sh .github/jobs/vmactions.sh test
 
   vmactions-openbsd:
     runs-on: ubuntu-latest
     name: OpenBSD / test (stable)
-    # rustup has no OpenBSD dist; pkg_add only
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -241,86 +216,59 @@ jobs:
           key: vmactions-openbsd-7.8-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-openbsd-7.8-
-      # Same provision/test split as the FreeBSD job (cache copyback + visible failures).
       - name: Provision VM
         uses: vmactions/openbsd-vm@v1
         with:
           release: "7.8"
           usesh: true
-          run: |
-            set -xe
-            if ! command -v cargo >/dev/null 2>&1; then
-              pkg_add rust
-            fi
-            export CARGO_HOME="${GITHUB_WORKSPACE}/.cache/ci/vmactions/openbsd/cargo-home"
-            mkdir -p "${CARGO_HOME}/bin"
-            export PATH="${CARGO_HOME}/bin:${PATH}"
-            if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
-              cargo install cargo-expand --locked
-            fi
-            cargo fetch
+          run: sh .github/jobs/vmactions.sh provision
       - name: Build and test
         shell: openbsd {0}
-        run: |
-          set -xe
-          export CARGO_HOME="$(pwd)/.cache/ci/vmactions/openbsd/cargo-home"
-          export PATH="${CARGO_HOME}/bin:${PATH}"
-          cargo build
-          cargo test
+        run: sh .github/jobs/vmactions.sh test
 
   vmactions-netbsd:
     runs-on: ubuntu-latest
-    # Full `cargo test` needs `cargo-expand`; installing it pulls deps (e.g. mio) that fail on NetBSD kqueue (udata typing).
-    # Smoke-test examples only
+    # Examples only: `cargo test` needs `cargo-expand`, whose dep tree fails to
+    # build on NetBSD (kqueue udata typing).
     name: NetBSD / examples (stable)
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - name: Start VM
+      - uses: actions/cache@v5
+        with:
+          path: .cache/ci/vmactions/netbsd
+          key: vmactions-netbsd-10.1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            vmactions-netbsd-10.1-
+      - name: Provision VM
         uses: vmactions/netbsd-vm@v1
         with:
           release: "10.1"
           usesh: true
-      - name: Run crate examples
+          run: sh .github/jobs/vmactions.sh provision
+      - name: Build and test
         shell: netbsd {0}
-        run: |
-          set -xe
-          export PATH="/usr/pkg/sbin:/usr/pkg/bin:/usr/sbin:/usr/bin:${PATH}"
-          if [ -x /usr/pkg/bin/pkgin ]; then
-            /usr/pkg/bin/pkgin update
-            /usr/pkg/bin/pkgin -y install rust
-          else
-            export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/amd64/10.1/All"
-            /usr/sbin/pkg_add rust
-          fi
-          cargo build --examples -p ctor -p dtor -p link-section
-          for example in ctor-basic ctor-example ctor-advanced ctor-priority; do
-            cargo run -p ctor --example "$example"
-          done
-          cargo run -p dtor --example dtor-example
-          cargo run -p link-section --example link-section-example
+        run: sh .github/jobs/vmactions.sh test
 
   vmactions-dragonflybsd:
     runs-on: ubuntu-latest
-    # Packaged Rust is often behind crates.io; full `cargo test` needs `cargo-expand` (rustc 1.88+ as of 2025).
-    # Smoke-test published examples only
+    # Examples only: packaged Rust is often behind what `cargo test` needs.
     name: DragonFly BSD / examples (stable)
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - name: Start VM
+      - uses: actions/cache@v5
+        with:
+          path: .cache/ci/vmactions/dragonfly
+          key: vmactions-dragonfly-6.4.2-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            vmactions-dragonfly-6.4.2-
+      - name: Provision VM
         uses: vmactions/dragonflybsd-vm@v1
         with:
           release: "6.4.2"
           usesh: true
-      - name: Run crate examples
+          run: sh .github/jobs/vmactions.sh provision
+      - name: Build and test
         shell: dragonflybsd {0}
-        run: |
-          set -xe
-          pkg install -y rust
-          cargo build --examples -p ctor -p dtor -p link-section
-          for example in ctor-basic ctor-example ctor-advanced ctor-priority; do
-            cargo run -p ctor --example "$example"
-          done
-          cargo run -p dtor --example dtor-example
-          cargo run -p link-section --example link-section-example
+        run: sh .github/jobs/vmactions.sh test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -185,17 +185,17 @@ jobs:
       - uses: actions/checkout@v6
       # macrotest needs `cargo expand`. Cache `CARGO_HOME` under the workspace (registry/git/bin)
       # so vmactions copyback + actions/cache reuse downloads and the installed `cargo-expand`.
-      # `cargo clean` after tests drops `target/` so copyback stays small.
       - uses: actions/cache@v5
         with:
           path: .cache/ci/vmactions/freebsd
           key: vmactions-freebsd-14.4-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-freebsd-14.4-
-      # Build must run in the same vmactions step as host→VM sync: copyback only runs when this
-      # action finishes. A later `shell: freebsd` step updates the VM only — the runner workspace
-      # never gets the new binary, so actions/cache would save an empty/stale path.
-      - name: Build and test
+      # Cache-relevant work (registry, installed bins) must happen in the VM action
+      # step: copyback runs when it finishes, before (and regardless of) the tests.
+      # Tests run in a `shell: freebsd` step so failures aren't buried in the
+      # action's collapsed log group behind "ssh exited with code 1".
+      - name: Provision VM
         uses: vmactions/freebsd-vm@v1
         with:
           release: "14.4"
@@ -218,9 +218,15 @@ jobs:
             if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
               cargo install cargo-expand --locked
             fi
-            cargo build
-            cargo test
-            cargo clean
+            cargo fetch
+      - name: Build and test
+        shell: freebsd {0}
+        run: |
+          set -xe
+          export CARGO_HOME="$(pwd)/.cache/ci/vmactions/freebsd/cargo-home"
+          export PATH="${CARGO_HOME}/bin:${PATH}"
+          cargo build
+          cargo test
 
   vmactions-openbsd:
     runs-on: ubuntu-latest
@@ -235,7 +241,8 @@ jobs:
           key: vmactions-openbsd-7.8-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-openbsd-7.8-
-      - name: Build and test
+      # Same provision/test split as the FreeBSD job (cache copyback + visible failures).
+      - name: Provision VM
         uses: vmactions/openbsd-vm@v1
         with:
           release: "7.8"
@@ -251,9 +258,15 @@ jobs:
             if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
               cargo install cargo-expand --locked
             fi
-            cargo build
-            cargo test
-            cargo clean
+            cargo fetch
+      - name: Build and test
+        shell: openbsd {0}
+        run: |
+          set -xe
+          export CARGO_HOME="$(pwd)/.cache/ci/vmactions/openbsd/cargo-home"
+          export PATH="${CARGO_HOME}/bin:${PATH}"
+          cargo build
+          cargo test
 
   vmactions-netbsd:
     runs-on: ubuntu-latest

--- a/tests/ctor/crt-static/test.crok
+++ b/tests/ctor/crt-static/test.crok
@@ -35,6 +35,13 @@ ignore {
         ! %{DATA}note: the message above does not take linker garbage collection into account
         ! %{SPACE}
     }
+    # FreeBSD cc (clang) warns -no-pie is unused
+    sequence {
+        ! %{DATA}argument unused during compilation: '-no-pie'%{DATA}
+        ! %{SPACE}|
+        ! %{SPACE}= note: `#[warn(linker_messages)]` on by default
+        ! %{SPACE}
+    }
 }
 if TARGET_OS == "openbsd" {
     # Appears to be a legit Rust/OpenBSD bug?

--- a/tests/dtor/link-section/test-crt-static.crok
+++ b/tests/dtor/link-section/test-crt-static.crok
@@ -29,6 +29,13 @@ ignore {
         ! %{DATA}note: the message above does not take linker garbage collection into account
         ! %{SPACE}
     }
+    # FreeBSD cc (clang) warns -no-pie is unused
+    sequence {
+        ! %{DATA}argument unused during compilation: '-no-pie'%{DATA}
+        ! %{SPACE}|
+        ! %{SPACE}= note: `#[warn(linker_messages)]` on by default
+        ! %{SPACE}
+    }
 }
 ! dtor-link-section:main
 if TARGET_OS == "linux" {


### PR DESCRIPTION
BSD builds are flaky because they are VMs running on GH runners. We can improve reliability by adding a timeout (no more 6-hr failures), and using rustup-init directly.