### PR TITLE
Fix WASM reference-section const cell layout

### DIFF
--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix cross-crate section-name error on Rust versions 1.88-1.94 (https://github.com/mmastrac/linktime/pull/509)
+- Fix undefined behavior on WASM when a `const` item is submitted to a `reference`
+  section: the item's cell lacked the fix-up slot the section-wide layout expects,
+  so materialisation read past the cell and could write through a garbage slot
+  pointer (https://github.com/mmastrac/linktime/pull/511).
 
 ## [0.19.2] - 2026-07-29
 

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -171,7 +171,7 @@ macro_rules! __register_wasm_item {
         );
     };
     // Reference-section const items do not expose a `Ref`, but their cells must
-    // still match the slot-bearing layout selected for the whole section.
+    // match the layout for static items.
     (reference, type=$ty:ty, value=$value:expr, section=$section:tt) => {
         $crate::__register_wasm_item!(@emit
             info_ty = ($crate::__support::wasm::LinkSectionInfo),

--- a/link-section/src/platform/wasm.rs
+++ b/link-section/src/platform/wasm.rs
@@ -170,6 +170,17 @@ macro_rules! __register_wasm_item {
             section = $section
         );
     };
+    // Reference-section const items do not expose a `Ref`, but their cells must
+    // still match the slot-bearing layout selected for the whole section.
+    (reference, type=$ty:ty, value=$value:expr, section=$section:tt) => {
+        $crate::__register_wasm_item!(@emit
+            info_ty = ($crate::__support::wasm::LinkSectionInfo),
+            ty = ($ty),
+            meta = ($crate::__support::wasm::LinkMetaSlot),
+            new = ($value, ::core::ptr::null()),
+            section = $section
+        );
+    };
     // Typed / mutable const items: value is copied into the section, no slot.
     ($section_type:ident, type=$ty:ty, value=$value:expr, section=$section:tt) => {
         $crate::__register_wasm_item!(@emit

--- a/link-section/tests/target-test/link-section-reference-const.rs
+++ b/link-section/tests/target-test/link-section-reference-const.rs
@@ -1,0 +1,14 @@
+use link_section::declarative::{in_section, section};
+use link_section::TypedReferenceSection;
+
+section! {
+    #[section(unsafe, type = reference)]
+    static FOO: TypedReferenceSection<u32>;
+}
+
+in_section! {
+    #[in_section(unsafe, type = reference, name = FOO)]
+    const ITEM: u32 = 42;
+}
+
+fn main() {}

--- a/link-section/tests/target-test/link-section-reference-const/wasm32-unknown-unknown.rs
+++ b/link-section/tests/target-test/link-section-reference-const/wasm32-unknown-unknown.rs
@@ -1,0 +1,109 @@
+use link_section::declarative::{in_section, section};
+use link_section::TypedReferenceSection;
+
+
+
+#[allow(non_camel_case_types)]
+struct FOO;
+impl FOO {
+    /// Get a `const` reference to the underlying section. In
+    /// non-const contexts, `deref` is sufficient.
+    pub const fn const_deref(&self) -> &'static TypedReferenceSection<u32> {
+        static SECTION: TypedReferenceSection<u32> =
+            {
+                let section =
+                    {
+                        static __LINK_SECTION_NAME: &'static str =
+                            ".data.link_section.FOO";
+                        #[export_name = ".data.link_section.FOO.bounds"]
+                        #[used]
+                        #[used]
+                        static __LINK_SECTION_INFO:
+                            ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>
+                            =
+                            ::link_section::__support::wasm::LinkSectionInfoLock::new(::link_section::__support::wasm::LinkSectionInfo::new::<(u32)>(__LINK_SECTION_NAME,
+                                    true));
+                        #[link_section = ".init_array.1"]
+                        #[used]
+                        #[allow(non_snake_case)]
+                        static __LINK_SECTION_FLATTEN_FN_REF: extern "C" fn() =
+                            {
+                                extern "C" fn __LINK_SECTION_FLATTEN_FN() {
+                                    unsafe {
+                                        ::link_section::__support::wasm::flatten(&raw const __LINK_SECTION_INFO);
+                                    }
+                                }
+                                __LINK_SECTION_FLATTEN_FN
+                            };
+                        unsafe {
+                            <::link_section::__support::Bounds>::new(&raw const __LINK_SECTION_INFO)
+                        }
+                    };
+                let name = ".data.link_section.FOO";
+                ::link_section::__support::validate_section_name(name);
+                unsafe { <TypedReferenceSection<u32>>::new(name, section) }
+            };
+        &SECTION
+    }
+}
+impl ::core::fmt::Debug for FOO {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        ::core::ops::Deref::deref(self).fmt(f)
+    }
+}
+impl ::core::ops::Deref for FOO {
+    type Target = TypedReferenceSection<u32>;
+    fn deref(&self) -> &Self::Target { self.const_deref() }
+}
+impl ::link_section::__support::SectionItemType for FOO {
+    type Item = (u32);
+}
+impl ::link_section::__support::SectionItemTyped<(u32)> for FOO {
+    type Item = (u32);
+}
+impl FOO {
+    /// Get the section as a slice.
+    pub fn as_slice(&self) -> &[(u32)] { self.const_deref().as_slice() }
+}
+impl ::core::iter::IntoIterator for FOO {
+    type Item = &'static (u32);
+    type IntoIter = ::core::slice::Iter<'static, (u32)>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.const_deref().as_slice().iter()
+    }
+}
+const ITEM: u32 =
+    const {
+            type __InSecStoredTy =
+                <::link_section::TypedSection<u32> as
+                ::link_section::__support::SectionItemType>::Item;
+            const __LINK_SECTION_CONST_ITEM_VALUE: __InSecStoredTy = 42;
+            #[used]
+            static __LINK_SECTION_CELL:
+                ::link_section::__support::wasm::LinkCell<__InSecStoredTy,
+                ::link_section::__support::wasm::LinkMetaSlot> =
+                <::link_section::__support::wasm::LinkCell<__InSecStoredTy,
+                        ::link_section::__support::wasm::LinkMetaSlot>>::new(__LINK_SECTION_CONST_ITEM_VALUE,
+                    ::core::ptr::null());
+            #[allow(missing_unsafe_on_extern)]
+            extern "C" {
+                #[link_name = ".data.link_section.FOO.bounds"]
+                static __LINK_SECTION_INFO:
+                    ::link_section::__support::wasm::LinkSectionInfoLock<::link_section::__support::wasm::LinkSectionInfo>;
+            }
+            #[link_section = ".init_array.0"]
+            #[used]
+            #[allow(non_snake_case)]
+            static __LINK_SECTION_ITEM_FN_REF: extern "C" fn() =
+                {
+                    extern "C" fn __LINK_SECTION_ITEM_FN() {
+                        unsafe {
+                            ::link_section::__support::wasm::register(&raw const __LINK_SECTION_INFO,
+                                __LINK_SECTION_CELL.as_cell_ptr());
+                        }
+                    }
+                    __LINK_SECTION_ITEM_FN
+                };
+            __LINK_SECTION_CONST_ITEM_VALUE
+        };
+fn main() {}

--- a/tests/wasm/runtime/src/lib.rs
+++ b/tests/wasm/runtime/src/lib.rs
@@ -49,6 +49,18 @@ mod link_section {
 
         #[in_section(DRIVERS)]
         pub static DRIVER: Driver = Driver::new("driver", || libc_println!("driver"));
+
+        // `const` items don't hand out a `Ref`, but must still share the
+        // slot-bearing cell layout of the reference section (issue fixed in
+        // #511: the old layout made materialisation read past the cell and
+        // write through a garbage slot pointer).
+        #[in_section(DRIVERS)]
+        pub const DRIVER_CONST: Driver =
+            Driver::new("driver_const", || libc_println!("driver_const"));
+
+        #[in_section(DRIVERS)]
+        pub const DRIVER_CONST2: Driver =
+            Driver::new("driver_const2", || libc_println!("driver_const2"));
     }
 
     mod movable {
@@ -94,7 +106,18 @@ mod link_section {
         libc_println!("test_link_section");
         libc_println!("DRIVER: {}", reference::DRIVER.name);
         (reference::DRIVER.f)();
-        assert!(reference::DRIVERS.offset_of(&reference::DRIVER) == Some(0));
+        // Submission order interleaves `static` and `const` registrations, so
+        // locate DRIVER by its resolved offset rather than assuming an index.
+        let drivers = reference::DRIVERS.as_slice();
+        assert_eq!(drivers.len(), 3);
+        let idx = reference::DRIVERS
+            .offset_of(&reference::DRIVER)
+            .expect("DRIVER not in section");
+        assert_eq!(drivers[idx].name, "driver");
+        for (idx, driver) in drivers.iter().enumerate() {
+            libc_println!("DRIVERS[{idx}]: {}", driver.name);
+            (driver.f)();
+        }
         assert!(empty::EMPTY_LINK_SECTION.is_empty());
     }
 }

--- a/tests/wasm/runtime/src/lib.rs
+++ b/tests/wasm/runtime/src/lib.rs
@@ -50,10 +50,7 @@ mod link_section {
         #[in_section(DRIVERS)]
         pub static DRIVER: Driver = Driver::new("driver", || libc_println!("driver"));
 
-        // `const` items don't hand out a `Ref`, but must still share the
-        // slot-bearing cell layout of the reference section (issue fixed in
-        // #511: the old layout made materialisation read past the cell and
-        // write through a garbage slot pointer).
+        // Interleave const/static items.
         #[in_section(DRIVERS)]
         pub const DRIVER_CONST: Driver =
             Driver::new("driver_const", || libc_println!("driver_const"));

--- a/tests/wasm/runtime/test.crok
+++ b/tests/wasm/runtime/test.crok
@@ -55,6 +55,12 @@ unordered {
 ! test_link_section
 ! DRIVER: driver
 ! driver
+! DRIVERS[0]: driver_const
+! driver_const
+! DRIVERS[1]: driver_const2
+! driver_const2
+! DRIVERS[2]: driver
+! driver
 ! dtor
 
 # wasm32-wasip1 via wasmtime
@@ -69,6 +75,12 @@ unordered {
 ! start
 ! test_link_section
 ! DRIVER: driver
+! driver
+! DRIVERS[0]: driver_const
+! driver_const
+! DRIVERS[1]: driver_const2
+! driver_const2
+! DRIVERS[2]: driver
 ! driver
 ! dtor
 
@@ -85,6 +97,12 @@ unordered {
 ! test_link_section
 ! DRIVER: driver
 ! driver
+! DRIVERS[0]: driver_const
+! driver_const
+! DRIVERS[1]: driver_const2
+! driver_const2
+! DRIVERS[2]: driver
+! driver
 ! dtor
 
 # wasm32-wasip2 via wasmtime
@@ -99,5 +117,11 @@ unordered {
 ! start
 ! test_link_section
 ! DRIVER: driver
+! driver
+! DRIVERS[0]: driver_const
+! driver_const
+! DRIVERS[1]: driver_const2
+! driver_const2
+! DRIVERS[2]: driver
 ! driver
 ! dtor


### PR DESCRIPTION
## Problem

On WASM, a `const` submitted to a `reference` section uses the generic registration arm and emits `LinkCell<T, LinkMeta>`. The section itself has `has_slot = true`, so materialization treats every cell as `LinkMetaSlot`, reads past the metadata, and can write through the resulting garbage slot pointer. This makes the documented safe API capable of UB.

## Fix

Emit `LinkMetaSlot` for reference-section constants too, with a null slot because constants do not expose a `Ref` handle. Add a target expansion fixture that locks the section-wide layout invariant.

## Verification

`TOOLCHAIN=nightly MACROTEST=overwrite cargo test -p link-section --test macrotest target_test` passed for all five target fixtures, including the new WASM reference-const case.