### PR TITLE
Test BSD and minimal targets with crok

### DIFF
--- a/.github/jobs/build-ctor-minimal.sh
+++ b/.github/jobs/build-ctor-minimal.sh
@@ -5,8 +5,8 @@ set -xeuo pipefail
 rm Cargo.lock || true
 find tests -name Cargo.lock -not -path '*/target/*' -delete
 
-# ctor/dtor only, the rest exceed ctor's MSRV. edition-2024 needs 1.85+.
+# Only these run on ctor's MSRV, the rest resolve deps too new for 1.65
 # Standalone crok, the in-tree harness needs a newer rustc
-find tests/ctor tests/dtor -name '*.crok' \
-  -not -path '*/target/*' -not -path '*/.*' -not -path '*/edition-2024/*' -print0 | sort -z |
+find tests/ctor/edition-2018 tests/ctor/edition-2021 tests/dtor/link-section -name '*.crok' \
+  -not -path '*/target/*' -not -path '*/.*' -print0 | sort -z |
   xargs -0 crok --timeout 300

--- a/.github/jobs/build-ctor-minimal.sh
+++ b/.github/jobs/build-ctor-minimal.sh
@@ -6,7 +6,13 @@ rm Cargo.lock || true
 find tests -name Cargo.lock -not -path '*/target/*' -delete
 
 # Only these run on ctor's MSRV, the rest resolve deps too new for 1.65
+minimal_crates=(
+  tests/ctor/edition-2018
+  tests/ctor/edition-2021
+  tests/dtor/link-section
+)
+
 # Standalone crok, the in-tree harness needs a newer rustc
-find tests/ctor/edition-2018 tests/ctor/edition-2021 tests/dtor/link-section -name '*.crok' \
+find "${minimal_crates[@]}" -name '*.crok' \
   -not -path '*/target/*' -not -path '*/.*' -print0 | sort -z |
   xargs -0 crok --timeout 300

--- a/.github/jobs/build-ctor-minimal.sh
+++ b/.github/jobs/build-ctor-minimal.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-. $(dirname "$0")/_init.sh
-
-# Remove Cargo.lock for testing down-level Rust versions
+# Remove Cargo.lock files for testing down-level Rust versions
 rm Cargo.lock || true
+find tests -name Cargo.lock -not -path '*/target/*' -delete
 
-minimal_crates=(
-  tests/ctor/edition-2018
-  tests/ctor/edition-2021
-  tests/dtor/link-section
-)
-for dir in "${minimal_crates[@]}"; do
-  (cd "$dir" && (rm Cargo.lock || true) && cargo run --target "$TARGET")
-done
+# ctor/dtor only, the rest exceed ctor's MSRV. edition-2024 needs 1.85+.
+# Standalone crok, the in-tree harness needs a newer rustc
+find tests/ctor tests/dtor -name '*.crok' \
+  -not -path '*/target/*' -not -path '*/.*' -not -path '*/edition-2024/*' -print0 | sort -z |
+  xargs -0 crok --timeout 300

--- a/.github/jobs/build-minimal.sh
+++ b/.github/jobs/build-minimal.sh
@@ -5,6 +5,11 @@ set -xeuo pipefail
 rm Cargo.lock || true
 find tests -name Cargo.lock -not -path '*/target/*' -delete
 
+# LNK4078 pollutes crok output, see test.sh
+case "${OS:-}" in
+  Windows_NT) export LINK="/IGNORE:4078" ;;
+esac
+
 # Standalone crok, the in-tree harness needs a newer rustc
 find tests -name '*.crok' -not -path '*/target/*' -not -path '*/.*' -print0 | sort -z |
   xargs -0 crok --timeout 300

--- a/.github/jobs/build-minimal.sh
+++ b/.github/jobs/build-minimal.sh
@@ -1,23 +1,10 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-. $(dirname "$0")/_init.sh
-
-# Remove Cargo.lock for testing down-level Rust versions
+# Remove Cargo.lock files for testing down-level Rust versions
 rm Cargo.lock || true
+find tests -name Cargo.lock -not -path '*/target/*' -delete
 
-minimal_crates=(
-  tests/ctor/edition-2018
-  tests/ctor/edition-2021
-  tests/dtor/link-section
-  tests/dtor/no-default-features
-  
-  tests/link_section/basic
-  tests/link_section/interior_mut
-  tests/link_section/mutable
-  tests/link_section/no-default-features
-  tests/link_section/copied
-)
-for dir in "${minimal_crates[@]}"; do
-  (cd "$dir" && (rm Cargo.lock || true) && cargo run --target "$TARGET")
-done
+# Standalone crok, the in-tree harness needs a newer rustc
+find tests -name '*.crok' -not -path '*/target/*' -not -path '*/.*' -print0 | sort -z |
+  xargs -0 crok --timeout 300

--- a/.github/jobs/vm-crok.sh
+++ b/.github/jobs/vm-crok.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run the crok suite on the host, driving commands into a vmactions VM.
+# Usage: vm-crok.sh <ssh-host> <target-os>  (e.g. dragonflybsd dragonfly)
+set -xeuo pipefail
+
+host="$1"
+target_os="$2"
+
+find tests -name '*.crok' -not -path '*/target/*' -not -path '*/.*' -print0 | sort -z |
+  xargs -0 crok --timeout 300 --target-os "$target_os" \
+    --runner "sh $(pwd)/.github/jobs/vm-run.sh $host"

--- a/.github/jobs/vm-run.sh
+++ b/.github/jobs/vm-run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# crok --runner wrapper: runs one command in a vmactions VM
+# Usage: vm-run.sh <ssh-host> <command>
+# Piped into sh on stdin (login shell may be csh). Host paths map verbatim.
+# Script-set env vars arrive inlined in the command (crok 0.9.0).
+set -eu
+
+host="$1"
+case "$host" in
+  dragonflybsd) os_dir=dragonfly ;;
+  *) os_dir="$host" ;;
+esac
+
+cargo_home="${GITHUB_WORKSPACE}/.cache/ci/vmactions/${os_dir}/cargo-home"
+path_prefix=""
+if [ "$host" = "netbsd" ]; then
+  path_prefix="/usr/pkg/sbin:/usr/pkg/bin:"
+fi
+
+printf '%s\n' \
+  "cd '$PWD' || exit 1" \
+  "export CARGO_HOME='$cargo_home'" \
+  "export PATH='${path_prefix}${cargo_home}/bin':\"\$PATH\"" \
+  "$2" \
+  | ssh -T \
+      -o ControlMaster=auto -o ControlPath=/tmp/crok-vm-%h -o ControlPersist=60 \
+      "$host" sh

--- a/.github/jobs/vmactions.sh
+++ b/.github/jobs/vmactions.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Runs inside vmactions BSD VMs (plain sh; BSD base systems have no bash).
-# Usage: vmactions.sh provision|doctest (crok suite runs host-side, see vm-crok.sh)
+# Runs inside vmactions BSD VMs
+# Usage: vmactions.sh provision|doctest
 set -xe
 
 mode="$1"

--- a/.github/jobs/vmactions.sh
+++ b/.github/jobs/vmactions.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Runs inside vmactions BSD VMs (plain sh; BSD base systems have no bash).
-# Usage: vmactions.sh provision|test
+# Usage: vmactions.sh provision|doctest (crok suite runs host-side, see vm-crok.sh)
 set -xe
 
 mode="$1"
@@ -57,38 +57,16 @@ provision() {
       ;;
   esac
 
-  # macrotest needs `cargo expand` (full-test OSes only - on NetBSD its dep
-  # tree fails to build against kqueue udata typing).
-  case "$os" in
-    FreeBSD|OpenBSD)
-      if [ ! -x "${CARGO_HOME}/bin/cargo-expand" ]; then
-        cargo install cargo-expand --locked
-      fi
-      ;;
-  esac
-
   cargo fetch
 }
 
-run_tests() {
-  case "$os" in
-    FreeBSD|OpenBSD)
-      cargo build
-      cargo test
-      ;;
-    *)
-      cargo build --examples -p ctor -p dtor -p link-section
-      for example in ctor-basic ctor-example ctor-advanced ctor-priority; do
-        cargo run -p ctor --example "$example"
-      done
-      cargo run -p dtor --example dtor-example
-      cargo run -p link-section --example link-section-example
-      ;;
-  esac
+# macrotest/compile-fail need cargo-expand, tier-1 only
+run_doctests() {
+  cargo test --doc
 }
 
 case "$mode" in
   provision) provision ;;
-  test) run_tests ;;
-  *) echo "usage: $0 provision|test"; exit 1 ;;
+  doctest) run_doctests ;;
+  *) echo "usage: $0 provision|doctest"; exit 1 ;;
 esac

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,13 @@ jobs:
       with:
         tool: ${{ matrix.needs }}
   
+    # Build crok with preinstalled stable, before the toolchain override
+    - name: Install crok
+      if: ${{ contains(matrix.job, 'minimal') }}
+      uses: taiki-e/cache-cargo-install-action@v2
+      with:
+        tool: crok@0.9.0
+
     - name: Install 32-bit host libraries
       if: ${{ contains(matrix.target, 'i686') }}
       run: |
@@ -175,12 +182,11 @@ jobs:
         env:
           BUILD_RESULT: ${{ needs.build.result }}
 
-  # Tier-*BSD smoke tests (QEMU); see https://github.com/vmactions
+  # Tier-*BSD tests (QEMU); see https://github.com/vmactions
   #
-  # All four jobs run .github/jobs/vmactions.sh, which branches on uname.
-  # Provisioning happens in the VM action step because copyback (which feeds
-  # the cache) runs when that step ends. Tests run in a `shell: <os>` step so
-  # failures show up in the log instead of a collapsed "ssh exited with code 1".
+  # vmactions.sh provisions the VM (copyback feeds the cache). The crok suite
+  # runs host-side, driving commands into the VM via vm-run.sh. FreeBSD/OpenBSD
+  # also run in-VM doctests. macrotest/compile-fail need cargo-expand, tier-1 only.
 
   vmactions-freebsd:
     runs-on: ubuntu-latest
@@ -194,15 +200,21 @@ jobs:
           key: vmactions-freebsd-14.4-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-freebsd-14.4-
+      - name: Install crok
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: crok@0.9.0
       - name: Provision VM
         uses: vmactions/freebsd-vm@v1
         with:
           release: "14.4"
           usesh: true
           run: sh .github/jobs/vmactions.sh provision
-      - name: Build and test
+      - name: Run crok suite
+        run: bash .github/jobs/vm-crok.sh freebsd freebsd
+      - name: Doc tests
         shell: freebsd {0}
-        run: sh .github/jobs/vmactions.sh test
+        run: sh .github/jobs/vmactions.sh doctest
 
   vmactions-openbsd:
     runs-on: ubuntu-latest
@@ -216,21 +228,25 @@ jobs:
           key: vmactions-openbsd-7.8-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-openbsd-7.8-
+      - name: Install crok
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: crok@0.9.0
       - name: Provision VM
         uses: vmactions/openbsd-vm@v1
         with:
           release: "7.8"
           usesh: true
           run: sh .github/jobs/vmactions.sh provision
-      - name: Build and test
+      - name: Run crok suite
+        run: bash .github/jobs/vm-crok.sh openbsd openbsd
+      - name: Doc tests
         shell: openbsd {0}
-        run: sh .github/jobs/vmactions.sh test
+        run: sh .github/jobs/vmactions.sh doctest
 
   vmactions-netbsd:
     runs-on: ubuntu-latest
-    # Examples only: `cargo test` needs `cargo-expand`, whose dep tree fails to
-    # build on NetBSD (kqueue udata typing).
-    name: NetBSD / examples (stable)
+    name: NetBSD / test (stable)
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -240,20 +256,22 @@ jobs:
           key: vmactions-netbsd-10.1-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-netbsd-10.1-
+      - name: Install crok
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: crok@0.9.0
       - name: Provision VM
         uses: vmactions/netbsd-vm@v1
         with:
           release: "10.1"
           usesh: true
           run: sh .github/jobs/vmactions.sh provision
-      - name: Build and test
-        shell: netbsd {0}
-        run: sh .github/jobs/vmactions.sh test
+      - name: Run crok suite
+        run: bash .github/jobs/vm-crok.sh netbsd netbsd
 
   vmactions-dragonflybsd:
     runs-on: ubuntu-latest
-    # Examples only: packaged Rust is often behind what `cargo test` needs.
-    name: DragonFly BSD / examples (stable)
+    name: DragonFly BSD / test (stable)
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -263,12 +281,15 @@ jobs:
           key: vmactions-dragonfly-6.4.2-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             vmactions-dragonfly-6.4.2-
+      - name: Install crok
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: crok@0.9.0
       - name: Provision VM
         uses: vmactions/dragonflybsd-vm@v1
         with:
           release: "6.4.2"
           usesh: true
           run: sh .github/jobs/vmactions.sh provision
-      - name: Build and test
-        shell: dragonflybsd {0}
-        run: sh .github/jobs/vmactions.sh test
+      - name: Run crok suite
+        run: bash .github/jobs/vm-crok.sh dragonflybsd dragonfly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,7 @@ jobs:
                 "this.job == 'lint'": [stable, nightly]
                 "this.job == 'test-used-linker'": nightly
                 "this.job == 'build'": [stable, beta, nightly]
+                "this.job == 'build-minimal' && this.label == 'windows'": ["1.88"]
                 "this.job == 'build-minimal'": ["1.85", "1.88"]
                 "this.job == 'build-ctor-minimal'": ["1.65"]
                 "this.job == 'wasm'": [stable, "1.85"]
@@ -69,7 +70,7 @@ jobs:
                 target: aarch64-apple-darwin
               windows:
                 os: windows-latest
-                job: [lint, test, miri]
+                job: [lint, test, miri, build-minimal]
                 target: x86_64-pc-windows-msvc
           config: |
             github: ${{ toJSON(github) }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -183,7 +183,7 @@ jobs:
         env:
           BUILD_RESULT: ${{ needs.build.result }}
 
-  # Tier-*BSD tests (QEMU); see https://github.com/vmactions
+  # Tier-*BSD tests (QEMU)
   #
   # vmactions.sh provisions the VM (copyback feeds the cache). The crok suite
   # runs host-side, driving commands into the VM via vm-run.sh. FreeBSD/OpenBSD

--- a/tests/ctor/crt-static/test.crok
+++ b/tests/ctor/crt-static/test.crok
@@ -47,7 +47,18 @@ if TARGET_OS == "openbsd" {
     # Appears to be a legit Rust/OpenBSD bug?
     ! -crt-static
 }
+# crt-static not honored here either
+if TARGET_OS == "netbsd" {
+    ! -crt-static
+}
+if TARGET_OS == "dragonfly" {
+    ! -crt-static
+}
 if TARGET_OS != "openbsd" {
-    ! +crt-static
+    if TARGET_OS != "netbsd" {
+        if TARGET_OS != "dragonfly" {
+            ! +crt-static
+        }
+    }
 }
 ! main

--- a/tests/ctor/warn-unsafe/test-enforced.crok
+++ b/tests/ctor/warn-unsafe/test-enforced.crok
@@ -11,8 +11,11 @@ $ cargo build
 !    Compiling warn-unsafe v0.0.0 %{DATA}
 """
 error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
-
-
+"""
+# older rustc renders these blank lines with trailing whitespace
+! %{SPACE}
+! %{SPACE}
+"""
        #[ctor]
        ^^^^^^^------- replace this with #[ctor(unsafe)]
 """
@@ -25,8 +28,10 @@ error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This e
   = note: this error originates in the macro `$crate::__ctor_parse_impl` which comes from the expansion of the attribute macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Missing unsafe keyword in #[ctor] annotation. Use #[ctor(unsafe)]. This error can be suppressed by passing `--cfg linktime_no_fail_on_missing_unsafe` in `RUSTFLAGS` or placing this in your `config.toml` file.
-
-
+"""
+! %{SPACE}
+! %{SPACE}
+"""
        #[ctor]
        ^^^^^^^------- replace this with #[ctor(unsafe)]
 """

--- a/tests/dtor/link-section/test-crt-static.crok
+++ b/tests/dtor/link-section/test-crt-static.crok
@@ -50,3 +50,9 @@ if TARGET_OS == "windows" {
 if TARGET_OS == "openbsd" {
     ! dtor-link-section:dtor
 }
+if TARGET_OS == "netbsd" {
+    ! dtor-link-section:dtor
+}
+if TARGET_OS == "dragonfly" {
+    ! dtor-link-section:dtor
+}

--- a/tests/dtor/link-section/test-no-crt-static.crok
+++ b/tests/dtor/link-section/test-no-crt-static.crok
@@ -21,3 +21,9 @@ if TARGET_OS == "freebsd" {
 if TARGET_OS == "openbsd" {
     ! dtor-link-section:dtor
 }
+if TARGET_OS == "netbsd" {
+    ! dtor-link-section:dtor
+}
+if TARGET_OS == "dragonfly" {
+    ! dtor-link-section:dtor
+}

--- a/tests/link_section/copied/test.crok
+++ b/tests/link_section/copied/test.crok
@@ -1,4 +1,8 @@
 #!/usr/bin/env crok --v0
+# DragonFly aborts pre-main in std TLS (KEY_SENTVAL assertion)
+if TARGET_OS == "dragonfly" {
+    exit script;
+}
 set RUSTFLAGS "";
 defer {
     $ cargo clean --quiet


### PR DESCRIPTION
We can avoid building inside of the BSD environment and instead drive a crok test across the boundary using `--runner`.

The same approach works for `build-minimal`, which means we can get some bonus additional coverage and simplify the test setup.