### PR TITLE
Revert "macOS: Use `global_asm` instead of magic `\x01` prefix (#518)"

### DIFF
--- a/link-section/CHANGELOG.md
+++ b/link-section/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added UEFI support (`*-unknown-uefi`), using the Windows marker-section scheme.
 
-### Changed
-
-- Cranelift support: Switched to `global_asm!` for section start/end symbols on macOS.
-
 ## [0.19.3] - 2026-08-09
 
 ### Changed

--- a/link-section/README.md
+++ b/link-section/README.md
@@ -195,11 +195,8 @@ Orphan sections are not sorted via numeric suffix (e.g.: `SECTION.1`,
 
 On macOS, sections are configured via `__DATA` or `__TEXT` prefix and option
 suffixes (`regular`, `no_dead_strip`, etc.). The linker emits start and stop
-symbols, but they are not C-compatible, and require a `global_asm!` alias to
-access. 
-
-Rust also has a (somewhat-stable) `\x01` prefix to avoid mangling
-the section name, but this is unsupported in Cranelift and other backends.
+symbols, but Rust requires a (somewhat-stable) `\x01` prefix to avoid mangling
+the section name. macOS does not support ordering in the linker.
 
 ### Windows
 

--- a/link-section/docs/PREAMBLE.md
+++ b/link-section/docs/PREAMBLE.md
@@ -195,11 +195,8 @@ Orphan sections are not sorted via numeric suffix (e.g.: `SECTION.1`,
 
 On macOS, sections are configured via `__DATA` or `__TEXT` prefix and option
 suffixes (`regular`, `no_dead_strip`, etc.). The linker emits start and stop
-symbols, but they are not C-compatible, and require a `global_asm!` alias to
-access. 
-
-Rust also has a (somewhat-stable) `\x01` prefix to avoid mangling
-the section name, but this is unsupported in Cranelift and other backends.
+symbols, but Rust requires a (somewhat-stable) `\x01` prefix to avoid mangling
+the section name. macOS does not support ordering in the linker.
 
 ### Windows
 

--- a/link-section/src/platform/apple.rs
+++ b/link-section/src/platform/apple.rs
@@ -7,8 +7,6 @@
 macro_rules! __get_section_apple {
     (movable, name=$name:tt, type=$generic_ty:ty) => {
         {
-            $crate::__alias_section_symbols!(item data $name);
-            $crate::__alias_section_symbols!(backref data $name);
             $crate::__support::MovableBounds::new(
                 $crate::__support::PtrBounds::new(
                     $crate::__address_of_symbol!(item data start $name),
@@ -23,7 +21,6 @@ macro_rules! __get_section_apple {
     };
     ($section_type:ident, name=$name:tt, type=$generic_ty:ty) => {
         {
-            $crate::__alias_section_symbols!(item data $name);
             $crate::__support::PtrBounds::new(
                 $crate::__address_of_symbol!(item data start $name),
                 $crate::__address_of_symbol!(item data end $name),
@@ -34,35 +31,7 @@ macro_rules! __get_section_apple {
 
 pub use crate::__get_section_apple as get_section;
 
-#[doc(hidden)]
-#[macro_export]
-#[cfg(not(miri))]
-macro_rules! __alias_section_symbols {
-    // `$ref_or_item` (`item` or `backref`) names the wrapper module so the
-    // value- and backref-symbol invocations in the `movable` arm don't collide.
-    ($ref_or_item:ident $section:ident $name:tt) => {
-        mod $ref_or_item {
-            ::core::arch::global_asm!(::core::concat!(
-                ".private_extern _", $crate::__support::section_name!(string $ref_or_item $section start $name), "\n",
-                ".set _",            $crate::__support::section_name!(string $ref_or_item $section start $name), ", ",
-                                     $crate::__support::section_name!(string $ref_or_item $section start $name), "\n",
-                ".private_extern _", $crate::__support::section_name!(string $ref_or_item $section end $name), "\n",
-                ".set _",            $crate::__support::section_name!(string $ref_or_item $section end $name), ", ",
-                                     $crate::__support::section_name!(string $ref_or_item $section end $name), "\n",
-            ));
-        }
-    };
-}
-
-// Under Miri, `__address_of_symbol!` yields a null pointer and no linker symbols
-// exist, so there is nothing to alias.
-#[doc(hidden)]
-#[macro_export]
-#[cfg(miri)]
-macro_rules! __alias_section_symbols {
-    ($($args:tt)*) => {};
-}
-
+// \x01: "do not mangle" (ref https://github.com/rust-lang/rust-bindgen/issues/2935)
 crate::__def_section_name! {
     __section_name_apple,
     {
@@ -70,8 +39,8 @@ crate::__def_section_name! {
         code bare =>    ("__TEXT,") __ ();
         data section => ("__DATA,") __ (",regular,no_dead_strip");
         code section => ("__TEXT,") __ (",regular,pure_instructions");
-        data start =>   ("section$start$__DATA$") __ ();
-        data end =>     ("section$end$__DATA$") __ ();
+        data start =>   ("\x01section$start$__DATA$") __ ();
+        data end =>     ("\x01section$end$__DATA$") __ ();
     }
     AUXILIARY = "_";
     REFS = "_r_";

--- a/link-section/tests/expand-darwin/link_section.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section.expanded.rs
@@ -15,12 +15,11 @@ impl FOO {
     pub const fn const_deref(&self) -> &'static TypedSection<fn()> {
         static SECTION: TypedSection<fn()> = {
             let section = {
-                mod item {}
                 ::link_section::__support::PtrBounds::new(
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "section$start$__DATA$FOObh0r0BSfLQP"]
+                            #[link_name = "\u{1}section$start$__DATA$FOObh0r0BSfLQP"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -28,7 +27,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "section$end$__DATA$FOObh0r0BSfLQP"]
+                            #[link_name = "\u{1}section$end$__DATA$FOObh0r0BSfLQP"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }

--- a/link-section/tests/expand-darwin/link_section_no_macro.expanded.rs
+++ b/link-section/tests/expand-darwin/link_section_no_macro.expanded.rs
@@ -7,12 +7,11 @@ impl FOO {
     pub const fn const_deref(&self) -> &'static TypedSection<fn()> {
         static SECTION: TypedSection<fn()> = {
             let section = {
-                mod item {}
                 ::link_section::__support::PtrBounds::new(
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "section$start$__DATA$my_crateFOO"]
+                            #[link_name = "\u{1}section$start$__DATA$my_crateFOO"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -20,7 +19,7 @@ impl FOO {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "section$end$__DATA$my_crateFOO"]
+                            #[link_name = "\u{1}section$end$__DATA$my_crateFOO"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -87,12 +86,11 @@ impl BAR {
     pub const fn const_deref(&self) -> &'static TypedSection<fn()> {
         static SECTION: TypedSection<fn()> = {
             let section = {
-                mod item {}
                 ::link_section::__support::PtrBounds::new(
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "section$start$__DATA$my_crate275b763e"]
+                            #[link_name = "\u{1}section$start$__DATA$my_crate275b763e"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }
@@ -100,7 +98,7 @@ impl BAR {
                     {
                         #[allow(missing_unsafe_on_extern)]
                         extern "C" {
-                            #[link_name = "section$end$__DATA$my_crate275b763e"]
+                            #[link_name = "\u{1}section$end$__DATA$my_crate275b763e"]
                             static __SYMBOL: u8;
                         }
                         unsafe { &raw const __SYMBOL as *const () }


### PR DESCRIPTION
This reverts commit 2ab375d246a65f668715c73ed3294665d202f5d1 that landed in #518.