### PR TITLE
Spurious hash collisions in scattered-collect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,14 +696,14 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "ctor 1.0.13",
  "divan",
  "link-section 0.19.3",
  "linktime 0.19.0",
  "linktime-proc-macro 0.2.3",
- "scattered-collect 0.22.0",
+ "scattered-collect 0.22.1",
  "trybuild",
  "wide",
  "xxhash-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ ctor = { path = "ctor", version = "1.0.13", default-features = false }
 dtor = { path = "dtor", version = "1.0.6", default-features = false }
 link-section = { path = "link-section", version = "0.19.3", default-features = false }
 linktime = { path = "linktime", version = "0.19.0", default-features = false }
-scattered-collect = { path = "scattered-collect", version = "0.22.0" }
+scattered-collect = { path = "scattered-collect", version = "0.22.1" }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.3" }

--- a/ctor/tests/macrotest.rs
+++ b/ctor/tests/macrotest.rs
@@ -75,7 +75,6 @@ pub fn pass_linux() {
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
     // TODO: whitespace issue (tabs?) in error tests
-    #[cfg(not(linktime_used_linker))]
     #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");

--- a/ctor/tests/macrotest.rs
+++ b/ctor/tests/macrotest.rs
@@ -75,6 +75,7 @@ pub fn pass_linux() {
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
     // TODO: whitespace issue (tabs?) in error tests
+    #[cfg(not(linktime_used_linker))]
     #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");

--- a/dtor/tests/macrotest.rs
+++ b/dtor/tests/macrotest.rs
@@ -77,6 +77,7 @@ pub fn pass_windows() {
 pub fn trybuild() {
     let t = trybuild::TestCases::new();
     // TODO: whitespace issue (tabs?) in error tests
+    #[cfg(not(linktime_used_linker))]
     #[cfg(not(target_os = "openbsd"))]
     t.compile_fail("tests/errors/*.rs");
     t.pass("tests/pass/*.rs");

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.22.1] - 2026-08-14
 
 ### Fixed
 

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Spurious `duplicate hash found` panic on control-byte collisions.
+
 ## [0.22.0] - 2026-08-09
 
 ### Added

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -100,10 +100,10 @@ pub fn initialize_scattered_map<K, V>(
             while bits != 0 {
                 let lane = bits.trailing_zeros() as usize;
                 let h2 = group.hashes[group_offset * BUCKET_SIZE + lane];
-                let (hash, index) = split_hash(index_bits, h2);
+                let (stored, index) = split_hash(index_bits, h2);
                 let hash_mask = (-1_i64 as u64) << (index_bits as usize);
-                if h2 == hash & hash_mask {
-                    panic!("duplicate hash found: {hash:x} at index {index}");
+                if stored == hash & hash_mask {
+                    panic!("duplicate hash found: {stored:x} at index {index}");
                 }
                 bits &= bits - 1;
             }

--- a/scattered-collect/tests/trybuild.rs
+++ b/scattered-collect/tests/trybuild.rs
@@ -2,6 +2,7 @@
 #![cfg(not(miri))]
 
 #[test]
+#[cfg(not(linktime_used_linker))]
 fn compile_fail() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/errors/*.rs");


### PR DESCRIPTION
There is a typo in the hash check that causes two matching control bytes to panic with a spurious hash collision at start time. 
